### PR TITLE
fix: streaming GGUF, npy ingestion, Grok-1 metadata & verifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ tokio = { version = "1.0", features = ["full"], optional = true }  # future asyn
 default = []
 gguf = []                    # future GGUF support if needed
 async = ["tokio"]
+
+# Standalone crate when nested under a parent workspace (see parent Cargo.toml).
+[workspace]

--- a/src/core/gguf.rs
+++ b/src/core/gguf.rs
@@ -5,6 +5,12 @@
 //! - Ternary-quantized (2-bit packed) tensors.
 //! - FP16 pass-through tensors for MoE routing gates.
 //!
+//! # Streaming
+//! [`GgufStreamWriter`] writes tensor **info** with placeholder offsets, then
+//! accepts each tensor's payload **once** via [`GgufStreamWriter::write_tensor_data`]
+//! (no accumulation of all tensors in RAM). Offsets are patched in a final
+//! [`GgufStreamWriter::finalize`] pass.
+//!
 //! # GGUF format overview (v3)
 //! ```text
 //! magic            u32  = 0x46554747 ("GGUF")
@@ -34,7 +40,7 @@ const GGUF_MAGIC: u32 = 0x4655_4747;
 /// Writer targets GGUF version 3.
 const GGUF_VERSION: u32 = 3;
 /// Tensor data is aligned to this boundary in bytes.
-const DATA_ALIGNMENT: u64 = 32;
+pub const DATA_ALIGNMENT: u64 = 32;
 
 // ---------------------------------------------------------------------------
 // GGUF value type tags (GGUFMetadataValueType)
@@ -64,65 +70,49 @@ pub enum GgufMetaValue {
 }
 
 // ---------------------------------------------------------------------------
-// Tensor descriptor queued for writing
+// Tensor header (no payload — data is streamed separately)
 // ---------------------------------------------------------------------------
 
-/// Records everything needed to write one tensor's info header and data blob.
-pub struct TensorEntry {
+/// Static tensor metadata written into the GGUF info section (payload follows
+/// in the data section via [`GgufStreamWriter::write_tensor_data`]).
+#[derive(Clone, Debug)]
+pub struct TensorHeader {
     pub name: String,
     /// Shape as a list of dimensions (slowest-varying last, per GGUF spec).
     pub shape: Vec<u64>,
     pub tensor_type: u32,
-    /// Raw bytes to be written in the data section.
-    pub data: Vec<u8>,
 }
 
 // ---------------------------------------------------------------------------
-// GgufWriter
+// GgufStreamWriter
 // ---------------------------------------------------------------------------
 
-/// Streaming GGUF writer.
-///
-/// Tensors are added one at a time via [`GgufWriter::add_tensor`]; the file is
-/// finalised by calling [`GgufWriter::finish`] which flushes the header (with
-/// correct byte offsets) followed by all tensor data blobs.
-pub struct GgufWriter {
-    metadata: BTreeMap<String, GgufMetaValue>,
-    tensors: Vec<TensorEntry>,
+/// Single-pass GGUF file writer: header with placeholder offsets, stream each
+/// tensor blob, then seek-back offset fix-up. Holds **no** tensor payloads.
+pub struct GgufStreamWriter<'a, W: Write + Seek> {
+    writer: &'a mut W,
+    tensor_count: usize,
+    tensors_written: usize,
+    offset_field_positions: Vec<u64>,
+    real_offsets: Vec<u64>,
+    data_section_start: u64,
 }
 
-impl GgufWriter {
-    /// Create a new, empty writer.
-    pub fn new() -> Self {
-        Self { metadata: BTreeMap::new(), tensors: Vec::new() }
-    }
-
-    /// Insert a metadata key-value pair.
-    pub fn set_metadata(&mut self, key: impl Into<String>, value: GgufMetaValue) {
-        self.metadata.insert(key.into(), value);
-    }
-
-    /// Queue a tensor for inclusion in the GGUF file.
-    pub fn add_tensor(&mut self, entry: TensorEntry) {
-        self.tensors.push(entry);
-    }
-
-    /// Write the complete GGUF file to `writer`.
-    ///
-    /// This performs two passes over the header area:
-    /// 1. Write a placeholder header with dummy offsets.
-    /// 2. Compute real data offsets from the actual header size.
-    /// 3. Seek back and rewrite tensor info with correct offsets.
-    /// 4. Pad to alignment, then stream tensor data blobs.
-    pub fn finish<W: Write + Seek>(&self, writer: &mut W) -> Result<()> {
-        // --- Pass 1: write header with placeholder offsets ---
+impl<'a, W: Write + Seek> GgufStreamWriter<'a, W> {
+    /// Write the metadata and tensor info headers (placeholder offsets), pad
+    /// to [`DATA_ALIGNMENT`], and leave the writer positioned at the start of
+    /// the tensor data section.
+    pub fn begin(
+        writer: &'a mut W,
+        metadata: &BTreeMap<String, GgufMetaValue>,
+        tensor_headers: &[TensorHeader],
+    ) -> Result<Self> {
         write_u32(writer, GGUF_MAGIC)?;
         write_u32(writer, GGUF_VERSION)?;
-        write_u64(writer, self.tensors.len() as u64)?;
-        write_u64(writer, self.metadata.len() as u64)?;
+        write_u64(writer, tensor_headers.len() as u64)?;
+        write_u64(writer, metadata.len() as u64)?;
 
-        // Metadata KV entries.
-        for (key, value) in &self.metadata {
+        for (key, value) in metadata {
             write_gguf_string(writer, key)?;
             match value {
                 GgufMetaValue::U32(v) => {
@@ -136,56 +126,82 @@ impl GgufWriter {
             }
         }
 
-        // Tensor info entries — record the position of each offset field so we
-        // can seek back and fix it up in pass 2.
-        let mut offset_positions: Vec<u64> = Vec::with_capacity(self.tensors.len());
-        for entry in &self.tensors {
+        let mut offset_field_positions: Vec<u64> = Vec::with_capacity(tensor_headers.len());
+        for entry in tensor_headers {
             write_gguf_string(writer, &entry.name)?;
             write_u32(writer, entry.shape.len() as u32)?;
             for &dim in &entry.shape {
                 write_u64(writer, dim)?;
             }
             write_u32(writer, entry.tensor_type)?;
-            // Placeholder offset — we'll overwrite this in pass 2.
-            offset_positions.push(writer.stream_position().map_err(GrokOzempicError::Io)?);
+            offset_field_positions.push(writer.stream_position().map_err(GrokOzempicError::Io)?);
             write_u64(writer, 0u64)?;
         }
 
-        // --- Alignment padding before data section ---
         let header_end = writer.stream_position().map_err(GrokOzempicError::Io)?;
         let padding_needed = (DATA_ALIGNMENT - (header_end % DATA_ALIGNMENT)) % DATA_ALIGNMENT;
-        let zeroes = vec![0u8; padding_needed as usize];
-        writer.write_all(&zeroes).map_err(GrokOzempicError::Io)?;
+        writer
+            .write_all(&vec![0u8; padding_needed as usize])
+            .map_err(GrokOzempicError::Io)?;
 
         let data_section_start = writer.stream_position().map_err(GrokOzempicError::Io)?;
 
-        // --- Pass 2: write tensor data and record real offsets ---
-        let mut real_offsets: Vec<u64> = Vec::with_capacity(self.tensors.len());
-        for entry in &self.tensors {
-            let pos = writer.stream_position().map_err(GrokOzempicError::Io)?;
-            real_offsets.push(pos - data_section_start);
-            writer.write_all(&entry.data).map_err(GrokOzempicError::Io)?;
-            // Align after each tensor blob.
-            let cur = writer.stream_position().map_err(GrokOzempicError::Io)?;
-            let pad = (DATA_ALIGNMENT - (cur % DATA_ALIGNMENT)) % DATA_ALIGNMENT;
-            writer.write_all(&vec![0u8; pad as usize]).map_err(GrokOzempicError::Io)?;
-        }
+        Ok(Self {
+            writer,
+            tensor_count: tensor_headers.len(),
+            tensors_written: 0,
+            offset_field_positions,
+            real_offsets: Vec::with_capacity(tensor_headers.len()),
+            data_section_start,
+        })
+    }
 
-        // --- Seek back and fix up offsets in tensor info headers ---
-        for (offset_pos, real_offset) in offset_positions.iter().zip(real_offsets.iter()) {
-            writer
-                .seek(SeekFrom::Start(*offset_pos))
-                .map_err(GrokOzempicError::Io)?;
-            write_u64(writer, *real_offset)?;
+    /// Append one tensor's raw bytes (quantized payload) in tensor-header order.
+    pub fn write_tensor_data(&mut self, data: &[u8]) -> Result<()> {
+        if self.tensors_written >= self.tensor_count {
+            return Err(GrokOzempicError::GgufWrite(
+                "write_tensor_data: more blobs than tensor headers".into(),
+            ));
         }
-
+        let pos = self.writer.stream_position().map_err(GrokOzempicError::Io)?;
+        self.real_offsets.push(pos - self.data_section_start);
+        self.writer.write_all(data).map_err(GrokOzempicError::Io)?;
+        let cur = self.writer.stream_position().map_err(GrokOzempicError::Io)?;
+        let pad = (DATA_ALIGNMENT - (cur % DATA_ALIGNMENT)) % DATA_ALIGNMENT;
+        self.writer
+            .write_all(&vec![0u8; pad as usize])
+            .map_err(GrokOzempicError::Io)?;
+        self.tensors_written += 1;
         Ok(())
     }
-}
 
-impl Default for GgufWriter {
-    fn default() -> Self {
-        Self::new()
+    /// Patch tensor offset fields and ensure blob count matches headers.
+    pub fn finalize(self) -> Result<()> {
+        if self.tensors_written != self.tensor_count {
+            return Err(GrokOzempicError::GgufWrite(format!(
+                "finalize: expected {} tensor blobs, got {}",
+                self.tensor_count, self.tensors_written
+            )));
+        }
+        if self.real_offsets.len() != self.offset_field_positions.len() {
+            return Err(GrokOzempicError::GgufWrite(
+                "internal: offset bookkeeping mismatch".into(),
+            ));
+        }
+        for (offset_pos, real_offset) in self
+            .offset_field_positions
+            .iter()
+            .zip(self.real_offsets.iter())
+        {
+            self.writer
+                .seek(SeekFrom::Start(*offset_pos))
+                .map_err(GrokOzempicError::Io)?;
+            write_u64(self.writer, *real_offset)?;
+        }
+        self.writer
+            .seek(SeekFrom::End(0))
+            .map_err(GrokOzempicError::Io)?;
+        Ok(())
     }
 }
 
@@ -217,66 +233,88 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
-    fn make_writer_with_one_tensor() -> (GgufWriter, TensorEntry) {
-        let mut gw = GgufWriter::new();
-        gw.set_metadata("general.name", GgufMetaValue::Str("grok-ozempic-test".into()));
-        gw.set_metadata("general.quantization_version", GgufMetaValue::U32(1));
-
-        let entry = TensorEntry {
-            name: "blk.0.ffn_gate.weight".to_string(),
-            shape: vec![64, 32],
-            tensor_type: GGUF_TENSOR_TYPE_TERNARY,
-            data: vec![0xAB; 64], // dummy packed data
-        };
-        (gw, entry)
+    fn sample_metadata() -> BTreeMap<String, GgufMetaValue> {
+        let mut m = BTreeMap::new();
+        m.insert("general.name".into(), GgufMetaValue::Str("grok-ozempic-test".into()));
+        m.insert("general.quantization_version".into(), GgufMetaValue::U32(1));
+        m
     }
 
     #[test]
-    fn write_and_check_magic() {
-        let (mut gw, entry) = make_writer_with_one_tensor();
-        gw.add_tensor(entry);
+    fn stream_writer_magic_and_version() {
+        let headers = vec![TensorHeader {
+            name: "blk.0.ffn_gate.weight".into(),
+            shape: vec![64, 32],
+            tensor_type: GGUF_TENSOR_TYPE_TERNARY,
+        }];
+        let meta = sample_metadata();
         let mut buf = Cursor::new(Vec::<u8>::new());
-        gw.finish(&mut buf).unwrap();
-
+        {
+            let mut w = GgufStreamWriter::begin(&mut buf, &meta, &headers).unwrap();
+            w.write_tensor_data(&vec![0xAB; 64]).unwrap();
+            w.finalize().unwrap();
+        }
         let bytes = buf.into_inner();
-        assert!(bytes.len() > 16, "output is too short");
-        // First 4 bytes must be GGUF magic in little-endian.
-        let magic = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
         assert_eq!(magic, GGUF_MAGIC);
-        // Next 4 bytes: version = 3.
-        let version = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
         assert_eq!(version, 3);
     }
 
     #[test]
-    fn tensor_count_is_correct() {
-        let (mut gw, entry) = make_writer_with_one_tensor();
-        gw.add_tensor(entry);
+    fn stream_writer_tensor_count() {
+        let headers = vec![TensorHeader {
+            name: "t".into(),
+            shape: vec![1],
+            tensor_type: GGUF_TENSOR_TYPE_F16,
+        }];
+        let meta = sample_metadata();
         let mut buf = Cursor::new(Vec::<u8>::new());
-        gw.finish(&mut buf).unwrap();
+        {
+            let mut w = GgufStreamWriter::begin(&mut buf, &meta, &headers).unwrap();
+            w.write_tensor_data(&[0u8; 2]).unwrap();
+            w.finalize().unwrap();
+        }
         let bytes = buf.into_inner();
-        // Bytes 8-15: tensor_count u64.
         let tc = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
         assert_eq!(tc, 1);
     }
 
     #[test]
-    fn data_section_is_aligned() {
-        let (mut gw, entry) = make_writer_with_one_tensor();
-        gw.add_tensor(entry);
+    fn stream_writer_two_tensors_no_payload_buffering() {
+        let headers = vec![
+            TensorHeader {
+                name: "a".into(),
+                shape: vec![2],
+                tensor_type: GGUF_TENSOR_TYPE_TERNARY,
+            },
+            TensorHeader {
+                name: "b".into(),
+                shape: vec![4],
+                tensor_type: GGUF_TENSOR_TYPE_F16,
+            },
+        ];
+        let meta = sample_metadata();
         let mut buf = Cursor::new(Vec::<u8>::new());
-        gw.finish(&mut buf).unwrap();
-        // The file must be non-empty and the total length a multiple of DATA_ALIGNMENT
-        // (because we pad after each tensor blob).
+        {
+            let mut w = GgufStreamWriter::begin(&mut buf, &meta, &headers).unwrap();
+            w.write_tensor_data(&[1, 2]).unwrap();
+            w.write_tensor_data(&[0u8; 8]).unwrap();
+            w.finalize().unwrap();
+        }
         let len = buf.into_inner().len() as u64;
-        assert_eq!(len % DATA_ALIGNMENT, 0, "file length not aligned to {DATA_ALIGNMENT}");
+        assert_eq!(len % DATA_ALIGNMENT, 0);
     }
 
     #[test]
-    fn empty_writer_produces_valid_header() {
-        let gw = GgufWriter::new();
+    fn stream_writer_empty_tensors() {
+        let headers: Vec<TensorHeader> = vec![];
+        let meta = sample_metadata();
         let mut buf = Cursor::new(Vec::<u8>::new());
-        gw.finish(&mut buf).unwrap();
+        {
+            let w = GgufStreamWriter::begin(&mut buf, &meta, &headers).unwrap();
+            w.finalize().unwrap();
+        }
         let bytes = buf.into_inner();
         let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
         assert_eq!(magic, GGUF_MAGIC);

--- a/src/core/gguf_read.rs
+++ b/src/core/gguf_read.rs
@@ -1,0 +1,222 @@
+//! Minimal GGUF v3 reader for **verification** (not full inference loading).
+//!
+//! Validates magic/version, parses metadata and tensor info headers, checks
+//! that tensor blobs fit within the file and offsets are monotonic.
+
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::Path,
+};
+
+use crate::{
+    core::gguf::{DATA_ALIGNMENT, GGUF_TENSOR_TYPE_F16, GGUF_TENSOR_TYPE_TERNARY},
+    error::{GrokOzempicError, Result},
+};
+
+const GGUF_MAGIC: u32 = 0x4655_4747;
+
+/// Summary returned by [`verify_gguf_file`].
+#[derive(Debug, Clone)]
+pub struct GgufVerifyReport {
+    pub version: u32,
+    pub tensor_count: usize,
+    pub metadata_keys: Vec<String>,
+    pub tensor_names: Vec<String>,
+    pub file_size: u64,
+}
+
+/// Read `path`, parse the GGUF header, and check tensor data layout.
+pub fn verify_gguf_file(path: &Path) -> Result<GgufVerifyReport> {
+    let mut f = File::open(path).map_err(GrokOzempicError::Io)?;
+    let file_size = f.metadata().map_err(GrokOzempicError::Io)?.len();
+
+    let magic = read_u32(&mut f)?;
+    if magic != GGUF_MAGIC {
+        return Err(GrokOzempicError::InvalidConfig(format!(
+            "gguf verify: bad magic {magic:#x}"
+        )));
+    }
+    let version = read_u32(&mut f)?;
+    let tensor_count = read_u64(&mut f)? as usize;
+    let meta_count = read_u64(&mut f)? as usize;
+
+    let mut metadata_keys = Vec::with_capacity(meta_count);
+    for _ in 0..meta_count {
+        let key = read_gguf_string(&mut f)?;
+        metadata_keys.push(key.clone());
+        let vtype = read_u32(&mut f)?;
+        skip_meta_value(&mut f, vtype)?;
+    }
+
+    let mut tensor_names = Vec::with_capacity(tensor_count);
+    let mut infos: Vec<TensorInfoParsed> = Vec::with_capacity(tensor_count);
+
+    for _ in 0..tensor_count {
+        let name = read_gguf_string(&mut f)?;
+        tensor_names.push(name.clone());
+        let ndim = read_u32(&mut f)? as usize;
+        let mut shape = Vec::with_capacity(ndim);
+        for _ in 0..ndim {
+            shape.push(read_u64(&mut f)?);
+        }
+        let tensor_type = read_u32(&mut f)?;
+        let offset = read_u64(&mut f)?;
+        infos.push(TensorInfoParsed {
+            name,
+            shape,
+            tensor_type,
+            data_offset: offset,
+        });
+    }
+
+    let header_end = f.stream_position().map_err(GrokOzempicError::Io)?;
+    let padding_needed = (DATA_ALIGNMENT - (header_end % DATA_ALIGNMENT)) % DATA_ALIGNMENT;
+    f.seek(SeekFrom::Current(padding_needed as i64))
+        .map_err(GrokOzempicError::Io)?;
+    let data_section_start = f.stream_position().map_err(GrokOzempicError::Io)?;
+
+    // Cumulative layout must match stored offsets (writer uses packed blobs + padding).
+    let mut expected_rel: u64 = 0;
+    for (i, info) in infos.iter().enumerate() {
+        if info.data_offset != expected_rel {
+            return Err(GrokOzempicError::InvalidConfig(format!(
+                "gguf verify: tensor {} ({}) data_offset {} != expected cumulative {}",
+                i, info.name, info.data_offset, expected_rel
+            )));
+        }
+        let nbytes = tensor_nbytes(info)?;
+        let abs = data_section_start + info.data_offset;
+        let end = abs.saturating_add(nbytes);
+        if end > file_size {
+            return Err(GrokOzempicError::InvalidConfig(format!(
+                "gguf verify: tensor {} ({}) blob end {} exceeds file size {}",
+                i, info.name, end, file_size
+            )));
+        }
+        expected_rel = expected_rel.saturating_add(align_up(nbytes, DATA_ALIGNMENT));
+    }
+
+    if data_section_start + expected_rel > file_size {
+        return Err(GrokOzempicError::InvalidConfig(format!(
+            "gguf verify: declared tensor payloads need {} bytes past data section start, file has {}",
+            expected_rel,
+            file_size.saturating_sub(data_section_start)
+        )));
+    }
+
+    Ok(GgufVerifyReport {
+        version,
+        tensor_count,
+        metadata_keys,
+        tensor_names,
+        file_size,
+    })
+}
+
+struct TensorInfoParsed {
+    name: String,
+    shape: Vec<u64>,
+    tensor_type: u32,
+    data_offset: u64,
+}
+
+fn tensor_nbytes(info: &TensorInfoParsed) -> Result<u64> {
+    let n: u64 = info.shape.iter().product();
+    match info.tensor_type {
+        GGUF_TENSOR_TYPE_F16 => n.checked_mul(2).ok_or_else(|| {
+            GrokOzempicError::InvalidConfig("gguf verify: shape overflow (f16)".into())
+        }),
+        GGUF_TENSOR_TYPE_TERNARY => {
+            let bytes = n.div_ceil(4);
+            Ok(bytes)
+        }
+        other => Err(GrokOzempicError::InvalidConfig(format!(
+            "gguf verify: unknown tensor type {other} (cannot compute size)"
+        ))),
+    }
+}
+
+fn align_up(n: u64, align: u64) -> u64 {
+    (n + align - 1) / align * align
+}
+
+fn read_u32<R: Read>(r: &mut R) -> Result<u32> {
+    let mut b = [0u8; 4];
+    r.read_exact(&mut b).map_err(GrokOzempicError::Io)?;
+    Ok(u32::from_le_bytes(b))
+}
+
+fn read_u64<R: Read>(r: &mut R) -> Result<u64> {
+    let mut b = [0u8; 8];
+    r.read_exact(&mut b).map_err(GrokOzempicError::Io)?;
+    Ok(u64::from_le_bytes(b))
+}
+
+fn read_gguf_string<R: Read>(r: &mut R) -> Result<String> {
+    let len = read_u64(r)? as usize;
+    let mut buf = vec![0u8; len];
+    r.read_exact(&mut buf).map_err(GrokOzempicError::Io)?;
+    String::from_utf8(buf).map_err(|e| GrokOzempicError::InvalidConfig(format!("gguf: bad utf8: {e}")))
+}
+
+fn skip_meta_value<R: Read>(r: &mut R, vtype: u32) -> Result<()> {
+    const GGUF_TYPE_UINT32: u32 = 5;
+    const GGUF_TYPE_STRING: u32 = 8;
+    match vtype {
+        GGUF_TYPE_UINT32 => {
+            let mut b = [0u8; 4];
+            r.read_exact(&mut b).map_err(GrokOzempicError::Io)?;
+        }
+        GGUF_TYPE_STRING => {
+            let _s = read_gguf_string(r)?;
+        }
+        _ => {
+            return Err(GrokOzempicError::InvalidConfig(format!(
+                "gguf verify: unsupported metadata value type {vtype}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::io::{BufWriter, Write};
+
+    use crate::core::gguf::{
+        GgufMetaValue, GgufStreamWriter, TensorHeader, GGUF_TENSOR_TYPE_TERNARY,
+    };
+
+    #[test]
+    fn verify_round_trip_stream_writer() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("grok_ozempic_verify_test.gguf");
+        let _ = std::fs::remove_file(&path);
+
+        let mut meta = BTreeMap::new();
+        meta.insert("general.name".into(), GgufMetaValue::Str("t".into()));
+        let headers = vec![TensorHeader {
+            name: "w".into(),
+            shape: vec![8],
+            tensor_type: GGUF_TENSOR_TYPE_TERNARY,
+        }];
+        let f = File::create(&path).unwrap();
+        let mut bw = BufWriter::new(f);
+        {
+            let mut w = GgufStreamWriter::begin(&mut bw, &meta, &headers).unwrap();
+            w.write_tensor_data(&[0xFF; 2]).unwrap();
+            w.finalize().unwrap();
+        }
+        bw.flush().unwrap();
+        drop(bw);
+
+        let report = verify_gguf_file(&path).unwrap();
+        assert_eq!(report.tensor_count, 1);
+        assert_eq!(report.version, 3);
+        assert!(report.metadata_keys.contains(&"general.name".to_string()));
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,4 +1,6 @@
 pub mod gguf;
+pub mod gguf_read;
+pub mod npy;
 pub mod olmoe;
 pub mod projector;
 pub mod quantizer;

--- a/src/core/npy.rs
+++ b/src/core/npy.rs
@@ -1,0 +1,202 @@
+//! Minimal `.npy` (NumPy array) header parsing for memory-mapped tensors.
+//!
+//! Grok-1 JAX checkpoints are often distributed as per-tensor `.npy` files.
+//! This module parses the header to obtain `dtype`, `shape`, and the byte
+//! offset where raw array data begins, so large tensors can be accessed via
+//! `mmap` without loading the full array into RAM.
+
+use std::path::Path;
+
+use memmap2::{Mmap, MmapOptions};
+
+use crate::error::{GrokOzempicError, Result};
+
+const NPY_MAGIC: &[u8; 6] = b"\x93NUMPY";
+
+/// Logical dtype of the `.npy` payload (only types used by the quantizer).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NpyDtype {
+    F32,
+    F16,
+    BF16,
+    Other,
+}
+
+/// Memory-mapped `.npy` with parsed header; raw values are in [`MmapNpy::data`].
+pub struct MmapNpy {
+    mmap: Mmap,
+    dtype: NpyDtype,
+    shape: Vec<usize>,
+    data_offset: usize,
+}
+
+impl MmapNpy {
+    pub fn map_path(path: &Path) -> Result<Self> {
+        let file = std::fs::File::open(path).map_err(GrokOzempicError::Io)?;
+        let mmap = unsafe { MmapOptions::new().map(&file).map_err(GrokOzempicError::Io)? };
+        let (dtype, shape, data_offset) = parse_npy_header(&mmap)?;
+        Ok(Self {
+            mmap,
+            dtype,
+            shape,
+            data_offset,
+        })
+    }
+
+    pub fn dtype(&self) -> NpyDtype {
+        self.dtype
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.mmap[self.data_offset..]
+    }
+}
+
+/// Parse NumPy `.npy` header prefix; returns `(dtype, shape, data_byte_offset)`.
+pub fn parse_npy_header(buf: &[u8]) -> Result<(NpyDtype, Vec<usize>, usize)> {
+    if buf.len() < 10 {
+        return Err(GrokOzempicError::InvalidConfig(
+            "npy: file too small for header".into(),
+        ));
+    }
+    if &buf[0..6] != NPY_MAGIC {
+        return Err(GrokOzempicError::InvalidConfig(
+            "npy: missing \\x93NUMPY magic".into(),
+        ));
+    }
+    let major = buf[6];
+    let (header_len, header_start) = match major {
+        1 => {
+            let hlen = u16::from_le_bytes([buf[8], buf[9]]) as usize;
+            (hlen, 10)
+        }
+        2 => {
+            if buf.len() < 12 {
+                return Err(GrokOzempicError::InvalidConfig("npy: truncated v2".into()));
+            }
+            let hlen = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]) as usize;
+            (hlen, 12)
+        }
+        _ => {
+            return Err(GrokOzempicError::InvalidConfig(format!(
+                "npy: unsupported version {major}"
+            )));
+        }
+    };
+    let header_end = header_start + header_len;
+    if buf.len() < header_end {
+        return Err(GrokOzempicError::InvalidConfig(
+            "npy: header length exceeds file".into(),
+        ));
+    }
+    let header_str = std::str::from_utf8(&buf[header_start..header_end]).map_err(|_| {
+        GrokOzempicError::InvalidConfig("npy: header is not valid UTF-8".into())
+    })?;
+    let descr = parse_descr(header_str).ok_or_else(|| {
+        GrokOzempicError::InvalidConfig("npy: could not parse descr".into())
+    })?;
+    let shape = parse_shape(header_str).ok_or_else(|| {
+        GrokOzempicError::InvalidConfig("npy: could not parse shape".into())
+    })?;
+    let dtype = npy_descr_to_dtype(descr);
+    let preamble = header_start;
+    let total = preamble + header_len;
+    let pad_to_64 = (64 - (total % 64)) % 64;
+    let data_offset = total + pad_to_64;
+    if buf.len() < data_offset {
+        return Err(GrokOzempicError::InvalidConfig(
+            "npy: file ends before data section".into(),
+        ));
+    }
+    Ok((dtype, shape, data_offset))
+}
+
+fn parse_descr(header: &str) -> Option<&str> {
+    let key = "'descr'";
+    let i = header.find(key)?;
+    let rest = &header[i + key.len()..];
+    let colon = rest.find(':')?;
+    let rest = rest[colon + 1..].trim_start();
+    let quote = rest.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let rest = &rest[quote.len_utf8()..];
+    let end = rest.find(quote)?;
+    Some(&rest[..end])
+}
+
+fn parse_shape(header: &str) -> Option<Vec<usize>> {
+    let key = "'shape'";
+    let i = header.find(key)?;
+    let rest = &header[i + key.len()..];
+    let colon = rest.find(':')?;
+    let rest = rest[colon + 1..].trim_start();
+    let rest = rest.strip_prefix('(')?;
+    let end_paren = rest.find(')')?;
+    let inner = &rest[..end_paren];
+    if inner.is_empty() {
+        return Some(vec![]);
+    }
+    let mut dims = Vec::new();
+    for part in inner.split(',') {
+        let p = part.trim();
+        if p.is_empty() {
+            continue;
+        }
+        let n: usize = p.parse().ok()?;
+        dims.push(n);
+    }
+    Some(dims)
+}
+
+fn npy_descr_to_dtype(descr: &str) -> NpyDtype {
+    let d = descr.trim();
+    let body = d
+        .strip_prefix('<')
+        .or_else(|| d.strip_prefix('>'))
+        .or_else(|| d.strip_prefix('|'))
+        .or_else(|| d.strip_prefix('='))
+        .unwrap_or(d);
+    match body {
+        "f4" => NpyDtype::F32,
+        "f2" => NpyDtype::F16,
+        "u2" | "bfloat16" | "bf16" => NpyDtype::BF16,
+        _ => NpyDtype::Other,
+    }
+}
+
+/// Map a filename stem like `blk__0__weight` back to a logical tensor name `blk.0.weight`.
+pub fn npy_stem_to_tensor_name(stem: &str) -> String {
+    stem.replace("__", ".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_v1_header() {
+        let dict = "{'descr': '<f4', 'fortran_order': False, 'shape': (3, 4), }";
+        let mut header = Vec::new();
+        header.extend_from_slice(NPY_MAGIC);
+        header.push(1);
+        header.push(0);
+        let hlen = dict.len() as u16;
+        header.extend_from_slice(&hlen.to_le_bytes());
+        header.extend_from_slice(dict.as_bytes());
+        let preamble = header.len();
+        let pad = (64 - (preamble % 64)) % 64;
+        header.extend(std::iter::repeat(b' ').take(pad));
+        let data_offset = header.len();
+        header.extend_from_slice(&[0u8; 48]);
+        let (dtype, shape, off) = parse_npy_header(&header).unwrap();
+        assert_eq!(dtype, NpyDtype::F32);
+        assert_eq!(shape, vec![3, 4]);
+        assert_eq!(off, data_offset);
+    }
+}

--- a/src/core/olmoe.rs
+++ b/src/core/olmoe.rs
@@ -1,6 +1,8 @@
+use half::f16;
+
 use crate::{
     error::{GrokOzempicError, Result},
-    types::{HybridConfig, EMBEDDING_DIM},
+    types::HybridConfig,
 };
 
 /// Sparse Mixture-of-Experts router for Grok's MoE layers.
@@ -16,7 +18,9 @@ pub struct OLMoE {
 }
 
 impl OLMoE {
-    /// Create a new `OLMoE` with zero-initialised gate weights.
+    /// Create a new `OLMoE` with zero-initialised gate weights (uniform routing
+    /// until you call [`Self::load_gates_from_fp16_stacked_experts`] with real
+    /// router / gate tensors).
     pub fn new(num_experts: usize, top_k: usize, embedding_dim: usize) -> Self {
         Self {
             num_experts,
@@ -28,7 +32,43 @@ impl OLMoE {
 
     /// Build an `OLMoE` from a [`HybridConfig`].
     pub fn from_config(config: &HybridConfig) -> Self {
-        Self::new(config.num_experts, config.top_k_experts, EMBEDDING_DIM)
+        Self::new(
+            config.num_experts,
+            config.top_k_experts,
+            config.embedding_dim,
+        )
+    }
+
+    /// Load all expert gate rows from a single FP16 blob: layout is
+    /// `[num_experts × embedding_dim]` values in row-major order (each row is
+    /// one expert's gate vector, little-endian IEEE half). Typical source: a
+    /// quantized Grok MoE router / gate tensor after conversion from GGUF.
+    pub fn load_gates_from_fp16_stacked_experts(&mut self, data: &[u8]) -> Result<()> {
+        let need = self
+            .num_experts
+            .checked_mul(self.embedding_dim)
+            .and_then(|n| n.checked_mul(2))
+            .ok_or_else(|| GrokOzempicError::InvalidConfig(
+                "gate buffer size overflow".into(),
+            ))?;
+        if data.len() != need {
+            return Err(GrokOzempicError::DimensionMismatch {
+                expected: need,
+                got: data.len(),
+            });
+        }
+        self.gate_weights.clear();
+        self.gate_weights.reserve(self.num_experts);
+        for e in 0..self.num_experts {
+            let mut row = Vec::with_capacity(self.embedding_dim);
+            for i in 0..self.embedding_dim {
+                let o = (e * self.embedding_dim + i) * 2;
+                let bits = u16::from_le_bytes([data[o], data[o + 1]]);
+                row.push(f16::from_bits(bits).to_f32());
+            }
+            self.gate_weights.push(row);
+        }
+        Ok(())
     }
 
     /// Set the gate weight vector for a single expert.

--- a/src/core/projector.rs
+++ b/src/core/projector.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Result,
-    types::{HybridConfig, ProjectionMode, EMBEDDING_DIM},
+    types::{HybridConfig, ProjectionMode},
 };
 
 /// Projector maps input activations to a ternary spike representation.
@@ -30,7 +30,12 @@ impl Projector {
 
     /// Build a `Projector` from a [`HybridConfig`].
     pub fn from_config(config: &HybridConfig) -> Self {
-        Self::new(EMBEDDING_DIM, EMBEDDING_DIM, config.projection_mode, config.snn_steps)
+        Self::new(
+            config.embedding_dim,
+            config.embedding_dim,
+            config.projection_mode,
+            config.snn_steps,
+        )
     }
 
     /// Reset the membrane potentials to zero (call between independent inputs).

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1,27 +1,21 @@
-//! Out-of-Core Streaming Quantization Engine
+//! Out-of-core streaming quantization engine
 //!
-//! Implements a zero-OOM pipeline for quantizing the full 318 GB Grok-1 model
-//! on hardware with limited VRAM / system RAM:
+//! 1. **Manifest pass** — scans safetensors shards or `.npy` files and records
+//!    only `(path, name, shape, dtype, router?)` (no weight payloads).
+//! 2. **Header pass** — writes GGUF metadata + tensor info with placeholder
+//!    offsets via [`GgufStreamWriter::begin`].
+//! 3. **Data pass** — for each manifest row, memory-maps the source tensor,
+//!    quantizes **one tensor at a time**, and streams bytes with
+//!    [`GgufStreamWriter::write_tensor_data`] (no accumulation of all tensors).
 //!
-//! 1. Memory-maps each Safetensors shard read-only via `memmap2` — the OS
-//!    kernel pages in only the bytes that are actually touched.
-//! 2. For each tensor, classifies it as a **router tensor** (kept in FP16) or
-//!    an **expert MLP tensor** (ternary-quantized with GIF saliency filter).
-//! 3. Streams the quantized bytes directly into a [`GgufWriter`] buffer and
-//!    writes the final GGUF file, then drops every allocation before moving on.
-//!
-//! # Memory behaviour
-//! - The raw weight bytes are accessed through a read-only `memmap2` mapping;
-//!   no heap allocation proportional to shard size is made.
-//! - Only the f32/f16 slice for **one tensor at a time** is materialised on
-//!   the heap (for the quantizer), then dropped before the next tensor is read.
-//! - The [`GgufWriter`] accumulates only the (much smaller) packed ternary /
-//!   FP16 output data.
+//! Pickle / pure JAX checkpoints are not read here; convert to safetensors or
+//! `.npy` first.
 
 use std::{
+    collections::BTreeMap,
     fs::{self, File},
-    io::BufWriter,
-    path::{Path, PathBuf},
+    io::{BufWriter, Write},
+    path::PathBuf,
 };
 
 use half::f16;
@@ -30,32 +24,71 @@ use safetensors::SafeTensors;
 
 use crate::{
     core::{
-        gguf::{GgufMetaValue, GgufWriter, TensorEntry, GGUF_TENSOR_TYPE_F16, GGUF_TENSOR_TYPE_TERNARY},
+        gguf::{
+            GgufMetaValue, GgufStreamWriter, TensorHeader, GGUF_TENSOR_TYPE_F16,
+            GGUF_TENSOR_TYPE_TERNARY,
+        },
+        npy::{npy_stem_to_tensor_name, MmapNpy, NpyDtype},
         quantizer::{convert_f32_to_f16_bytes, passthrough_f16, quantize_f16, quantize_f32},
     },
     error::{GrokOzempicError, Result},
-    types::QuantizationConfig,
+    types::{QuantizationConfig, QuantizationInputFormat},
 };
+
+// Grok-1 architecture hints for downstream loaders (llama.cpp-style keys).
+// Confirm against https://huggingface.co/xai-org/grok-1 `config.json` when updating.
+const GROK1_CONTEXT_LENGTH: u32 = 8192;
+const GROK1_EMBEDDING_LENGTH: u32 = 6144;
+const GROK1_FEED_FORWARD_LENGTH: u32 = 32768;
+const GROK1_ATTENTION_HEAD_COUNT: u32 = 48;
+const GROK1_ATTENTION_HEAD_COUNT_KV: u32 = 8;
+const GROK1_BLOCK_COUNT: u32 = 64;
+const GROK1_EXPERT_COUNT: u32 = 256;
+
+/// Append Grok-1-ish architecture metadata so GGUF consumers can size the graph.
+pub fn append_grok1_arch_metadata(meta: &mut BTreeMap<String, GgufMetaValue>) {
+    meta.insert(
+        "general.architecture".into(),
+        GgufMetaValue::Str("grok".into()),
+    );
+    meta.insert(
+        "grok.context_length".into(),
+        GgufMetaValue::U32(GROK1_CONTEXT_LENGTH),
+    );
+    meta.insert(
+        "grok.embedding_length".into(),
+        GgufMetaValue::U32(GROK1_EMBEDDING_LENGTH),
+    );
+    meta.insert(
+        "grok.feed_forward_length".into(),
+        GgufMetaValue::U32(GROK1_FEED_FORWARD_LENGTH),
+    );
+    meta.insert(
+        "grok.attention.head_count".into(),
+        GgufMetaValue::U32(GROK1_ATTENTION_HEAD_COUNT),
+    );
+    meta.insert(
+        "grok.attention.head_count_kv".into(),
+        GgufMetaValue::U32(GROK1_ATTENTION_HEAD_COUNT_KV),
+    );
+    meta.insert(
+        "grok.block_count".into(),
+        GgufMetaValue::U32(GROK1_BLOCK_COUNT),
+    );
+    meta.insert(
+        "grok.expert_count".into(),
+        GgufMetaValue::U32(GROK1_EXPERT_COUNT),
+    );
+}
 
 // ---------------------------------------------------------------------------
 // Tensor classification
 // ---------------------------------------------------------------------------
 
-/// Returns `true` when the tensor `name` should be kept in FP16 (router /
-/// gate weights) rather than being ternary-quantized.
-///
-/// The classification is based on substring matching against the patterns
-/// listed in [`QuantizationConfig::router_patterns`].  If no patterns are
-/// configured the default set is used (covers Grok-1's gate / router layers).
 fn is_router_tensor(name: &str, patterns: &[String]) -> bool {
     if patterns.is_empty() {
-        // Default Grok-1 routing tensor name fragments.
         let defaults = [
-            "router",
-            "gate",
-            "moe_gate",
-            "expert_router",
-            "routing",
+            "router", "gate", "moe_gate", "expert_router", "routing",
         ];
         return defaults.iter().any(|p| name.contains(p));
     }
@@ -63,197 +96,334 @@ fn is_router_tensor(name: &str, patterns: &[String]) -> bool {
 }
 
 // ---------------------------------------------------------------------------
-// Safetensors dtype helpers
+// Source dtype (safetensors + npy)
 // ---------------------------------------------------------------------------
 
-/// Dtype tag values used by the Safetensors format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Dtype {
+enum SourceDtype {
     F32,
     F16,
     BF16,
     Other,
 }
 
-fn parse_dtype(dt: safetensors::Dtype) -> Dtype {
+fn parse_safetensors_dtype(dt: safetensors::Dtype) -> SourceDtype {
     match dt {
-        safetensors::Dtype::F32 => Dtype::F32,
-        safetensors::Dtype::F16 => Dtype::F16,
-        safetensors::Dtype::BF16 => Dtype::BF16,
-        _ => Dtype::Other,
+        safetensors::Dtype::F32 => SourceDtype::F32,
+        safetensors::Dtype::F16 => SourceDtype::F16,
+        safetensors::Dtype::BF16 => SourceDtype::BF16,
+        _ => SourceDtype::Other,
+    }
+}
+
+fn npy_dtype_to_source(dt: NpyDtype) -> SourceDtype {
+    match dt {
+        NpyDtype::F32 => SourceDtype::F32,
+        NpyDtype::F16 => SourceDtype::F16,
+        NpyDtype::BF16 => SourceDtype::BF16,
+        NpyDtype::Other => SourceDtype::Other,
     }
 }
 
 // ---------------------------------------------------------------------------
-// Streaming engine
+// Manifest
 // ---------------------------------------------------------------------------
 
-/// Diagnostic statistics emitted after processing each shard.
+#[derive(Debug, Clone)]
+struct ManifestEntry {
+    source_path: PathBuf,
+    tensor_name: String,
+    shape: Vec<u64>,
+    is_router: bool,
+}
+
+/// Diagnostic statistics emitted after processing each shard / source file.
 #[derive(Debug, Default)]
 pub struct ShardStats {
     pub shard_path: PathBuf,
     pub tensors_ternary: usize,
     pub tensors_fp16: usize,
     pub tensors_skipped: usize,
-    /// Average sparsity across ternary tensors (fraction silenced to 0).
     pub avg_sparsity: f32,
 }
 
 /// Run the full out-of-core quantization pipeline described by `config`.
-///
-/// # Errors
-/// Returns an error if:
-/// - `input_dir` contains no `.safetensors` files.
-/// - Any shard cannot be memory-mapped or parsed.
-/// - The output GGUF file cannot be created or written.
 pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> {
-    // Collect shard paths, sorted for deterministic output ordering.
-    let shards = collect_shards(&config.input_dir)?;
-    if shards.is_empty() {
-        return Err(GrokOzempicError::InvalidConfig(format!(
-            "no .safetensors files found in '{}'",
-            config.input_dir
-        )));
+    let manifest = match config.input_format {
+        QuantizationInputFormat::Safetensors => {
+            let shards = collect_safetensor_shards(&config.input_dir)?;
+            if shards.is_empty() {
+                return Err(GrokOzempicError::InvalidConfig(format!(
+                    "no .safetensors files found in '{}'",
+                    config.input_dir
+                )));
+            }
+            build_manifest_safetensors(&shards, &config.router_patterns)?
+        }
+        QuantizationInputFormat::NpyDir => {
+            let paths = collect_npy_files(&config.input_dir)?;
+            if paths.is_empty() {
+                return Err(GrokOzempicError::InvalidConfig(format!(
+                    "no .npy files found in '{}'",
+                    config.input_dir
+                )));
+            }
+            build_manifest_npy(&paths, &config.router_patterns)?
+        }
+    };
+
+    if manifest.is_empty() {
+        return Err(GrokOzempicError::InvalidConfig(
+            "no quantizable tensors found (all skipped as unsupported dtype?)".into(),
+        ));
     }
 
-    // Create the output GGUF file.
+    let headers: Vec<TensorHeader> = manifest
+        .iter()
+        .map(|e| TensorHeader {
+            name: e.tensor_name.clone(),
+            shape: e.shape.clone(),
+            tensor_type: if e.is_router {
+                GGUF_TENSOR_TYPE_F16
+            } else {
+                GGUF_TENSOR_TYPE_TERNARY
+            },
+        })
+        .collect();
+
+    let mut metadata: BTreeMap<String, GgufMetaValue> = BTreeMap::new();
+    metadata.insert(
+        "general.name".into(),
+        GgufMetaValue::Str("grok-ozempic".into()),
+    );
+    metadata.insert(
+        "general.quantization_version".into(),
+        GgufMetaValue::U32(1),
+    );
+    metadata.insert(
+        "grok_ozempic.gif_threshold".into(),
+        GgufMetaValue::Str(config.gif_threshold.to_string()),
+    );
+    append_grok1_arch_metadata(&mut metadata);
+
     let out_file = File::create(&config.output_path).map_err(GrokOzempicError::Io)?;
     let mut out_writer = BufWriter::new(out_file);
 
-    let mut gguf = GgufWriter::new();
+    let mut stream = GgufStreamWriter::begin(&mut out_writer, &metadata, &headers)?;
 
-    // Write top-level metadata.
-    gguf.set_metadata("general.name", GgufMetaValue::Str("grok-ozempic".into()));
-    gguf.set_metadata(
-        "general.quantization_version",
-        GgufMetaValue::U32(1),
-    );
-    gguf.set_metadata(
-        "grok_ozempic.gif_threshold",
-        GgufMetaValue::Str(config.gif_threshold.to_string()),
-    );
+    let mut all_stats: Vec<ShardStats> = Vec::new();
+    let mut current_path: Option<PathBuf> = None;
+    let mut shard_stats = ShardStats::default();
+    let mut sparsity_sum = 0.0f32;
+    let mut sparsity_n = 0usize;
 
-    let mut all_stats: Vec<ShardStats> = Vec::with_capacity(shards.len());
+    for entry in &manifest {
+        if current_path.as_ref() != Some(&entry.source_path) {
+            if current_path.is_some() {
+                if sparsity_n > 0 {
+                    shard_stats.avg_sparsity = sparsity_sum / sparsity_n as f32;
+                }
+                all_stats.push(shard_stats);
+                sparsity_sum = 0.0;
+                sparsity_n = 0;
+            }
+            shard_stats = ShardStats {
+                shard_path: entry.source_path.clone(),
+                ..Default::default()
+            };
+            current_path = Some(entry.source_path.clone());
+        }
 
-    for shard_path in &shards {
-        let stats = process_shard(shard_path, config, &mut gguf)?;
-        all_stats.push(stats);
+        let (packed, ternary_sparsity) = quantize_manifest_entry(entry, config)?;
+        if entry.is_router {
+            shard_stats.tensors_fp16 += 1;
+        } else {
+            shard_stats.tensors_ternary += 1;
+            if let Some(sp) = ternary_sparsity {
+                sparsity_sum += sp;
+                sparsity_n += 1;
+            }
+        }
+        stream.write_tensor_data(&packed)?;
+    }
+    if current_path.is_some() {
+        if sparsity_n > 0 {
+            shard_stats.avg_sparsity = sparsity_sum / sparsity_n as f32;
+        }
+        all_stats.push(shard_stats);
     }
 
-    // Flush everything to disk.
-    gguf.finish(&mut out_writer)
-        .map_err(|e| GrokOzempicError::GgufWrite(e.to_string()))?;
+    stream.finalize()?;
+    out_writer
+        .flush()
+        .map_err(GrokOzempicError::Io)?;
 
     Ok(all_stats)
 }
 
-/// Process a single Safetensors shard: memory-map it, iterate tensors, quantize
-/// each one, and add it to the GGUF writer.
-fn process_shard(
-    shard_path: &Path,
+fn quantize_manifest_entry(
+    entry: &ManifestEntry,
     config: &QuantizationConfig,
-    gguf: &mut GgufWriter,
-) -> Result<ShardStats> {
-    let file = File::open(shard_path).map_err(GrokOzempicError::Io)?;
-
-    // Safety: we open the file read-only and do not mutate the mapping.  The
-    // file is not modified while the mapping is alive (single-threaded).
-    let mmap = unsafe { MmapOptions::new().map(&file).map_err(GrokOzempicError::Io)? };
-
-    let tensors = SafeTensors::deserialize(&mmap).map_err(GrokOzempicError::Safetensors)?;
-
-    let mut stats = ShardStats {
-        shard_path: shard_path.to_owned(),
-        ..Default::default()
-    };
-    let mut sparsity_sum = 0.0f32;
-
-    for (name, view) in tensors.tensors() {
-        let dtype = parse_dtype(view.dtype());
-        if dtype == Dtype::Other {
-            // Skip unsupported dtypes (e.g., I8, Bool) without failing.
-            stats.tensors_skipped += 1;
-            continue;
-        }
-
-        let router = is_router_tensor(&name, &config.router_patterns);
-
-        let (packed_data, tensor_type, shape) = if router {
-            // ── Mixed-precision: keep routing gate in FP16 ──────────────────
-            let fp16_bytes = match dtype {
-                Dtype::F16 => {
-                    // Already FP16 — read raw bytes directly from the mmap.
-                    let raw = view.data();
-                    let f16_slice: &[f16] = bytemuck_cast_f16(raw);
-                    passthrough_f16(f16_slice)
-                }
-                Dtype::F32 => {
-                    let raw = view.data();
-                    let f32_slice = bytemuck_cast_f32(raw);
-                    convert_f32_to_f16_bytes(f32_slice)
-                }
-                Dtype::BF16 => {
-                    // Convert BF16 → f32 → f16.
-                    let raw = view.data();
-                    let f32_vals = bf16_bytes_to_f32(raw);
-                    convert_f32_to_f16_bytes(&f32_vals)
-                }
-                Dtype::Other => unreachable!(),
-            };
-            let shape: Vec<u64> = view.shape().iter().map(|&d| d as u64).collect();
-            (fp16_bytes, GGUF_TENSOR_TYPE_F16, shape)
-        } else {
-            // ── Saliency-aware GIF ternary quantization ──────────────────────
-            let qt = match dtype {
-                Dtype::F32 => {
-                    let raw = view.data();
-                    let f32_slice = bytemuck_cast_f32(raw);
-                    quantize_f32(f32_slice, config.gif_threshold)
-                }
-                Dtype::F16 => {
-                    let raw = view.data();
-                    let f16_slice: &[f16] = bytemuck_cast_f16(raw);
-                    quantize_f16(f16_slice, config.gif_threshold)
-                }
-                Dtype::BF16 => {
-                    let raw = view.data();
-                    let f32_vals = bf16_bytes_to_f32(raw);
-                    quantize_f32(&f32_vals, config.gif_threshold)
-                }
-                Dtype::Other => unreachable!(),
-            };
-            sparsity_sum += qt.sparsity;
-            stats.tensors_ternary += 1;
-            let shape: Vec<u64> = view.shape().iter().map(|&d| d as u64).collect();
-            (qt.packed, GGUF_TENSOR_TYPE_TERNARY, shape)
-        };
-
-        if router {
-            stats.tensors_fp16 += 1;
-        }
-
-        // Add tensor to GGUF writer — the quantized bytes are small compared
-        // with the original, and the mmap bytes are not copied here.
-        gguf.add_tensor(TensorEntry {
-            name: name.to_string(),
-            shape,
-            tensor_type,
-            data: packed_data,
-        });
+) -> Result<(Vec<u8>, Option<f32>)> {
+    match config.input_format {
+        QuantizationInputFormat::Safetensors => quantize_safetensors_entry(entry, config),
+        QuantizationInputFormat::NpyDir => quantize_npy_entry(entry, config),
     }
-
-    if stats.tensors_ternary > 0 {
-        stats.avg_sparsity = sparsity_sum / stats.tensors_ternary as f32;
-    }
-
-    Ok(stats)
 }
 
-// ---------------------------------------------------------------------------
-// File discovery
-// ---------------------------------------------------------------------------
+fn quantize_safetensors_entry(
+    entry: &ManifestEntry,
+    config: &QuantizationConfig,
+) -> Result<(Vec<u8>, Option<f32>)> {
+    let file = File::open(&entry.source_path).map_err(GrokOzempicError::Io)?;
+    let mmap = unsafe { MmapOptions::new().map(&file).map_err(GrokOzempicError::Io)? };
+    let tensors = SafeTensors::deserialize(&mmap).map_err(GrokOzempicError::Safetensors)?;
+    let view = tensors.tensor(&entry.tensor_name)?;
 
-fn collect_shards(dir: &str) -> Result<Vec<PathBuf>> {
+    let dtype = parse_safetensors_dtype(view.dtype());
+    if dtype == SourceDtype::Other {
+        return Err(GrokOzempicError::InvalidConfig(format!(
+            "tensor {} has unsupported dtype",
+            entry.tensor_name
+        )));
+    }
+
+    if entry.is_router {
+        let fp16_bytes = router_fp16_bytes(dtype, view.data())?;
+        Ok((fp16_bytes, None))
+    } else {
+        let qt = match dtype {
+            SourceDtype::F32 => {
+                let f32_slice = bytemuck_cast_f32(view.data());
+                quantize_f32(f32_slice, config.gif_threshold)
+            }
+            SourceDtype::F16 => {
+                let f16_slice: &[f16] = bytemuck_cast_f16(view.data());
+                quantize_f16(f16_slice, config.gif_threshold)
+            }
+            SourceDtype::BF16 => {
+                let f32_vals = bf16_bytes_to_f32(view.data());
+                quantize_f32(&f32_vals, config.gif_threshold)
+            }
+            SourceDtype::Other => unreachable!(),
+        };
+        let sp = qt.sparsity;
+        Ok((qt.packed, Some(sp)))
+    }
+}
+
+fn quantize_npy_entry(
+    entry: &ManifestEntry,
+    config: &QuantizationConfig,
+) -> Result<(Vec<u8>, Option<f32>)> {
+    let npy = MmapNpy::map_path(&entry.source_path)?;
+    let dtype = npy_dtype_to_source(npy.dtype());
+    if dtype == SourceDtype::Other {
+        return Err(GrokOzempicError::InvalidConfig(format!(
+            "npy {} has unsupported descr",
+            entry.source_path.display()
+        )));
+    }
+    let raw = npy.data();
+
+    if entry.is_router {
+        let fp16_bytes = router_fp16_bytes(dtype, raw)?;
+        Ok((fp16_bytes, None))
+    } else {
+        let qt = match dtype {
+            SourceDtype::F32 => {
+                let f32_slice = bytemuck_cast_f32(raw);
+                quantize_f32(f32_slice, config.gif_threshold)
+            }
+            SourceDtype::F16 => {
+                let f16_slice: &[f16] = bytemuck_cast_f16(raw);
+                quantize_f16(f16_slice, config.gif_threshold)
+            }
+            SourceDtype::BF16 => {
+                let f32_vals = bf16_bytes_to_f32(raw);
+                quantize_f32(&f32_vals, config.gif_threshold)
+            }
+            SourceDtype::Other => unreachable!(),
+        };
+        let sp = qt.sparsity;
+        Ok((qt.packed, Some(sp)))
+    }
+}
+
+fn router_fp16_bytes(dtype: SourceDtype, raw: &[u8]) -> Result<Vec<u8>> {
+    let b = match dtype {
+        SourceDtype::F16 => {
+            let f16_slice: &[f16] = bytemuck_cast_f16(raw);
+            passthrough_f16(f16_slice)
+        }
+        SourceDtype::F32 => {
+            let f32_slice = bytemuck_cast_f32(raw);
+            convert_f32_to_f16_bytes(f32_slice)
+        }
+        SourceDtype::BF16 => {
+            let f32_vals = bf16_bytes_to_f32(raw);
+            convert_f32_to_f16_bytes(&f32_vals)
+        }
+        SourceDtype::Other => unreachable!(),
+    };
+    Ok(b)
+}
+
+fn build_manifest_safetensors(
+    shards: &[PathBuf],
+    patterns: &[String],
+) -> Result<Vec<ManifestEntry>> {
+    let mut v = Vec::new();
+    for shard in shards {
+        let file = File::open(shard).map_err(GrokOzempicError::Io)?;
+        let mmap = unsafe { MmapOptions::new().map(&file).map_err(GrokOzempicError::Io)? };
+        let tensors = SafeTensors::deserialize(&mmap).map_err(GrokOzempicError::Safetensors)?;
+        for (name, view) in tensors.tensors() {
+            let dtype = parse_safetensors_dtype(view.dtype());
+            if dtype == SourceDtype::Other {
+                continue;
+            }
+            let is_router = is_router_tensor(&name, patterns);
+            let shape: Vec<u64> = view.shape().iter().map(|&d| d as u64).collect();
+            v.push(ManifestEntry {
+                source_path: shard.clone(),
+                tensor_name: name,
+                shape,
+                is_router,
+            });
+        }
+    }
+    Ok(v)
+}
+
+fn build_manifest_npy(paths: &[PathBuf], patterns: &[String]) -> Result<Vec<ManifestEntry>> {
+    let mut v = Vec::new();
+    for path in paths {
+        let npy = MmapNpy::map_path(path)?;
+        let dtype = npy_dtype_to_source(npy.dtype());
+        if dtype == SourceDtype::Other {
+            continue;
+        }
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| {
+                GrokOzempicError::InvalidConfig(format!("bad npy filename: {}", path.display()))
+            })?;
+        let tensor_name = npy_stem_to_tensor_name(stem);
+        let is_router = is_router_tensor(&tensor_name, patterns);
+        let shape: Vec<u64> = npy.shape().iter().map(|&d| d as u64).collect();
+        v.push(ManifestEntry {
+            source_path: path.clone(),
+            tensor_name,
+            shape,
+            is_router,
+        });
+    }
+    Ok(v)
+}
+
+fn collect_safetensor_shards(dir: &str) -> Result<Vec<PathBuf>> {
     let mut paths: Vec<PathBuf> = fs::read_dir(dir)
         .map_err(GrokOzempicError::Io)?
         .filter_map(|e| e.ok())
@@ -264,53 +434,41 @@ fn collect_shards(dir: &str) -> Result<Vec<PathBuf>> {
     Ok(paths)
 }
 
-// ---------------------------------------------------------------------------
-// Safe byte-slice reinterpretation helpers
-// ---------------------------------------------------------------------------
+fn collect_npy_files(dir: &str) -> Result<Vec<PathBuf>> {
+    let mut paths: Vec<PathBuf> = fs::read_dir(dir)
+        .map_err(GrokOzempicError::Io)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "npy"))
+        .collect();
+    paths.sort();
+    Ok(paths)
+}
 
-/// Reinterpret a raw byte slice as a `&[f32]`.
-///
-/// # Panics
-/// Panics if `raw` is not aligned to 4 bytes or its length is not a multiple
-/// of 4.  Safetensors guarantees both properties for F32 tensors.
 fn bytemuck_cast_f32(raw: &[u8]) -> &[f32] {
     assert_eq!(raw.len() % 4, 0, "f32 data length must be a multiple of 4");
-    // SAFETY: safetensors guarantees the data is properly aligned and sized for
-    // the declared dtype; raw is valid for reads of raw.len() bytes.
     unsafe {
         std::slice::from_raw_parts(raw.as_ptr().cast::<f32>(), raw.len() / 4)
     }
 }
 
-/// Reinterpret a raw byte slice as a `&[f16]`.
 fn bytemuck_cast_f16(raw: &[u8]) -> &[f16] {
     assert_eq!(raw.len() % 2, 0, "f16 data length must be a multiple of 2");
-    // SAFETY: same guarantees as bytemuck_cast_f32 for F16 data.
     unsafe {
         std::slice::from_raw_parts(raw.as_ptr().cast::<f16>(), raw.len() / 2)
     }
 }
 
-/// Convert a BF16 byte slice (little-endian) to a vector of f32 values.
-///
-/// BF16 is the upper 16 bits of IEEE 754 f32; padding the lower 16 bits with
-/// zeros gives the equivalent f32.
 fn bf16_bytes_to_f32(raw: &[u8]) -> Vec<f32> {
     assert_eq!(raw.len() % 2, 0, "bf16 data length must be a multiple of 2");
     raw.chunks_exact(2)
         .map(|chunk| {
-            // BF16 little-endian: chunk[0] = low byte of BF16, chunk[1] = high byte.
-            // Reconstruct as f32 with the BF16 bits in the upper 16 bits.
             let bf16_bits = u16::from_le_bytes([chunk[0], chunk[1]]);
             let f32_bits = (bf16_bits as u32) << 16;
             f32::from_bits(f32_bits)
         })
         .collect()
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -334,8 +492,6 @@ mod tests {
 
     #[test]
     fn bf16_bytes_to_f32_one() {
-        // BF16 representation of 1.0f32.
-        // 1.0f32 = 0x3F800000; top 16 bits = 0x3F80 → LE bytes [0x80, 0x3F].
         let raw = [0x80u8, 0x3F];
         let result = bf16_bytes_to_f32(&raw);
         assert_eq!(result.len(), 1);
@@ -359,7 +515,7 @@ mod tests {
 
     #[test]
     fn collect_shards_nonexistent_dir() {
-        let result = collect_shards("/tmp/nonexistent_grok_ozempic_dir_xyz");
+        let result = collect_safetensor_shards("/tmp/nonexistent_grok_ozempic_dir_xyz");
         assert!(result.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,16 @@ pub mod types;
 pub mod core;
 pub mod error;
 
-pub use types::{HybridConfig, HybridOutput, QuantizationConfig, TelemetrySnapshot, TensorPrecision};
+pub use types::{
+    HybridConfig, HybridOutput, QuantizationConfig, QuantizationInputFormat, TelemetrySnapshot,
+    TensorPrecision, GROK1_HIDDEN_DIM,
+};
 pub use core::HybridModel;
 
 // Re-export main types for convenience
 pub use crate::core::projector::Projector;
 pub use crate::core::olmoe::OLMoE;
-pub use crate::core::stream::{run_quantization, ShardStats};
-pub use crate::core::gguf::GgufWriter;
-pub use crate::core::quantizer::{quantize_f32, quantize_f16, QuantizedTensor};
+pub use crate::core::stream::{append_grok1_arch_metadata, run_quantization, ShardStats};
+pub use crate::core::gguf::{GgufMetaValue, GgufStreamWriter, TensorHeader};
+pub use crate::core::gguf_read::{verify_gguf_file, GgufVerifyReport};
+pub use crate::core::quantizer::{quantize_f16, quantize_f32, QuantizedTensor};

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,10 +13,24 @@ pub enum TensorPrecision {
     Fp16,
 }
 
+/// Weight container layout for [`QuantizationConfig::input_dir`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuantizationInputFormat {
+    /// Hugging Face–style `*.safetensors` shards (memory-mapped).
+    #[default]
+    Safetensors,
+    /// Directory of per-tensor `*.npy` files (NumPy; typical JAX export).
+    /// Use `__` in the filename stem in place of `.` in tensor names
+    /// (e.g. `blk__0__weight.npy` → `blk.0.weight`).
+    NpyDir,
+}
+
 /// Configuration for the out-of-core quantization pipeline.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
 pub struct QuantizationConfig {
-    /// Directory that holds the Grok-1 Safetensors shards.
+    /// Directory that holds weight shards (see [`QuantizationInputFormat`]).
     pub input_dir: String,
     /// Path for the output GGUF file.
     pub output_path: String,
@@ -26,6 +40,20 @@ pub struct QuantizationConfig {
     /// Tensor name substrings that identify routing / gate tensors which should
     /// remain in FP16 instead of being ternary-quantized.
     pub router_patterns: Vec<String>,
+    /// Input layout: safetensors shards vs flat `.npy` tensors.
+    pub input_format: QuantizationInputFormat,
+}
+
+impl Default for QuantizationConfig {
+    fn default() -> Self {
+        Self {
+            input_dir: String::new(),
+            output_path: String::new(),
+            gif_threshold: 0.05,
+            router_patterns: Vec::new(),
+            input_format: QuantizationInputFormat::Safetensors,
+        }
+    }
 }
 
 #[derive(Clone, Default, Serialize, Deserialize)]
@@ -45,24 +73,62 @@ impl TelemetrySnapshot {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HybridConfig {
-    pub model_path: String,           // path to safetensors or GGUF
+    #[serde(default)]
+    pub model_path: String, // path to safetensors or GGUF
+    /// Hidden / embedding size (Grok-1 uses 6144).
+    #[serde(default = "default_grok_embedding_dim")]
+    pub embedding_dim: usize,
+    #[serde(default = "default_num_experts")]
     pub num_experts: usize,
+    #[serde(default = "default_top_k_experts")]
     pub top_k_experts: usize,
+    #[serde(default = "default_snn_steps")]
     pub snn_steps: usize,
+    #[serde(default)]
     pub projection_mode: ProjectionMode,
+    #[serde(default)]
     pub execution_mode: ExecutionMode,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ProjectionMode {
-    SpikingTernary,   // your main mode
-    // add others later if needed
+fn default_grok_embedding_dim() -> usize {
+    GROK1_HIDDEN_DIM
+}
+fn default_num_experts() -> usize {
+    8
+}
+fn default_top_k_experts() -> usize {
+    2
+}
+fn default_snn_steps() -> usize {
+    4
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+impl Default for HybridConfig {
+    fn default() -> Self {
+        Self {
+            model_path: String::new(),
+            embedding_dim: GROK1_HIDDEN_DIM,
+            num_experts: 8,
+            top_k_experts: 2,
+            snn_steps: 4,
+            projection_mode: ProjectionMode::SpikingTernary,
+            execution_mode: ExecutionMode::SpikingSim,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProjectionMode {
+    #[default]
+    SpikingTernary, // your main mode
+                    // add others later if needed
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExecutionMode {
-    SpikingSim,       // GIF + ternary
-    DenseSim,         // for comparison
+    #[default]
+    SpikingSim, // GIF + ternary
+    DenseSim,   // for comparison
 }
 
 #[derive(Clone, Debug)]
@@ -73,4 +139,5 @@ pub struct HybridOutput {
     pub selected_experts: Option<Vec<usize>>,
 }
 
-pub const EMBEDDING_DIM: usize = 2048;  // adjust if Grok uses different dim
+/// Grok-1 hidden size (`hidden_size` / `embedding_length` in model cards).
+pub const GROK1_HIDDEN_DIM: usize = 6144;


### PR DESCRIPTION
## Summary
Addresses the streaming quantization pipeline gaps: OOM from buffering all tensors in RAM, JAX-style `.npy` inputs, missing GGUF arch metadata, no verifier, wrong Grok-1 hidden dim, and unusable MoE gates until loaded from real router weights.

## Changes
- **GgufStreamWriter**: write tensor info + placeholders, stream each payload, patch offsets (no `Vec<TensorEntry>` heap for full model).
- **Manifest + two-pass flow** in `stream.rs`: enumerate tensors, then quantize one-at-a-time into the GGUF data section.
- **`QuantizationInputFormat::NpyDir`**: mmap + parse NumPy `.npy` headers; `__` in filenames maps to `.` in tensor names.
- **`append_grok1_arch_metadata`**: `grok.*` KV fields for downstream loaders (values should be checked against [xai-org/grok-1](https://huggingface.co/xai-org/grok-1) `config.json`).
- **`verify_gguf_file`**: structural verification + cumulative offset checks.
- **`HybridConfig.embedding_dim`** default **6144**; **`OLMoE::load_gates_from_fp16_stacked_experts`** for real gates.
- **Cargo.toml**: trailing `[workspace]` so the crate builds when nested under another workspace.

## Testing
`cargo test` (18 tests).

Pickle-only JAX checkpoints are still unsupported; convert to safetensors or per-tensor `.npy` first.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses several gaps in the streaming quantization pipeline: it introduces `GgufStreamWriter` for true streaming GGUF output (no full-model tensor buffering), adds `.npy` file ingestion for JAX-checkpoint workflows, appends Grok-1 architecture metadata to the output GGUF, adds a structural verifier (`verify_gguf_file`), corrects the Grok-1 hidden dim to 6144, and wires up `OLMoE::load_gates_from_fp16_stacked_experts` for real router weights.

The core streaming design (manifest → header pass → data pass) is sound and the quantizer/verifier byte-size arithmetic is internally consistent (both use `n.div_ceil(4)` for 2-bit ternary). However, two correctness issues remain:

- The `.npy` parser does not validate `fortran_order`, so a column-major array would be silently quantized with transposed layout.
- The constant `GROK1_EXPERT_COUNT = 256` written to GGUF metadata is inconsistent with the Grok-1 per-layer expert count of 8 used throughout the rest of the codebase; downstream GGUF consumers that read this field to size expert buffers could allocate 32× too many slots.

Prior concerns (unsafe pointer cast alignment, `<u2` → BF16 heuristic, shard re-open per tensor, GGUF version not validated) were flagged in earlier rounds and are not repeated here.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the GROK1_EXPERT_COUNT inconsistency and the fortran_order gap are resolved — both can cause silent correctness failures.

The streaming architecture and quantizer math are sound, and prior concerns were valid incremental improvements. However, two new P1 issues remain: (1) Fortran-order .npy files would produce silently corrupt quantized weights with no error, and (2) GROK1_EXPERT_COUNT=256 conflicts directly with the 8-expert default used by OLMoE — downstream GGUF loaders reading that field would size their expert buffers wrong.

src/core/npy.rs (fortran_order not validated) and src/core/stream.rs (GROK1_EXPERT_COUNT=256 vs. 8-expert OLMoE default)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/core/npy.rs | New module for mmap-based .npy ingestion; correctly parses magic, version, descr, shape, and aligns data offset to 64 bytes — but silently accepts Fortran-order (column-major) arrays, which would produce transposed weight layouts during quantization. |
| src/core/stream.rs | Implements the two-pass manifest → GGUF streaming pipeline and Grok-1 arch metadata; GROK1_EXPERT_COUNT = 256 conflicts with the per-layer 8-expert count used by the rest of the codebase, and each npy file is opened twice (once in manifest pass, once per tensor). |
| src/core/gguf.rs | Clean streaming writer: header with placeholder offsets, per-tensor data streaming, seek-back finalization — no tensor accumulation in RAM; tests verify magic, version, tensor count, and alignment. |
| src/core/gguf_read.rs | Structural GGUF verifier with cumulative offset checks; byte-size arithmetic for ternary tensors matches the writer; only UINT32 and STRING metadata types are handled, consistent with the writer's capabilities. |
| src/core/olmoe.rs | Adds load_gates_from_fp16_stacked_experts for real router weight loading; overflow-safe size calculation, correct byte indexing, bounds-checked expert index. |
| src/types.rs | Adds NpyDir input format variant, corrects GROK1_HIDDEN_DIM to 6144, and wires HybridConfig.embedding_dim default to that constant. |
| Cargo.toml | Adds trailing [workspace] table so the crate builds when nested under a parent workspace; dependencies unchanged. |
| src/lib.rs | Re-exports for the new public API surface (verify_gguf_file, GgufVerifyReport, append_grok1_arch_metadata, OLMoE, etc.). |
| src/core/projector.rs | No changes beyond embedding_dim propagation from the corrected HybridConfig default; GIF dynamics unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[QuantizationConfig] --> B{input_format?}
    B -- Safetensors --> C[collect_safetensor_shards]
    B -- NpyDir --> D[collect_npy_files]
    C --> E[build_manifest_safetensors]
    D --> F[build_manifest_npy]
    E --> G[ManifestEntry list]
    F --> G
    G --> H[Build TensorHeader list]
    H --> I[GgufStreamWriter::begin]
    I --> J[For each ManifestEntry]
    J --> K{input_format?}
    K -- Safetensors --> L[quantize_safetensors_entry]
    K -- NpyDir --> M[quantize_npy_entry]
    L --> N{is_router?}
    M --> N
    N -- Yes --> O[router_fp16_bytes]
    N -- No --> P[quantize F32/F16/BF16]
    O --> T[GgufStreamWriter::write_tensor_data]
    P --> T
    T --> U{more tensors?}
    U -- Yes --> J
    U -- No --> V[GgufStreamWriter::finalize]
    V --> W[flush BufWriter]
    W --> X[Output .gguf file]
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fcore%2Fnpy.rs%3A99-115%0A**Fortran-order%20arrays%20silently%20quantized%20with%20transposed%20layout**%0A%0A%60parse_npy_header%60%20parses%20%60descr%60%20and%20%60shape%60%20but%20never%20reads%20%60fortran_order%60.%20If%20a%20%60.npy%60%20file%20was%20saved%20with%20%60order%3D'F'%60%20%28column-major%29%2C%20the%20raw%20bytes%20are%20laid%20out%20in%20column-major%20order%2C%20so%20the%20shape%20dimensions%20map%20to%20memory%20in%20reverse.%20Every%20weight%20access%20would%20silently%20use%20a%20transposed%20view%2C%20producing%20completely%20wrong%20quantized%20values.%0A%0AWhile%20JAX%20checkpoints%20are%20almost%20always%20C-order%2C%20the%20code%20should%20explicitly%20reject%20Fortran-order%20files%20%28or%20at%20minimum%20warn%29%20rather%20than%20silently%20producing%20corrupt%20quantizations%3A%0A%0A%60%60%60rust%0Afn%20parse_fortran_order%28header%3A%20%26str%29%20-%3E%20bool%20%7B%0A%20%20%20%20header.contains%28%22'fortran_order'%3A%20True%22%29%0A%20%20%20%20%20%20%20%20%7C%7C%20header.contains%28%22%5C%22fortran_order%5C%22%3A%20True%22%29%0A%7D%0A%60%60%60%0A%0AThen%20in%20%60parse_npy_header%60%2C%20after%20parsing%20%60descr%60%20and%20%60shape%60%3A%0A%0A%60%60%60rust%0Aif%20parse_fortran_order%28header_str%29%20%7B%0A%20%20%20%20return%20Err%28GrokOzempicError%3A%3AInvalidConfig%28%0A%20%20%20%20%20%20%20%20%22npy%3A%20Fortran-order%20%28column-major%29%20arrays%20are%20not%20supported%3B%20re-save%20with%20order%3D'C'%22.into%28%29%2C%0A%20%20%20%20%29%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fcore%2Fstream.rs%3A46%0A**%60GROK1_EXPERT_COUNT%20%3D%20256%60%20conflicts%20with%20the%20per-layer%20expert%20count%20used%20everywhere%20else**%0A%0AThe%20GGUF%20metadata%20written%20to%20%60grok.expert_count%60%20is%20256%2C%20but%3A%0A-%20%60default_num_experts%28%29%60%20in%20%60types.rs%60%20returns%20**8**%2C%20explicitly%20matching%20Grok-1's%20published%20per-layer%20expert%20count%20%288%20routed%20experts%2C%20top-2%20active%29.%0A-%20%60OLMoE%3A%3Afrom_config%60%20inherits%20this%208-expert%20default%2C%20so%20the%20inference%20module%20and%20the%20GGUF%20metadata%20describe%20different%20model%20shapes.%0A%0AAny%20downstream%20GGUF%20consumer%20%28e.g.%2C%20llama.cpp%29%20that%20reads%20%60grok.expert_count%60%20to%20size%20the%20expert%20weight%20tensors%20would%20allocate%20256%20expert%20slots%2C%20then%20fail%20to%20find%20248%20of%20them%20or%20silently%20use%20zero-initialised%20weights%20for%20the%20missing%20ones.%0A%0AIf%20256%20is%20meant%20to%20represent%20the%20**total**%20global%20expert%20count%20across%20all%20transformer%20layers%2C%20that%20distinction%20should%20be%20documented.%20Otherwise%2C%20change%20it%20to%208%20to%20match%20the%20rest%20of%20the%20codebase%3A%0A%0A%60%60%60rust%0Aconst%20GROK1_EXPERT_COUNT%3A%20u32%20%3D%208%3B%20%2F%2F%20experts%20per%20MoE%20layer%3B%202%20active%20%28top-k%20%3D%202%29%0A%60%60%60%0A%0AThe%20PR%20description%20already%20flags%20this%20for%20verification%20against%20%60xai-org%2Fgrok-1%60%20%60config.json%60%20%E2%80%94%20resolving%20the%20inconsistency%20before%20merge%20would%20prevent%20downstream%20loaders%20from%20silently%20using%20wrong%20graph%20shapes.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fcore%2Fstream.rs%3A399-423%0A**Each%20%60.npy%60%20file%20is%20memory-mapped%20twice**%0A%0A%60build_manifest_npy%60%20opens%20and%20mmaps%20every%20file%20to%20read%20the%20header%20%28dtype%20and%20shape%29.%20Then%20%60quantize_npy_entry%60%20opens%20and%20mmaps%20the%20same%20file%20a%20second%20time%20to%20read%20the%20data.%20For%20N%20tensors%20this%20is%202N%20%60File%3A%3Aopen%60%20%2B%20%60MmapOptions%3A%3Amap%60%20calls%20where%20N%20would%20suffice.%0A%0AThe%20simplest%20fix%20is%20to%20store%20the%20parsed%20dtype%20in%20%60ManifestEntry%60%3A%0A%0A%60%60%60rust%0Astruct%20ManifestEntry%20%7B%0A%20%20%20%20source_path%3A%20PathBuf%2C%0A%20%20%20%20tensor_name%3A%20String%2C%0A%20%20%20%20shape%3A%20Vec%3Cu64%3E%2C%0A%20%20%20%20is_router%3A%20bool%2C%0A%20%20%20%20dtype%3A%20SourceDtype%2C%20%2F%2F%20avoids%20re-parsing%20header%20on%20the%20data%20pass%0A%7D%0A%60%60%60%0A%0AFor%20the%20npy%20path%2C%20%60quantize_npy_entry%60%20can%20then%20skip%20re-parsing%20the%20header%20and%20use%20the%20already-known%20dtype.%0A%0A&repo=spikenaut%2Fgrok-ozempic"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: streaming GGUF writer, npy ingestio..."](https://github.com/spikenaut/grok-ozempic/commit/d69876c9e70d01907d20b8d6af9cc3d67de9e4b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27943690)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->