### PR TITLE
feat: ingest xai-dissect manifest (schema v1, no pipeline change)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 thiserror = "1.0"
 safetensors = "0.4"          # optional HF-style shards (JAX workflows often use .npy via npy module)
 memmap2 = "0.9"              # zero-copy memory-mapped file I/O for out-of-core streaming

--- a/dissect/README.md
+++ b/dissect/README.md
@@ -1,0 +1,39 @@
+# dissect/ — non-authoritative reference manifests
+
+This directory contains **non-authoritative** reference manifests consumed
+by `grok-ozempic`'s manifest loader (see
+[`src/core/manifest.rs`](../src/core/manifest.rs) and
+[`docs/dissect-manifest.md`](../docs/dissect-manifest.md)).
+
+## Source of truth
+
+The authoritative source for these manifests is the upstream
+[`xai-dissect`](https://github.com/rmems/xai-dissect) repository. The
+files checked in here are **regenerated fallback / reference copies**
+intended for:
+
+- bootstrapping (so the crate can be built and tested without first
+  running `xai-dissect`),
+- documentation (a minimal example of schema v1 in practice),
+- fallback resolution when no explicit manifest path is supplied.
+
+Do **not** hand-edit these files to drive pipeline behavior in
+production runs. If `xai-dissect` says something different, `xai-dissect`
+wins. This repo does not produce manifests; it only consumes them.
+
+## Layout
+
+- `grok-1/baseline.json` — minimal v1 manifest for Grok-1 (xai-org/grok-1)
+  encoding today's default router/gate heuristic as a `preserve` list.
+
+## Consumption order (phase 2+)
+
+Resolved first-hit-wins by the selection seam introduced in phase 2:
+
+1. `QuantizationConfig.manifest_path` (explicit caller override).
+2. `GROK_OZEMPIC_MANIFEST` environment variable.
+3. In-tree fallback (this directory, `grok-1/baseline.json`).
+4. Legacy `router_patterns` substring heuristic in `stream.rs`.
+
+Phase 1 (current) only loads manifests on demand; the pipeline is not
+wired yet.

--- a/dissect/grok-1/baseline.json
+++ b/dissect/grok-1/baseline.json
@@ -1,0 +1,28 @@
+{
+  "schema": "xai-dissect.manifest",
+  "schema_version": 1,
+  "model": {
+    "family": "grok-1",
+    "source": "xai-org/grok-1",
+    "tensor_name_convention": "blk.{L}.{role}.weight"
+  },
+  "produced_by": {
+    "tool": "grok-ozempic (non-authoritative reference)",
+    "version": "0.1.0",
+    "commit": null
+  },
+  "defaults": {
+    "precision": "ternary_snn",
+    "gif_threshold": 0.05
+  },
+  "preserve": [
+    { "name": "blk.*.moe_gate.weight", "reason": "routing-critical gate" },
+    { "name": "blk.*.expert_router.weight", "reason": "routing-critical router" },
+    { "name": "blk.*.routing.weight", "reason": "routing-critical" }
+  ],
+  "fp16": [
+    { "name": "blk.*.attn_router.weight", "reason": "router readout (legacy FP16 default)" }
+  ],
+  "ternary_candidates": [],
+  "blocks": []
+}

--- a/docs/dissect-manifest.md
+++ b/docs/dissect-manifest.md
@@ -1,0 +1,121 @@
+# xai-dissect Manifest — schema v1
+
+Machine-readable JSON contract that lets `grok-ozempic` consume structural
+analysis produced by the upstream [`xai-dissect`](https://github.com/rmems/xai-dissect)
+repository, without depending on it as a runtime crate.
+
+This document freezes **schema v1**. Phase 1 implements the loader only;
+the batch pipeline in `src/core/stream.rs` is not rewired yet.
+
+## Authority and source of truth
+
+- **`xai-dissect` is authoritative.** Manifests are produced there.
+- The `dissect/grok-1/baseline.json` file committed in this repo is a
+  **non-authoritative fallback / reference copy** regenerated from
+  `xai-dissect` releases. Do not treat it as ground truth.
+- `grok-ozempic` **never writes manifests** and never depends on
+  `xai-dissect` as a Cargo crate.
+
+## Delivery
+
+The manifest reaches `grok-ozempic` through one of the following paths,
+resolved in order (first hit wins):
+
+1. Explicit `QuantizationConfig.manifest_path` (caller-provided).
+2. Environment variable `GROK_OZEMPIC_MANIFEST`.
+3. In-tree baseline at `dissect/grok-1/baseline.json` (reference fallback).
+4. Legacy heuristic in `stream.rs` (`router_patterns` substring match) —
+   preserved only until phase 2 wiring lands.
+
+Phase 1 exposes the config field and loader; enforcement of the resolution
+order lives in the selection/precision seams introduced in phase 2.
+
+## Manifest precedence over legacy `router_patterns`
+
+When a manifest is provided, it **wins** over the legacy
+`QuantizationConfig.router_patterns` substring list. In phase 2 the
+wiring code will log a deprecation warning if both are present. The
+legacy field remains supported only for the manifest-less fallback path.
+
+## Schema v1
+
+```json
+{
+  "schema": "xai-dissect.manifest",
+  "schema_version": 1,
+  "model": {
+    "family": "grok-1",
+    "source": "xai-org/grok-1",
+    "tensor_name_convention": "blk.{L}.{role}.weight"
+  },
+  "produced_by": {
+    "tool": "xai-dissect",
+    "version": "0.x.y",
+    "commit": "optional-sha"
+  },
+  "defaults": {
+    "precision": "ternary_snn",
+    "gif_threshold": 0.05
+  },
+  "preserve": [
+    { "name": "blk.*.attn_router.weight", "reason": "routing-critical" }
+  ],
+  "fp16": [
+    { "name": "token_embd.weight", "reason": "embedding table" }
+  ],
+  "ternary_candidates": [
+    { "name": "blk.0.ffn_up.weight",   "rank": 0.98, "gif_threshold": 0.04 },
+    { "name": "blk.0.ffn_down.weight", "rank": 0.95 }
+  ],
+  "blocks": [
+    { "index": 0, "experts": 8, "role": "moe" }
+  ]
+}
+```
+
+### Resolution order inside a manifest
+
+`preserve` > `fp16` > `ternary_candidates` > `defaults`.
+
+### Name matching
+
+- Exact tensor names or simple globs with `*` matching one or more dotted
+  segments (e.g. `blk.*.attn_router.weight`).
+- **No regular expressions in v1.**
+- `gate` substring matches are intentionally not performed; globs must be
+  anchored at dotted segments to avoid the historical `ffn_gate` false
+  positive.
+
+### Precision tiers (v1)
+
+| Tier           | Meaning                                                 |
+| -------------- | ------------------------------------------------------- |
+| `preserve`     | Keep source dtype. **Reserved in phase 1** — consumed by the pipeline in a later phase. During the transitional window this may be aliased to FP16 passthrough; the alias is temporary and tracked via a follow-up issue. |
+| `fp16`         | Force FP16 passthrough (current router behavior).       |
+| `ternary_snn` | Ternary {-1, 0, +1} with GIF saliency threshold.         |
+
+### Per-tensor fields
+
+- `rank` — optional hint in `[0, 1]`. Higher = stronger ternary candidate.
+- `gif_threshold` — optional per-tensor override of the global threshold.
+- `reason` — free-form human string, ignored by the loader.
+
+## Hard-fail validation
+
+The loader **must** reject the following with typed errors rather than
+best-effort parse:
+
+- `schema_version` other than `1`.
+- `model.tensor_name_convention` other than `"blk.{L}.{role}.weight"`
+  (v1 only supports the canonical Grok-1 naming used by
+  `src/core/npy.rs::npy_stem_to_tensor_name`).
+- Non-existent / unreadable manifest file.
+- Malformed JSON.
+
+Unknown top-level fields are **tolerated** for forward compatibility.
+
+## Versioning
+
+Future schema versions bump `schema_version`. Loaders must refuse any
+version they do not explicitly understand. This prevents silent drift
+between `xai-dissect` and `grok-ozempic`.

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -322,6 +322,22 @@ mod tests {
     }
 
     #[test]
+    fn in_tree_grok1_baseline_loads() {
+        // Guard: the committed reference manifest must always parse against
+        // the current loader. It is non-authoritative (xai-dissect is the
+        // source of truth) but it is the crate's own bootstrapping example.
+        let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        path.push("dissect/grok-1/baseline.json");
+        let manifest = load_manifest(&path).expect("baseline must load");
+        assert_eq!(manifest.schema_version, 1);
+        assert_eq!(manifest.model.family, "grok-1");
+        assert_eq!(
+            manifest.model.tensor_name_convention,
+            MANIFEST_NAME_CONVENTION_V1
+        );
+    }
+
+    #[test]
     fn malformed_json_is_parse_error() {
         let path = write_tmp("malformed", "{ not valid json");
         let err = load_manifest(&path).unwrap_err();

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -1,0 +1,334 @@
+//! xai-dissect manifest ingestion (schema v1).
+//!
+//! `grok-ozempic` consumes JSON manifests produced by the upstream
+//! [`xai-dissect`](https://github.com/rmems/xai-dissect) repository to drive
+//! tensor selection and per-tensor precision policy. The manifest is the
+//! single contract between the two repositories; `grok-ozempic` does **not**
+//! depend on `xai-dissect` as a runtime crate.
+//!
+//! See `docs/dissect-manifest.md` for the full schema description.
+//!
+//! Phase 1 (this module) is **ingestion only**. The batch pipeline in
+//! [`crate::core::stream`] is not rewired yet; selection and precision
+//! seams land in a follow-up PR.
+
+use std::{fs, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{GrokOzempicError, Result};
+
+/// Schema version understood by this loader.
+pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+/// Tensor name convention accepted in v1 (canonical Grok-1 naming used by
+/// [`crate::core::npy::npy_stem_to_tensor_name`]).
+pub const MANIFEST_NAME_CONVENTION_V1: &str = "blk.{L}.{role}.weight";
+
+/// Top-level manifest document.
+///
+/// Unknown top-level fields are tolerated for forward compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DissectManifest {
+    /// Schema family tag, e.g. `"xai-dissect.manifest"`. Informational.
+    #[serde(default)]
+    pub schema: String,
+
+    /// Integer schema version. Must equal [`MANIFEST_SCHEMA_VERSION`].
+    pub schema_version: u32,
+
+    /// Model-identity block. `tensor_name_convention` is validated
+    /// strictly by the loader.
+    pub model: ManifestModel,
+
+    /// Optional provenance block.
+    #[serde(default)]
+    pub produced_by: Option<ManifestProducedBy>,
+
+    /// Pipeline-wide defaults applied when a tensor matches none of the
+    /// typed sections.
+    #[serde(default)]
+    pub defaults: ManifestDefaults,
+
+    /// Tensors that must keep their source precision (routing-critical
+    /// layers, etc.). Reserved in phase 1; not yet consumed by the
+    /// pipeline.
+    #[serde(default)]
+    pub preserve: Vec<PreserveEntry>,
+
+    /// Tensors that must be emitted as FP16 passthrough.
+    #[serde(default)]
+    pub fp16: Vec<Fp16Entry>,
+
+    /// Tensors ranked as candidates for ternary / SAAQ-oriented
+    /// compression.
+    #[serde(default)]
+    pub ternary_candidates: Vec<TernaryCandidate>,
+
+    /// Optional structural metadata (block/expert counts). Advisory in v1.
+    #[serde(default)]
+    pub blocks: Vec<ManifestBlock>,
+}
+
+/// Model identity carried in the manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestModel {
+    pub family: String,
+    #[serde(default)]
+    pub source: String,
+    pub tensor_name_convention: String,
+}
+
+/// Provenance block (informational).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestProducedBy {
+    #[serde(default)]
+    pub tool: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub commit: Option<String>,
+}
+
+/// Pipeline-wide defaults.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ManifestDefaults {
+    /// Default precision tier. Free-form string in the manifest; mapping
+    /// into [`crate::types::TensorPrecision`] happens in the selection
+    /// seam (phase 2).
+    #[serde(default)]
+    pub precision: Option<String>,
+
+    /// Default GIF threshold multiplier. Optional.
+    #[serde(default)]
+    pub gif_threshold: Option<f32>,
+}
+
+/// An entry in the `preserve` list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PreserveEntry {
+    /// Exact tensor name or simple glob (`*` matches one or more dotted
+    /// segments).
+    pub name: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// An entry in the `fp16` list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Fp16Entry {
+    pub name: String,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// An entry in `ternary_candidates`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TernaryCandidate {
+    pub name: String,
+    /// Optional rank hint in `[0, 1]`. Higher = stronger candidate for
+    /// aggressive ternary compression.
+    #[serde(default)]
+    pub rank: Option<f32>,
+    /// Optional per-tensor override of the global GIF threshold.
+    #[serde(default)]
+    pub gif_threshold: Option<f32>,
+}
+
+/// Advisory block metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestBlock {
+    pub index: u32,
+    #[serde(default)]
+    pub experts: Option<u32>,
+    #[serde(default)]
+    pub role: Option<String>,
+}
+
+/// Load and validate a manifest from disk.
+///
+/// # Errors
+///
+/// Returns a typed [`GrokOzempicError`] variant rather than a best-effort
+/// parse if:
+///
+/// - the file cannot be read ([`GrokOzempicError::ManifestIo`]),
+/// - the JSON is malformed ([`GrokOzempicError::ManifestParse`]),
+/// - `schema_version` is not [`MANIFEST_SCHEMA_VERSION`]
+///   ([`GrokOzempicError::ManifestSchemaVersion`]),
+/// - `model.tensor_name_convention` is not
+///   [`MANIFEST_NAME_CONVENTION_V1`]
+///   ([`GrokOzempicError::ManifestNameConventionMismatch`]).
+///
+/// Unknown top-level fields are tolerated.
+pub fn load_manifest(path: &Path) -> Result<DissectManifest> {
+    let bytes = fs::read(path).map_err(|e| GrokOzempicError::ManifestIo {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+
+    let manifest: DissectManifest =
+        serde_json::from_slice(&bytes).map_err(|e| GrokOzempicError::ManifestParse {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+
+    if manifest.schema_version != MANIFEST_SCHEMA_VERSION {
+        return Err(GrokOzempicError::ManifestSchemaVersion {
+            got: manifest.schema_version,
+            expected: MANIFEST_SCHEMA_VERSION,
+        });
+    }
+
+    if manifest.model.tensor_name_convention != MANIFEST_NAME_CONVENTION_V1 {
+        return Err(GrokOzempicError::ManifestNameConventionMismatch {
+            got: manifest.model.tensor_name_convention.clone(),
+            expected: MANIFEST_NAME_CONVENTION_V1.to_string(),
+        });
+    }
+
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, contents: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!("grok-ozempic-manifest-test-{name}.json"));
+        let mut f = fs::File::create(&path).unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        path
+    }
+
+    fn valid_manifest_json() -> &'static str {
+        r#"{
+            "schema": "xai-dissect.manifest",
+            "schema_version": 1,
+            "model": {
+                "family": "grok-1",
+                "source": "xai-org/grok-1",
+                "tensor_name_convention": "blk.{L}.{role}.weight"
+            },
+            "produced_by": {
+                "tool": "xai-dissect",
+                "version": "0.1.0"
+            },
+            "defaults": {
+                "precision": "ternary_snn",
+                "gif_threshold": 0.05
+            },
+            "preserve": [
+                { "name": "blk.*.attn_router.weight", "reason": "routing-critical" }
+            ],
+            "fp16": [
+                { "name": "token_embd.weight" }
+            ],
+            "ternary_candidates": [
+                { "name": "blk.0.ffn_up.weight", "rank": 0.98, "gif_threshold": 0.04 }
+            ],
+            "blocks": [
+                { "index": 0, "experts": 8, "role": "moe" }
+            ]
+        }"#
+    }
+
+    #[test]
+    fn loads_valid_v1_manifest() {
+        let path = write_tmp("valid", valid_manifest_json());
+        let manifest = load_manifest(&path).expect("valid manifest should load");
+        assert_eq!(manifest.schema_version, 1);
+        assert_eq!(manifest.model.family, "grok-1");
+        assert_eq!(manifest.preserve.len(), 1);
+        assert_eq!(manifest.fp16.len(), 1);
+        assert_eq!(manifest.ternary_candidates.len(), 1);
+        assert_eq!(manifest.blocks.len(), 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_file_is_manifest_io_error() {
+        let mut path = std::env::temp_dir();
+        path.push("grok-ozempic-manifest-test-does-not-exist.json");
+        let _ = fs::remove_file(&path);
+        let err = load_manifest(&path).unwrap_err();
+        assert!(
+            matches!(err, GrokOzempicError::ManifestIo { .. }),
+            "expected ManifestIo, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unsupported_schema_version_is_rejected() {
+        let json = r#"{
+            "schema": "xai-dissect.manifest",
+            "schema_version": 2,
+            "model": {
+                "family": "grok-1",
+                "tensor_name_convention": "blk.{L}.{role}.weight"
+            }
+        }"#;
+        let path = write_tmp("version", json);
+        let err = load_manifest(&path).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GrokOzempicError::ManifestSchemaVersion { got: 2, expected: 1 }
+            ),
+            "expected ManifestSchemaVersion, got {err:?}"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn mismatched_name_convention_hard_fails() {
+        let json = r#"{
+            "schema": "xai-dissect.manifest",
+            "schema_version": 1,
+            "model": {
+                "family": "grok-1",
+                "tensor_name_convention": "model.layers.{L}.weight"
+            }
+        }"#;
+        let path = write_tmp("convention", json);
+        let err = load_manifest(&path).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GrokOzempicError::ManifestNameConventionMismatch { .. }
+            ),
+            "expected ManifestNameConventionMismatch, got {err:?}"
+        );
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unknown_top_level_field_is_tolerated() {
+        let json = r#"{
+            "schema": "xai-dissect.manifest",
+            "schema_version": 1,
+            "future_field": { "hello": "world" },
+            "model": {
+                "family": "grok-1",
+                "tensor_name_convention": "blk.{L}.{role}.weight"
+            }
+        }"#;
+        let path = write_tmp("unknown", json);
+        let manifest = load_manifest(&path).expect("unknown fields should be tolerated");
+        assert_eq!(manifest.schema_version, 1);
+        let _ = fs::remove_file(&path);
+    }
+
+    #[test]
+    fn malformed_json_is_parse_error() {
+        let path = write_tmp("malformed", "{ not valid json");
+        let err = load_manifest(&path).unwrap_err();
+        assert!(
+            matches!(err, GrokOzempicError::ManifestParse { .. }),
+            "expected ManifestParse, got {err:?}"
+        );
+        let _ = fs::remove_file(&path);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod weight_pack;
 pub mod weight_pack_read;
+pub mod manifest;
 pub mod npy;
 pub mod ozempic;
 pub mod projector;

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,28 @@ pub enum GrokOzempicError {
 
     #[error("GOZ1 pack write error: {0}")]
     PackWrite(String),
+
+    #[error("manifest I/O error at {path}: {source}")]
+    ManifestIo {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("manifest parse error at {path}: {source}")]
+    ManifestParse {
+        path: String,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("unsupported manifest schema_version: got {got}, expected {expected}")]
+    ManifestSchemaVersion { got: u32, expected: u32 },
+
+    #[error(
+        "manifest tensor_name_convention mismatch: got {got:?}, expected {expected:?}"
+    )]
+    ManifestNameConventionMismatch { got: String, expected: String },
 }
 
 pub type Result<T> = std::result::Result<T, GrokOzempicError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,8 @@ pub use crate::core::weight_pack::{
 };
 pub use crate::core::weight_pack_read::{verify_pack_file, PackVerifyReport};
 pub use crate::core::quantizer::{quantize_f16, quantize_f32, QuantizedTensor};
+pub use crate::core::manifest::{
+    load_manifest, DissectManifest, Fp16Entry, ManifestBlock, ManifestDefaults, ManifestModel,
+    ManifestProducedBy, PreserveEntry, TernaryCandidate, MANIFEST_NAME_CONVENTION_V1,
+    MANIFEST_SCHEMA_VERSION,
+};

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -11,6 +13,21 @@ pub enum TensorPrecision {
     TernarySnN,
     /// Keep original FP16 — used for MoE routing gates.
     Fp16,
+    /// Keep the tensor in its source dtype (routing-critical layers etc.).
+    ///
+    /// **Reserved in phase 1.** This variant is declared so the
+    /// `xai-dissect` manifest contract can reference it, but it is **not
+    /// yet consumed** by [`crate::core::stream::run_quantization`]. A
+    /// follow-up PR will wire it through the selection / precision seams.
+    ///
+    /// **Temporary semantic shortcut:** during the transitional window
+    /// the wiring code may alias `Preserve` to FP16 passthrough. That
+    /// alias is explicitly temporary and must be removed once
+    /// source-dtype passthrough lands. See the phase 2/3 tracking issue.
+    //
+    // TODO(phase-3): remove any Preserve→FP16 alias once source-dtype
+    // passthrough is implemented in stream.rs + weight_pack.rs.
+    Preserve,
 }
 
 /// Weight container layout for [`QuantizationConfig::input_dir`].
@@ -39,9 +56,27 @@ pub struct QuantizationConfig {
     pub gif_threshold: f32,
     /// Tensor name substrings that identify routing / gate tensors which should
     /// remain in FP16 instead of being ternary-quantized.
+    ///
+    /// **Legacy field.** When an `xai-dissect` manifest is supplied via
+    /// [`QuantizationConfig::manifest_path`], the manifest wins and this
+    /// list is ignored. A deprecation log line will be emitted by the
+    /// selection seam introduced in phase 2.
     pub router_patterns: Vec<String>,
     /// Input layout: safetensors shards vs flat `.npy` tensors.
     pub input_format: QuantizationInputFormat,
+    /// Optional path to an `xai-dissect` JSON manifest (schema v1).
+    ///
+    /// **Reserved in phase 1.** The field is exposed so callers can start
+    /// plumbing manifests through configuration, but
+    /// [`crate::core::stream::run_quantization`] does **not** consume it
+    /// yet. Wiring lands in phase 2 via dedicated selection and precision
+    /// modules.
+    ///
+    /// Precedence (phase 2+): this explicit path > `GROK_OZEMPIC_MANIFEST`
+    /// env var > in-tree `dissect/grok-1/baseline.json` fallback > legacy
+    /// `router_patterns` heuristic.
+    #[serde(default)]
+    pub manifest_path: Option<PathBuf>,
 }
 
 impl Default for QuantizationConfig {
@@ -52,6 +87,7 @@ impl Default for QuantizationConfig {
             gif_threshold: 0.05,
             router_patterns: Vec::new(),
             input_format: QuantizationInputFormat::Safetensors,
+            manifest_path: None,
         }
     }
 }


### PR DESCRIPTION
## **User description**
Closes #5. Follow-up tracked in #6.

Phase 1 of the `xai-dissect` → `grok-ozempic` integration. **Library-first, ingestion-only, zero behavior change in the quantization pipeline.**

## What this PR does

- Freezes the JSON manifest schema v1 in `docs/dissect-manifest.md`.
- Adds `src/core/manifest.rs` with:
  - `DissectManifest` + nested structs (`ManifestModel`, `ManifestDefaults`, `PreserveEntry`, `Fp16Entry`, `TernaryCandidate`, `ManifestBlock`, `ManifestProducedBy`).
  - `load_manifest(&Path) -> Result<DissectManifest>`.
  - Constants `MANIFEST_SCHEMA_VERSION` and `MANIFEST_NAME_CONVENTION_V1`.
- Adds typed error variants to `GrokOzempicError`:
  - `ManifestIo`, `ManifestParse`, `ManifestSchemaVersion`, `ManifestNameConventionMismatch`.
- Extends `TensorPrecision` with a **reserved** `Preserve` variant (not yet consumed).
- Extends `QuantizationConfig` with an **optional, reserved** `manifest_path: Option<PathBuf>`.
- Commits `dissect/grok-1/baseline.json` + `dissect/README.md` as a **non-authoritative reference copy**.
- Adds `serde_json` dependency.
- 7 new unit tests (6 loader scenarios + 1 CI guard that loads the committed baseline).

## What this PR does **not** do

- `@src/core/stream.rs` is untouched. `git diff main..HEAD -- src/core/stream.rs` is empty.
- No `selection.rs` / `precision.rs` yet.
- No CLI binary.
- No consumption of `TensorPrecision::Preserve` — the variant exists only so the contract can reference it.
- No runtime dependency on `xai-dissect`.

Wiring + Preserve semantics land in #6.

## Contract rules (locked in)

- **JSON only** in v1.
- **`xai-dissect` is authoritative.** The in-tree baseline is a fallback / reference copy, documented as such in `dissect/README.md`.
- **Hard-fail** on `model.tensor_name_convention` mismatch (typed error, not a warning).
- **Manifest wins over legacy `router_patterns`** (documented now, enforced in phase 2).
- Unknown top-level fields tolerated for forward compatibility.
- Resolution order inside a manifest: `preserve > fp16 > ternary_candidates > defaults`.

## Preserve tier — temporary semantic shortcut

`TensorPrecision::Preserve` is declared but unconsumed. The doc comment in `@src/types.rs` states explicitly that any temporary Preserve→FP16 alias introduced during phase 2 is a transitional shortcut and must be removed in phase 3. A `TODO(phase-3)` marker is placed at the variant. #6 tracks removal.

## Tests

```
running 26 tests
...
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Commit log

1. `docs: add xai-dissect manifest schema v1`
2. `chore: add serde_json dependency`
3. `feat(manifest): add DissectManifest loader with hard-fail validation`
4. `feat(types): add Preserve tier and manifest_path config field`
5. `feat(dissect): add non-authoritative Grok-1 baseline manifest`

## Scope boundary

This PR keeps the `grok-ozempic` / `xai-dissect` split intact:

- `xai-dissect` remains read-only / analysis-only.
- `grok-ozempic` remains the runtime / quantization experimentation repo.
- Neither side is merged into the other. Knowledge flows one way: `xai-dissect` → `manifest.json` → `grok-ozempic`.


___

## **CodeAnt-AI Description**
**Add manifest-based ingestion for xai-dissect outputs**

### What Changed
- Added support for loading and validating xai-dissect JSON manifests, including typed errors for unreadable files, malformed JSON, unsupported schema versions, and name-convention mismatches
- Exposed manifest-related types and configuration so callers can pass a manifest path into quantization settings
- Added a new `Preserve` precision tier and documented that it is reserved for later pipeline wiring
- Marked manifest-backed routing as the preferred path over the legacy `router_patterns` fallback when a manifest is supplied
- Added the schema reference, a non-authoritative Grok-1 baseline manifest, and a README explaining manifest source of truth and fallback behavior

### Impact
`✅ Clearer manifest load errors`
`✅ Safer xai-dissect integration`
`✅ Less risk of silent manifest drift`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=rS1b6taX6yorbOIRKvbm-3yJ3h0Rsu6Sn8K93DwOF8M&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
