### PR TITLE
feat: wire xai-dissect manifest into the quantization pipeline (phase 2)

### DIFF
--- a/docs/dissect-manifest.md
+++ b/docs/dissect-manifest.md
@@ -79,12 +79,17 @@ legacy field remains supported only for the manifest-less fallback path.
 
 ### Name matching
 
-- Exact tensor names or simple globs with `*` matching one or more dotted
-  segments (e.g. `blk.*.attn_router.weight`).
+- Exact tensor names or simple globs where `*` matches **exactly one**
+  dotted segment (e.g. `blk.*.attn_router.weight` matches
+  `blk.0.attn_router.weight` but **not**
+  `blk.0.sub.attn_router.weight`).
+- Matching is anchored at dotted segments. The pattern and the tensor
+  name must have the same segment count; each segment must equal `*` or
+  match the literal.
 - **No regular expressions in v1.**
-- `gate` substring matches are intentionally not performed; globs must be
-  anchored at dotted segments to avoid the historical `ffn_gate` false
-  positive.
+- `gate` substring matches are intentionally not performed; this is why
+  globs must be segment-anchored. Historical false positives like
+  `ffn_gate` being swept up by a `gate` substring are impossible in v1.
 
 ### Precision tiers (v1)
 

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -107,8 +107,9 @@ pub struct ManifestDefaults {
 /// An entry in the `preserve` list.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PreserveEntry {
-    /// Exact tensor name or simple glob (`*` matches one or more dotted
-    /// segments).
+    /// Exact tensor name or simple glob where `*` matches **exactly one**
+    /// dotted segment. See `docs/dissect-manifest.md` for the full
+    /// matching rules.
     pub name: String,
     #[serde(default)]
     pub reason: Option<String>,

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -8,15 +8,30 @@
 //!
 //! See `docs/dissect-manifest.md` for the full schema description.
 //!
-//! Phase 1 (this module) is **ingestion only**. The batch pipeline in
-//! [`crate::core::stream`] is not rewired yet; selection and precision
-//! seams land in a follow-up PR.
+//! This module handles **ingestion only**: JSON parsing, schema
+//! validation, and caching of the embedded Grok-1 fallback. The
+//! pipeline-side wiring (tensor classification and precision policy)
+//! lives in [`crate::core::selection`] and [`crate::core::precision`].
 
-use std::{fs, path::Path};
+use std::{fs, path::Path, sync::OnceLock};
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::{GrokOzempicError, Result};
+
+/// The in-tree, non-authoritative reference manifest for Grok-1 embedded
+/// into the binary at build time.
+///
+/// Used as the last-resort fallback by the manifest precedence chain in
+/// [`crate::core::stream`] when neither
+/// [`crate::types::QuantizationConfig::manifest_path`] nor the
+/// `GROK_OZEMPIC_MANIFEST` environment variable is set. Parsed exactly
+/// once per process via [`embedded_grok1_baseline`].
+///
+/// `xai-dissect` remains the authoritative source of truth; this constant
+/// is a bootstrapping convenience.
+pub const GROK1_BASELINE_JSON: &str =
+    include_str!("../../dissect/grok-1/baseline.json");
 
 /// Schema version understood by this loader.
 pub const MANIFEST_SCHEMA_VERSION: u32 = 1;
@@ -167,10 +182,18 @@ pub fn load_manifest(path: &Path) -> Result<DissectManifest> {
         path: path.display().to_string(),
         source: e,
     })?;
+    parse_manifest_bytes(&bytes, &path.display().to_string())
+}
 
+/// Parse and validate a manifest from already-loaded bytes.
+///
+/// Shared validation path used by [`load_manifest`] (filesystem) and
+/// [`embedded_grok1_baseline`] (`include_str!`). The `label` is used in
+/// error messages to identify the origin of the bytes.
+pub fn parse_manifest_bytes(bytes: &[u8], label: &str) -> Result<DissectManifest> {
     let manifest: DissectManifest =
-        serde_json::from_slice(&bytes).map_err(|e| GrokOzempicError::ManifestParse {
-            path: path.display().to_string(),
+        serde_json::from_slice(bytes).map_err(|e| GrokOzempicError::ManifestParse {
+            path: label.to_string(),
             source: e,
         })?;
 
@@ -189,6 +212,58 @@ pub fn load_manifest(path: &Path) -> Result<DissectManifest> {
     }
 
     Ok(manifest)
+}
+
+/// Return the embedded Grok-1 reference manifest, parsed lazily on first
+/// call and cached for the remainder of the process.
+///
+/// The underlying JSON is compiled into the binary from
+/// `dissect/grok-1/baseline.json` via [`GROK1_BASELINE_JSON`]. If parsing
+/// ever fails (which would require the CI guard to regress), the error is
+/// returned on every call; parsing is not retried.
+pub fn embedded_grok1_baseline() -> Result<&'static DissectManifest> {
+    static CACHE: OnceLock<std::result::Result<DissectManifest, GrokOzempicError>> =
+        OnceLock::new();
+    match CACHE.get_or_init(|| {
+        parse_manifest_bytes(
+            GROK1_BASELINE_JSON.as_bytes(),
+            "<embedded grok-1 baseline>",
+        )
+    }) {
+        Ok(m) => Ok(m),
+        Err(e) => Err(clone_typed_error(e)),
+    }
+}
+
+/// Clone a [`GrokOzempicError`] for cases where we hand shared refs out
+/// of a [`OnceLock`] but still want owned typed errors on the caller side.
+///
+/// Only the subset of variants that [`parse_manifest_bytes`] can produce
+/// needs real logic; everything else falls through to a best-effort
+/// stringified [`GrokOzempicError::InvalidConfig`].
+fn clone_typed_error(e: &GrokOzempicError) -> GrokOzempicError {
+    match e {
+        GrokOzempicError::ManifestParse { path, source: _ } => {
+            GrokOzempicError::InvalidConfig(format!(
+                "embedded grok-1 baseline parse error at {path}"
+            ))
+        }
+        GrokOzempicError::ManifestSchemaVersion { got, expected } => {
+            GrokOzempicError::ManifestSchemaVersion {
+                got: *got,
+                expected: *expected,
+            }
+        }
+        GrokOzempicError::ManifestNameConventionMismatch { got, expected } => {
+            GrokOzempicError::ManifestNameConventionMismatch {
+                got: got.clone(),
+                expected: expected.clone(),
+            }
+        }
+        other => GrokOzempicError::InvalidConfig(format!(
+            "embedded grok-1 baseline failed to load: {other}"
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -335,6 +410,34 @@ mod tests {
         assert_eq!(
             manifest.model.tensor_name_convention,
             MANIFEST_NAME_CONVENTION_V1
+        );
+    }
+
+    #[test]
+    fn embedded_grok1_baseline_loads_and_caches() {
+        // Ensures include_str!-embedded baseline parses via the shared
+        // parse_manifest_bytes path and that OnceLock caches the result.
+        let a = embedded_grok1_baseline().expect("embedded baseline must load");
+        let b = embedded_grok1_baseline().expect("embedded baseline must load (2nd call)");
+        assert!(std::ptr::eq(a, b), "OnceLock must return the same ref");
+        assert_eq!(a.schema_version, MANIFEST_SCHEMA_VERSION);
+        assert_eq!(a.model.family, "grok-1");
+    }
+
+    #[test]
+    fn parse_manifest_bytes_rejects_bad_version() {
+        let json = br#"{
+            "schema": "xai-dissect.manifest",
+            "schema_version": 99,
+            "model": {
+                "family": "grok-1",
+                "tensor_name_convention": "blk.{L}.{role}.weight"
+            }
+        }"#;
+        let err = parse_manifest_bytes(json, "<test>").unwrap_err();
+        assert!(
+            matches!(err, GrokOzempicError::ManifestSchemaVersion { got: 99, .. }),
+            "got {err:?}"
         );
     }
 

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -211,6 +211,22 @@ pub fn parse_manifest_bytes(bytes: &[u8], label: &str) -> Result<DissectManifest
         });
     }
 
+    // Validate defaults.precision eagerly so a malformed manifest always
+    // hard-fails regardless of which tensors are actually processed. Without
+    // this check an invalid string would only surface when a tensor falls
+    // through to the Default class — a coverage-dependent, non-deterministic
+    // failure mode.
+    if let Some(ref p) = manifest.defaults.precision {
+        match p.as_str() {
+            "ternary_snn" | "fp16" | "preserve" => {}
+            other => {
+                return Err(GrokOzempicError::ManifestInvalidPrecision {
+                    got: other.to_string(),
+                });
+            }
+        }
+    }
+
     Ok(manifest)
 }
 
@@ -450,5 +466,32 @@ mod tests {
             "expected ManifestParse, got {err:?}"
         );
         let _ = fs::remove_file(&path);
+    }
+
+    /// Regression guard for the eager defaults.precision validation:
+    /// a manifest with an invalid precision string must always hard-fail
+    /// at parse time regardless of which tensors are present.
+    #[test]
+    fn invalid_defaults_precision_is_rejected_at_parse_time() {
+        let json = br#"{
+            "schema": "xai-dissect.manifest",
+            "schema_version": 1,
+            "model": {
+                "family": "grok-1",
+                "tensor_name_convention": "blk.{L}.{role}.weight"
+            },
+            "defaults": { "precision": "bogus_tier" },
+            "preserve": [ { "name": "blk.*.*.weight" } ]
+        }"#;
+        // All tensors would be covered by the preserve glob, but the
+        // invalid precision string must still fail at parse time.
+        let err = parse_manifest_bytes(json, "<test>").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                GrokOzempicError::ManifestInvalidPrecision { ref got } if got == "bogus_tier"
+            ),
+            "expected ManifestInvalidPrecision(bogus_tier), got {err:?}"
+        );
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@ pub mod weight_pack_read;
 pub mod manifest;
 pub mod npy;
 pub mod ozempic;
+pub mod precision;
 pub mod projector;
 pub mod quantizer;
 pub mod selection;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,6 +5,7 @@ pub mod npy;
 pub mod ozempic;
 pub mod projector;
 pub mod quantizer;
+pub mod selection;
 pub mod stream;
 
 use crate::{

--- a/src/core/precision.rs
+++ b/src/core/precision.rs
@@ -1,0 +1,232 @@
+//! Precision policy — turn a [`crate::core::selection::TensorClass`] into a
+//! concrete [`crate::types::TensorPrecision`] and an effective GIF
+//! threshold.
+//!
+//! Threshold resolution order:
+//! 1. Per-tensor `gif_threshold` carried on a `TernaryCandidate`.
+//! 2. `manifest.defaults.gif_threshold` if set.
+//! 3. `config.gif_threshold` (always present).
+//!
+//! Precision tier resolution:
+//! - `TensorClass::Preserve`          → [`TensorPrecision::Preserve`]
+//! - `TensorClass::Fp16`              → [`TensorPrecision::Fp16`]
+//! - `TensorClass::TernaryCandidate`  → [`TensorPrecision::TernarySnN`]
+//! - `TensorClass::Default`           → parsed from
+//!   `manifest.defaults.precision` (if present), else
+//!   [`TensorPrecision::TernarySnN`].
+//!
+//! Unknown `defaults.precision` strings are a **hard failure**
+//! ([`GrokOzempicError::ManifestInvalidPrecision`]) to match the rest of
+//! the manifest validation story.
+
+use crate::{
+    core::{manifest::DissectManifest, selection::TensorClass},
+    error::{GrokOzempicError, Result},
+    types::{QuantizationConfig, TensorPrecision},
+};
+
+/// Decide `(precision, effective_gif_threshold)` for a single tensor.
+pub fn decide(
+    class: &TensorClass,
+    manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) -> Result<(TensorPrecision, f32)> {
+    let precision = match class {
+        TensorClass::Preserve { .. } => TensorPrecision::Preserve,
+        TensorClass::Fp16 { .. } => TensorPrecision::Fp16,
+        TensorClass::TernaryCandidate { .. } => TensorPrecision::TernarySnN,
+        TensorClass::Default => resolve_default_precision(manifest)?,
+    };
+    let threshold = resolve_threshold(class, manifest, config);
+    Ok((precision, threshold))
+}
+
+fn resolve_default_precision(manifest: Option<&DissectManifest>) -> Result<TensorPrecision> {
+    let Some(m) = manifest else {
+        return Ok(TensorPrecision::TernarySnN);
+    };
+    match m.defaults.precision.as_deref() {
+        None => Ok(TensorPrecision::TernarySnN),
+        Some(s) => parse_precision_str(s),
+    }
+}
+
+fn resolve_threshold(
+    class: &TensorClass,
+    manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) -> f32 {
+    if let TensorClass::TernaryCandidate {
+        gif_threshold: Some(t),
+        ..
+    } = class
+    {
+        return *t;
+    }
+    if let Some(m) = manifest
+        && let Some(t) = m.defaults.gif_threshold
+    {
+        return t;
+    }
+    config.gif_threshold
+}
+
+/// Parse a manifest precision string into a concrete
+/// [`TensorPrecision`] tier.
+///
+/// Accepted values: `ternary_snn`, `fp16`, `preserve`.
+pub fn parse_precision_str(s: &str) -> Result<TensorPrecision> {
+    match s {
+        "ternary_snn" => Ok(TensorPrecision::TernarySnN),
+        "fp16" => Ok(TensorPrecision::Fp16),
+        "preserve" => Ok(TensorPrecision::Preserve),
+        other => Err(GrokOzempicError::ManifestInvalidPrecision {
+            got: other.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::manifest::{
+        DissectManifest, ManifestDefaults, ManifestModel, MANIFEST_NAME_CONVENTION_V1,
+        MANIFEST_SCHEMA_VERSION,
+    };
+
+    fn manifest_with_defaults(precision: Option<&str>, gif: Option<f32>) -> DissectManifest {
+        DissectManifest {
+            schema: "xai-dissect.manifest".into(),
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            model: ManifestModel {
+                family: "grok-1".into(),
+                source: "xai-org/grok-1".into(),
+                tensor_name_convention: MANIFEST_NAME_CONVENTION_V1.into(),
+            },
+            produced_by: None,
+            defaults: ManifestDefaults {
+                precision: precision.map(String::from),
+                gif_threshold: gif,
+            },
+            preserve: vec![],
+            fp16: vec![],
+            ternary_candidates: vec![],
+            blocks: vec![],
+        }
+    }
+
+    fn config_with_threshold(t: f32) -> QuantizationConfig {
+        QuantizationConfig {
+            gif_threshold: t,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn parse_precision_accepts_known_tiers() {
+        assert_eq!(
+            parse_precision_str("ternary_snn").unwrap(),
+            TensorPrecision::TernarySnN
+        );
+        assert_eq!(
+            parse_precision_str("fp16").unwrap(),
+            TensorPrecision::Fp16
+        );
+        assert_eq!(
+            parse_precision_str("preserve").unwrap(),
+            TensorPrecision::Preserve
+        );
+    }
+
+    #[test]
+    fn parse_precision_hard_fails_on_unknown() {
+        match parse_precision_str("mystery_tier") {
+            Err(GrokOzempicError::ManifestInvalidPrecision { got }) => {
+                assert_eq!(got, "mystery_tier");
+            }
+            other => panic!("expected ManifestInvalidPrecision, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserve_class_maps_to_preserve_precision() {
+        let config = config_with_threshold(0.05);
+        let cls = TensorClass::Preserve { reason: None };
+        let (p, _) = decide(&cls, None, &config).unwrap();
+        assert_eq!(p, TensorPrecision::Preserve);
+    }
+
+    #[test]
+    fn fp16_class_maps_to_fp16_precision() {
+        let config = config_with_threshold(0.05);
+        let cls = TensorClass::Fp16 { reason: None };
+        let (p, _) = decide(&cls, None, &config).unwrap();
+        assert_eq!(p, TensorPrecision::Fp16);
+    }
+
+    #[test]
+    fn ternary_candidate_maps_to_ternary_snn() {
+        let config = config_with_threshold(0.05);
+        let cls = TensorClass::TernaryCandidate {
+            rank: Some(0.9),
+            gif_threshold: None,
+        };
+        let (p, _) = decide(&cls, None, &config).unwrap();
+        assert_eq!(p, TensorPrecision::TernarySnN);
+    }
+
+    #[test]
+    fn candidate_threshold_overrides_manifest_default() {
+        let config = config_with_threshold(0.05);
+        let m = manifest_with_defaults(None, Some(0.08));
+        let cls = TensorClass::TernaryCandidate {
+            rank: None,
+            gif_threshold: Some(0.03),
+        };
+        let (_, t) = decide(&cls, Some(&m), &config).unwrap();
+        assert_eq!(t, 0.03);
+    }
+
+    #[test]
+    fn manifest_default_threshold_overrides_config_default() {
+        let config = config_with_threshold(0.05);
+        let m = manifest_with_defaults(None, Some(0.08));
+        let cls = TensorClass::Default;
+        let (_, t) = decide(&cls, Some(&m), &config).unwrap();
+        assert_eq!(t, 0.08);
+    }
+
+    #[test]
+    fn config_default_wins_when_no_overrides() {
+        let config = config_with_threshold(0.05);
+        let cls = TensorClass::Default;
+        let (_, t) = decide(&cls, None, &config).unwrap();
+        assert_eq!(t, 0.05);
+    }
+
+    #[test]
+    fn manifest_default_precision_applies_to_default_class() {
+        let config = config_with_threshold(0.05);
+        let m = manifest_with_defaults(Some("preserve"), None);
+        let (p, _) = decide(&TensorClass::Default, Some(&m), &config).unwrap();
+        assert_eq!(p, TensorPrecision::Preserve);
+    }
+
+    #[test]
+    fn default_precision_falls_back_to_ternary_snn_without_manifest() {
+        let config = config_with_threshold(0.05);
+        let (p, _) = decide(&TensorClass::Default, None, &config).unwrap();
+        assert_eq!(p, TensorPrecision::TernarySnN);
+    }
+
+    #[test]
+    fn unknown_defaults_precision_bubbles_as_typed_error() {
+        let config = config_with_threshold(0.05);
+        let m = manifest_with_defaults(Some("bogus"), None);
+        let err = decide(&TensorClass::Default, Some(&m), &config).unwrap_err();
+        assert!(
+            matches!(err, GrokOzempicError::ManifestInvalidPrecision { .. }),
+            "got {err:?}"
+        );
+    }
+}

--- a/src/core/selection.rs
+++ b/src/core/selection.rs
@@ -1,0 +1,310 @@
+//! Tensor classification — the **single source of truth** for deciding
+//! whether a tensor belongs to the `preserve`, `fp16`, `ternary_candidate`,
+//! or default bucket.
+//!
+//! When an `xai-dissect` manifest is supplied, classification is driven by
+//! the manifest using segment-anchored glob matching (see
+//! `docs/dissect-manifest.md`). When no manifest is present, the module
+//! falls back to the legacy substring-router heuristic that was previously
+//! embedded in [`crate::core::stream`]; that heuristic lives here now and
+//! nowhere else in the codebase.
+//!
+//! Resolution order inside a manifest:
+//! `preserve` > `fp16` > `ternary_candidates` > `Default`.
+
+use crate::core::manifest::{
+    DissectManifest, Fp16Entry, PreserveEntry, TernaryCandidate,
+};
+
+/// Default legacy router-name substrings used when no manifest is present
+/// and [`crate::types::QuantizationConfig::router_patterns`] is empty.
+///
+/// Kept here (not in [`crate::core::stream`]) so all classification logic
+/// lives in one place.
+pub const LEGACY_DEFAULT_ROUTER_PATTERNS: &[&str] = &[
+    "router",
+    "gate",
+    "moe_gate",
+    "expert_router",
+    "routing",
+];
+
+/// Outcome of classification for a single tensor.
+///
+/// The classification is precision-agnostic: [`crate::core::precision::decide`]
+/// turns it into a concrete [`crate::types::TensorPrecision`] plus effective
+/// GIF threshold.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TensorClass {
+    /// Tensor appeared in the manifest's `preserve` list — must keep its
+    /// source precision (routing-critical layers, etc.).
+    Preserve { reason: Option<String> },
+    /// Tensor appeared in the manifest's `fp16` list **or** matched the
+    /// legacy router heuristic when no manifest is present.
+    Fp16 { reason: Option<String> },
+    /// Tensor appeared in the manifest's `ternary_candidates` list with
+    /// optional rank and per-tensor threshold override.
+    TernaryCandidate {
+        rank: Option<f32>,
+        gif_threshold: Option<f32>,
+    },
+    /// No explicit manifest entry; falls through to manifest
+    /// `defaults.precision` or the pipeline's global default.
+    Default,
+}
+
+/// Classify `name` against the manifest (if any), otherwise fall back to
+/// the legacy substring-router heuristic.
+///
+/// `legacy_patterns` is consulted only when `manifest.is_none()`; if the
+/// slice is empty, [`LEGACY_DEFAULT_ROUTER_PATTERNS`] is used.
+pub fn classify(
+    name: &str,
+    manifest: Option<&DissectManifest>,
+    legacy_patterns: &[String],
+) -> TensorClass {
+    if let Some(m) = manifest {
+        return classify_from_manifest(name, m);
+    }
+    classify_legacy(name, legacy_patterns)
+}
+
+fn classify_from_manifest(name: &str, manifest: &DissectManifest) -> TensorClass {
+    // Precedence: preserve > fp16 > ternary_candidates > default.
+    if let Some(entry) = find_match(name, &manifest.preserve, |e: &PreserveEntry| &e.name) {
+        return TensorClass::Preserve {
+            reason: entry.reason.clone(),
+        };
+    }
+    if let Some(entry) = find_match(name, &manifest.fp16, |e: &Fp16Entry| &e.name) {
+        return TensorClass::Fp16 {
+            reason: entry.reason.clone(),
+        };
+    }
+    if let Some(entry) = find_match(
+        name,
+        &manifest.ternary_candidates,
+        |e: &TernaryCandidate| &e.name,
+    ) {
+        return TensorClass::TernaryCandidate {
+            rank: entry.rank,
+            gif_threshold: entry.gif_threshold,
+        };
+    }
+    TensorClass::Default
+}
+
+fn classify_legacy(name: &str, legacy_patterns: &[String]) -> TensorClass {
+    let hit = if legacy_patterns.is_empty() {
+        LEGACY_DEFAULT_ROUTER_PATTERNS
+            .iter()
+            .any(|p| name.contains(p))
+    } else {
+        legacy_patterns.iter().any(|p| name.contains(p.as_str()))
+    };
+    if hit {
+        TensorClass::Fp16 { reason: None }
+    } else {
+        TensorClass::Default
+    }
+}
+
+fn find_match<'a, T, F>(name: &str, entries: &'a [T], get_pattern: F) -> Option<&'a T>
+where
+    F: Fn(&T) -> &String,
+{
+    entries.iter().find(|e| glob_match(get_pattern(e), name))
+}
+
+/// Segment-anchored glob matcher.
+///
+/// `*` matches **exactly one** dotted segment (the text between two `.`
+/// characters, or the text before the first `.` / after the last `.`).
+/// Pattern and name must have the same number of segments; each segment
+/// must equal `*` or match the literal.
+///
+/// Examples:
+/// - `glob_match("blk.*.attn_router.weight", "blk.0.attn_router.weight")` → `true`
+/// - `glob_match("blk.*.attn_router.weight", "blk.0.sub.attn_router.weight")` → `false`
+/// - `glob_match("gate", "blk.0.ffn_gate.weight")` → `false`
+pub fn glob_match(pattern: &str, name: &str) -> bool {
+    let p: Vec<&str> = pattern.split('.').collect();
+    let n: Vec<&str> = name.split('.').collect();
+    if p.len() != n.len() {
+        return false;
+    }
+    p.iter().zip(n.iter()).all(|(a, b)| *a == "*" || a == b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::manifest::{
+        DissectManifest, Fp16Entry, ManifestDefaults, ManifestModel, PreserveEntry,
+        TernaryCandidate, MANIFEST_NAME_CONVENTION_V1, MANIFEST_SCHEMA_VERSION,
+    };
+
+    fn empty_manifest() -> DissectManifest {
+        DissectManifest {
+            schema: "xai-dissect.manifest".into(),
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            model: ManifestModel {
+                family: "grok-1".into(),
+                source: "xai-org/grok-1".into(),
+                tensor_name_convention: MANIFEST_NAME_CONVENTION_V1.into(),
+            },
+            produced_by: None,
+            defaults: ManifestDefaults::default(),
+            preserve: vec![],
+            fp16: vec![],
+            ternary_candidates: vec![],
+            blocks: vec![],
+        }
+    }
+
+    // -------- glob_match --------
+
+    #[test]
+    fn glob_exact_match() {
+        assert!(glob_match("blk.0.attn_router.weight", "blk.0.attn_router.weight"));
+    }
+
+    #[test]
+    fn glob_single_segment_wildcard() {
+        assert!(glob_match(
+            "blk.*.attn_router.weight",
+            "blk.0.attn_router.weight"
+        ));
+        assert!(glob_match(
+            "blk.*.attn_router.weight",
+            "blk.42.attn_router.weight"
+        ));
+    }
+
+    #[test]
+    fn glob_wildcard_does_not_cross_segments() {
+        assert!(!glob_match(
+            "blk.*.attn_router.weight",
+            "blk.0.sub.attn_router.weight"
+        ));
+    }
+
+    #[test]
+    fn glob_rejects_substring_like_gate_false_positive() {
+        // The legacy 'gate' substring heuristic would match this; the
+        // glob matcher must not.
+        assert!(!glob_match("gate", "blk.0.ffn_gate.weight"));
+    }
+
+    #[test]
+    fn glob_rejects_different_segment_counts() {
+        assert!(!glob_match("a.b.c", "a.b"));
+        assert!(!glob_match("a.b", "a.b.c"));
+    }
+
+    // -------- classify (manifest path) --------
+
+    #[test]
+    fn manifest_precedence_preserve_wins_over_fp16() {
+        let mut m = empty_manifest();
+        // Both lists contain a matching pattern; preserve must win.
+        m.preserve.push(PreserveEntry {
+            name: "blk.*.attn_router.weight".into(),
+            reason: Some("routing-critical".into()),
+        });
+        m.fp16.push(Fp16Entry {
+            name: "blk.*.attn_router.weight".into(),
+            reason: Some("legacy".into()),
+        });
+        let cls = classify("blk.0.attn_router.weight", Some(&m), &[]);
+        assert!(matches!(cls, TensorClass::Preserve { .. }), "got {cls:?}");
+    }
+
+    #[test]
+    fn manifest_precedence_fp16_wins_over_ternary() {
+        let mut m = empty_manifest();
+        m.fp16.push(Fp16Entry {
+            name: "blk.0.w.weight".into(),
+            reason: None,
+        });
+        m.ternary_candidates.push(TernaryCandidate {
+            name: "blk.0.w.weight".into(),
+            rank: Some(0.9),
+            gif_threshold: None,
+        });
+        let cls = classify("blk.0.w.weight", Some(&m), &[]);
+        assert!(matches!(cls, TensorClass::Fp16 { .. }), "got {cls:?}");
+    }
+
+    #[test]
+    fn manifest_ternary_candidate_fields_propagate() {
+        let mut m = empty_manifest();
+        m.ternary_candidates.push(TernaryCandidate {
+            name: "blk.0.ffn_up.weight".into(),
+            rank: Some(0.98),
+            gif_threshold: Some(0.04),
+        });
+        let cls = classify("blk.0.ffn_up.weight", Some(&m), &[]);
+        match cls {
+            TensorClass::TernaryCandidate { rank, gif_threshold } => {
+                assert_eq!(rank, Some(0.98));
+                assert_eq!(gif_threshold, Some(0.04));
+            }
+            other => panic!("expected TernaryCandidate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn manifest_unmatched_name_is_default() {
+        let m = empty_manifest();
+        let cls = classify("blk.0.ffn_up.weight", Some(&m), &[]);
+        assert!(matches!(cls, TensorClass::Default), "got {cls:?}");
+    }
+
+    // -------- classify (legacy path) --------
+
+    #[test]
+    fn legacy_default_substrings_match_router_names() {
+        assert!(matches!(
+            classify("blk.0.moe_gate.weight", None, &[]),
+            TensorClass::Fp16 { .. }
+        ));
+        assert!(matches!(
+            classify("model.layers.4.expert_router.weight", None, &[]),
+            TensorClass::Fp16 { .. }
+        ));
+        assert!(matches!(
+            classify("transformer.h.1.routing.weight", None, &[]),
+            TensorClass::Fp16 { .. }
+        ));
+    }
+
+    #[test]
+    fn legacy_default_leaves_ffn_weights_as_default() {
+        // Note: with the legacy heuristic, 'ffn_gate' false-matches
+        // 'gate'. That's a known weakness — see the manifest path for
+        // the fix. This test documents current legacy behavior.
+        assert!(matches!(
+            classify("blk.0.ffn_down.weight", None, &[]),
+            TensorClass::Default
+        ));
+        assert!(matches!(
+            classify("blk.0.ffn_up.weight", None, &[]),
+            TensorClass::Default
+        ));
+    }
+
+    #[test]
+    fn legacy_custom_patterns_override_defaults() {
+        let patterns = vec!["special_router".to_string()];
+        assert!(matches!(
+            classify("blk.0.special_router.weight", None, &patterns),
+            TensorClass::Fp16 { .. }
+        ));
+        // Default 'gate' is not consulted when a custom list is given.
+        assert!(matches!(
+            classify("blk.0.gate.weight", None, &patterns),
+            TensorClass::Default
+        ));
+    }
+}

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -99,22 +99,28 @@ pub const MANIFEST_ENV_VAR: &str = "GROK_OZEMPIC_MANIFEST";
 ///
 /// 1. [`QuantizationConfig::manifest_path`] (explicit caller override).
 /// 2. `GROK_OZEMPIC_MANIFEST` environment variable.
-/// 3. Embedded Grok-1 baseline via [`embedded_grok1_baseline`].
+/// 3. Embedded Grok-1 baseline via [`embedded_grok1_baseline`], but
+///    **only** when [`QuantizationConfig::use_embedded_baseline`] is
+///    `true`. This is opt-in so upgrading from phase 1 does not
+///    silently apply a Grok-1 manifest to non-Grok-1 exports.
 /// 4. `None` — selection falls back to the legacy heuristic in
 ///    [`crate::core::selection::classify`].
 fn resolve_manifest(config: &QuantizationConfig) -> Result<Option<DissectManifest>> {
     if let Some(path) = &config.manifest_path {
         return Ok(Some(load_manifest(path)?));
     }
-    if let Ok(env_path) = std::env::var(MANIFEST_ENV_VAR) {
-        if !env_path.is_empty() {
-            let p = std::path::PathBuf::from(env_path);
-            return Ok(Some(load_manifest(&p)?));
-        }
+    if let Ok(env_path) = std::env::var(MANIFEST_ENV_VAR)
+        && !env_path.is_empty()
+    {
+        let p = std::path::PathBuf::from(env_path);
+        return Ok(Some(load_manifest(&p)?));
     }
-    // Embedded baseline: clone once so callers own a DissectManifest.
-    // The OnceLock inside manifest.rs keeps the parse one-shot.
-    Ok(Some(embedded_grok1_baseline()?.clone()))
+    if config.use_embedded_baseline {
+        // Embedded baseline: clone once so callers own a DissectManifest.
+        // The OnceLock inside manifest.rs keeps the parse one-shot.
+        return Ok(Some(embedded_grok1_baseline()?.clone()));
+    }
+    Ok(None)
 }
 
 /// Return `true` if a deprecation warning about `router_patterns`
@@ -553,6 +559,12 @@ fn bytemuck_cast_f16(raw: &[u8]) -> &[f16] {
     }
 }
 
+/// Serialises env-var mutations across tests that touch
+/// `GROK_OZEMPIC_MANIFEST`. Declared at the module level so the
+/// `#[cfg(test)]` test module can refer to it via `super::`.
+#[cfg(test)]
+static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn bf16_bytes_to_f32(raw: &[u8]) -> Vec<f32> {
     assert_eq!(raw.len() % 2, 0, "bf16 data length must be a multiple of 2");
     raw.chunks_exact(2)
@@ -570,6 +582,119 @@ mod tests {
 
     // Router-classification tests moved to src/core/selection.rs; this
     // file no longer owns classification logic.
+
+    // ---------- test helpers ----------
+    //
+    // Minimal FP32 `.npy` writer sufficient for round-tripping through
+    // `run_quantization`. Mirrors the header format exercised by
+    // `core::npy::tests::parse_simple_v1_header`.
+    fn write_npy_f32(path: &std::path::Path, shape: &[usize], data: &[f32]) {
+        use std::io::Write as _;
+        let expected: usize = shape.iter().product();
+        assert_eq!(expected, data.len(), "data length must match shape");
+        let shape_str = if shape.is_empty() {
+            "()".to_string()
+        } else if shape.len() == 1 {
+            format!("({},)", shape[0])
+        } else {
+            let inner = shape
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("({inner})")
+        };
+        let dict = format!(
+            "{{'descr': '<f4', 'fortran_order': False, 'shape': {shape_str}, }}"
+        );
+        let magic = b"\x93NUMPY";
+        let preamble_len = magic.len() + 1 /* major */ + 1 /* minor */ + 2 /* hlen */;
+        // Pad the header string with spaces so (preamble + hlen) is a
+        // multiple of 64, then terminate with `\n` inside the padded
+        // region (NumPy convention). Our parser only requires 64-byte
+        // alignment, so plain space-padding is fine here.
+        let raw_header_len = dict.len();
+        let total_unpadded = preamble_len + raw_header_len;
+        let pad = (64 - (total_unpadded % 64)) % 64;
+        let header_len = raw_header_len + pad;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(magic);
+        bytes.push(1); // major
+        bytes.push(0); // minor
+        bytes.extend_from_slice(&(header_len as u16).to_le_bytes());
+        bytes.extend_from_slice(dict.as_bytes());
+        bytes.extend(std::iter::repeat(b' ').take(pad));
+        for v in data {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&bytes).unwrap();
+    }
+
+    /// Per-test unique scratch dir.
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("grok-ozempic-stream-{tag}-{pid}-{nanos}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    /// Write the phase-2 parity fixture. Names chosen so the legacy
+    /// heuristic and the in-tree Grok-1 baseline manifest agree on the
+    /// precision of every tensor:
+    ///
+    /// - `blk.0.moe_gate.weight`      legacy: 'gate'/'moe_gate' substring →
+    ///   FP16. Baseline: preserve list → FP16 (transitional alias).
+    /// - `blk.0.expert_router.weight` legacy: 'expert_router' → FP16.
+    ///   Baseline: preserve → FP16.
+    /// - `blk.0.attn_router.weight`   legacy: 'router' → FP16. Baseline:
+    ///   fp16 list → FP16.
+    /// - `blk.0.ffn_up.weight`        legacy: no match → ternary.
+    ///   Baseline: defaults → ternary_snn.
+    fn write_parity_fixture(dir: &std::path::Path) {
+        // 2x2 tensors are enough to exercise ternary pack alignment.
+        let moe_gate = [0.1f32, -0.2, 0.3, -0.4];
+        let expert_router = [1.0f32, -1.0, 0.5, -0.5];
+        let attn_router = [0.05f32, 0.9, -0.05, -0.9];
+        let ffn_up = [0.3f32, -0.3, 0.01, -0.01];
+        write_npy_f32(&dir.join("blk__0__moe_gate__weight.npy"), &[2, 2], &moe_gate);
+        write_npy_f32(
+            &dir.join("blk__0__expert_router__weight.npy"),
+            &[2, 2],
+            &expert_router,
+        );
+        write_npy_f32(
+            &dir.join("blk__0__attn_router__weight.npy"),
+            &[2, 2],
+            &attn_router,
+        );
+        write_npy_f32(&dir.join("blk__0__ffn_up__weight.npy"), &[2, 2], &ffn_up);
+    }
+
+    fn base_config(dir: &std::path::Path, out: &std::path::Path) -> QuantizationConfig {
+        // gif_threshold must match the baseline manifest's
+        // defaults.gif_threshold (0.05) for parity. The embedded
+        // baseline's default overrides the config value per
+        // precision::decide, so matching the two makes the two code
+        // paths produce identical thresholds on ternary tensors.
+        QuantizationConfig {
+            input_dir: dir.to_string_lossy().into_owned(),
+            output_path: out.to_string_lossy().into_owned(),
+            gif_threshold: 0.05,
+            input_format: QuantizationInputFormat::NpyDir,
+            ..Default::default()
+        }
+    }
+
+    fn goz1_bytes(p: &std::path::Path) -> Vec<u8> {
+        std::fs::read(p).expect("failed to read GOZ1 output")
+    }
+
+    // ---------- tests ----------
 
     #[test]
     fn deprecation_warning_fires_when_both_present() {
@@ -641,5 +766,205 @@ mod tests {
     fn collect_shards_nonexistent_dir() {
         let result = collect_safetensor_shards("/tmp/nonexistent_grok_ozempic_dir_xyz");
         assert!(result.is_err());
+    }
+
+    // ---------- parity / divergence / precedence / env-var ----------
+
+    /// Parity test: on the carefully chosen fixture, the legacy heuristic
+    /// (no manifest) and the embedded Grok-1 baseline (opt-in) produce
+    /// byte-identical GOZ1 output.
+    #[test]
+    fn parity_legacy_vs_baseline_is_byte_identical() {
+        // Hold ENV_TEST_MUTEX so a parallel env-var test cannot leak
+        // GROK_OZEMPIC_MANIFEST into the legacy run below.
+        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+
+        let dir = scratch_dir("parity-input");
+        write_parity_fixture(&dir);
+
+        let out_legacy = scratch_dir("parity-legacy-out").join("a.goz1");
+        let out_baseline = scratch_dir("parity-baseline-out").join("b.goz1");
+
+        let mut config = base_config(&dir, &out_legacy);
+        run_quantization(&config).expect("legacy path");
+
+        config.output_path = out_baseline.to_string_lossy().into_owned();
+        config.use_embedded_baseline = true;
+        run_quantization(&config).expect("baseline path");
+
+        let a = goz1_bytes(&out_legacy);
+        let b = goz1_bytes(&out_baseline);
+        if a != b {
+            let first_diff = a
+                .iter()
+                .zip(b.iter())
+                .position(|(x, y)| x != y)
+                .unwrap_or(a.len().min(b.len()));
+            panic!(
+                "parity failed: a.len={} b.len={} first_diff_at={} a_byte={:?} b_byte={:?}",
+                a.len(),
+                b.len(),
+                first_diff,
+                a.get(first_diff),
+                b.get(first_diff),
+            );
+        }
+    }
+
+    /// Divergence test: adding `blk.0.ffn_gate.weight` to the fixture
+    /// forces the two paths apart. The legacy heuristic false-matches
+    /// the `gate` substring and routes it to FP16; the baseline manifest
+    /// does not match it at all so it goes ternary. This documents the
+    /// value of the manifest wiring.
+    #[test]
+    fn divergence_on_ffn_gate_false_positive() {
+        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+
+        let dir = scratch_dir("diverge-input");
+        write_parity_fixture(&dir);
+        let ffn_gate = [0.7f32, -0.7, 0.4, -0.4];
+        write_npy_f32(
+            &dir.join("blk__0__ffn_gate__weight.npy"),
+            &[2, 2],
+            &ffn_gate,
+        );
+
+        let out_legacy = scratch_dir("diverge-legacy-out").join("a.goz1");
+        let out_baseline = scratch_dir("diverge-baseline-out").join("b.goz1");
+
+        let mut config = base_config(&dir, &out_legacy);
+        run_quantization(&config).expect("legacy path");
+
+        config.output_path = out_baseline.to_string_lossy().into_owned();
+        config.use_embedded_baseline = true;
+        run_quantization(&config).expect("baseline path");
+
+        let a = goz1_bytes(&out_legacy);
+        let b = goz1_bytes(&out_baseline);
+        assert_ne!(
+            a, b,
+            "`ffn_gate` false-positive should make the two paths diverge"
+        );
+    }
+
+    /// End-to-end: an explicit `manifest_path` winning over the embedded
+    /// baseline and producing the same bytes as a config that points at
+    /// the in-tree baseline file directly.
+    #[test]
+    fn explicit_manifest_path_wins_over_env_var() {
+        // Build a tiny manifest-from-disk and a DIFFERENT env-var manifest.
+        // Classify a single tensor that each classifies differently; the
+        // explicit path must win.
+        let dir = scratch_dir("prec-input");
+        let ffn_up = [0.3f32, -0.3, 0.01, -0.01];
+        write_npy_f32(&dir.join("blk__0__ffn_up__weight.npy"), &[2, 2], &ffn_up);
+
+        // Explicit manifest forces ffn_up to FP16.
+        let explicit_path = scratch_dir("prec-explicit").join("m.json");
+        std::fs::write(
+            &explicit_path,
+            r#"{
+                "schema": "xai-dissect.manifest",
+                "schema_version": 1,
+                "model": {
+                    "family": "grok-1",
+                    "tensor_name_convention": "blk.{L}.{role}.weight"
+                },
+                "fp16": [ { "name": "blk.0.ffn_up.weight" } ]
+            }"#,
+        )
+        .unwrap();
+
+        // Env manifest forces ffn_up into preserve.
+        let env_path = scratch_dir("prec-env").join("m.json");
+        std::fs::write(
+            &env_path,
+            r#"{
+                "schema": "xai-dissect.manifest",
+                "schema_version": 1,
+                "model": {
+                    "family": "grok-1",
+                    "tensor_name_convention": "blk.{L}.{role}.weight"
+                },
+                "preserve": [ { "name": "blk.0.ffn_up.weight" } ]
+            }"#,
+        )
+        .unwrap();
+
+        let out_a = scratch_dir("prec-out-a").join("a.goz1");
+        let out_b = scratch_dir("prec-out-b").join("b.goz1");
+
+        // Serialize env-var mutations for test-safety.
+        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
+        // SAFETY: mutation guarded by the single-threaded test mutex.
+        unsafe { std::env::set_var(MANIFEST_ENV_VAR, &env_path) };
+
+        // A: explicit + env — explicit must win.
+        let mut config = base_config(&dir, &out_a);
+        config.manifest_path = Some(explicit_path.clone());
+        run_quantization(&config).expect("explicit+env run");
+
+        // B: explicit only — same explicit manifest, no env. Should
+        // produce identical bytes to A if explicit truly won.
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+        let mut config = base_config(&dir, &out_b);
+        config.manifest_path = Some(explicit_path.clone());
+        run_quantization(&config).expect("explicit only run");
+
+        let a = goz1_bytes(&out_a);
+        let b = goz1_bytes(&out_b);
+        assert_eq!(
+            a, b,
+            "explicit manifest_path must win over GROK_OZEMPIC_MANIFEST"
+        );
+    }
+
+    /// `GROK_OZEMPIC_MANIFEST` is honored when no explicit path is set
+    /// (and changes classification versus the no-manifest legacy path).
+    #[test]
+    fn env_var_manifest_is_resolved_when_no_explicit_path() {
+        let dir = scratch_dir("env-input");
+        let ffn_up = [0.3f32, -0.3, 0.01, -0.01];
+        write_npy_f32(&dir.join("blk__0__ffn_up__weight.npy"), &[2, 2], &ffn_up);
+
+        // Env manifest forces ffn_up to FP16 (legacy heuristic would
+        // leave it ternary, so the bytes must differ).
+        let env_path = scratch_dir("env-manifest").join("m.json");
+        std::fs::write(
+            &env_path,
+            r#"{
+                "schema": "xai-dissect.manifest",
+                "schema_version": 1,
+                "model": {
+                    "family": "grok-1",
+                    "tensor_name_convention": "blk.{L}.{role}.weight"
+                },
+                "fp16": [ { "name": "blk.0.ffn_up.weight" } ]
+            }"#,
+        )
+        .unwrap();
+
+        let out_legacy = scratch_dir("env-out-legacy").join("a.goz1");
+        let out_env = scratch_dir("env-out-env").join("b.goz1");
+
+        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
+        // Legacy run (env var unset).
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+        let config = base_config(&dir, &out_legacy);
+        run_quantization(&config).expect("legacy run");
+
+        // Env-var run.
+        unsafe { std::env::set_var(MANIFEST_ENV_VAR, &env_path) };
+        let config = base_config(&dir, &out_env);
+        run_quantization(&config).expect("env var run");
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+
+        assert_ne!(
+            goz1_bytes(&out_legacy),
+            goz1_bytes(&out_env),
+            "env-var-supplied manifest must change classification vs legacy"
+        );
     }
 }

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -24,14 +24,17 @@ use safetensors::SafeTensors;
 
 use crate::{
     core::{
+        manifest::{embedded_grok1_baseline, load_manifest, DissectManifest},
+        npy::{npy_stem_to_tensor_name, MmapNpy, NpyDtype},
+        precision::decide as precision_decide,
+        quantizer::{convert_f32_to_f16_bytes, passthrough_f16, quantize_f16, quantize_f32},
+        selection::{classify, TensorClass},
         weight_pack::{
             PackMetaValue, PackStreamWriter, PackTensorHeader, TENSOR_F16, TENSOR_TERNARY,
         },
-        npy::{npy_stem_to_tensor_name, MmapNpy, NpyDtype},
-        quantizer::{convert_f32_to_f16_bytes, passthrough_f16, quantize_f16, quantize_f32},
     },
     error::{GrokOzempicError, Result},
-    types::{QuantizationConfig, QuantizationInputFormat},
+    types::{QuantizationConfig, QuantizationInputFormat, TensorPrecision},
 };
 
 // Grok-1 (JAX) architecture hints embedded in GOZ1 metadata — confirm against
@@ -82,17 +85,60 @@ pub fn append_grok1_arch_metadata(meta: &mut BTreeMap<String, PackMetaValue>) {
 }
 
 // ---------------------------------------------------------------------------
-// Tensor classification
+// Manifest resolution & deprecation warning
 // ---------------------------------------------------------------------------
 
-fn is_router_tensor(name: &str, patterns: &[String]) -> bool {
-    if patterns.is_empty() {
-        let defaults = [
-            "router", "gate", "moe_gate", "expert_router", "routing",
-        ];
-        return defaults.iter().any(|p| name.contains(p));
+/// Environment variable consulted when [`QuantizationConfig::manifest_path`]
+/// is `None`.
+pub const MANIFEST_ENV_VAR: &str = "GROK_OZEMPIC_MANIFEST";
+
+/// Resolve the xai-dissect manifest that governs this `run_quantization`
+/// call.
+///
+/// Precedence (first hit wins, errors bubble; no silent fallthrough):
+///
+/// 1. [`QuantizationConfig::manifest_path`] (explicit caller override).
+/// 2. `GROK_OZEMPIC_MANIFEST` environment variable.
+/// 3. Embedded Grok-1 baseline via [`embedded_grok1_baseline`].
+/// 4. `None` — selection falls back to the legacy heuristic in
+///    [`crate::core::selection::classify`].
+fn resolve_manifest(config: &QuantizationConfig) -> Result<Option<DissectManifest>> {
+    if let Some(path) = &config.manifest_path {
+        return Ok(Some(load_manifest(path)?));
     }
-    patterns.iter().any(|p| name.contains(p.as_str()))
+    if let Ok(env_path) = std::env::var(MANIFEST_ENV_VAR) {
+        if !env_path.is_empty() {
+            let p = std::path::PathBuf::from(env_path);
+            return Ok(Some(load_manifest(&p)?));
+        }
+    }
+    // Embedded baseline: clone once so callers own a DissectManifest.
+    // The OnceLock inside manifest.rs keeps the parse one-shot.
+    Ok(Some(embedded_grok1_baseline()?.clone()))
+}
+
+/// Return `true` if a deprecation warning about `router_patterns`
+/// alongside a manifest should be emitted.
+///
+/// Exposed (crate-private) so tests can assert the condition without
+/// capturing stderr.
+pub(crate) fn should_warn_router_patterns_deprecated(
+    manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) -> bool {
+    manifest.is_some() && !config.router_patterns.is_empty()
+}
+
+fn maybe_warn_router_patterns_deprecated(
+    manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) {
+    if should_warn_router_patterns_deprecated(manifest, config) {
+        eprintln!(
+            "grok-ozempic: router_patterns is set alongside an xai-dissect manifest; \
+             the manifest wins and router_patterns is ignored (deprecated)."
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -134,7 +180,22 @@ struct ManifestEntry {
     source_path: PathBuf,
     tensor_name: String,
     shape: Vec<u64>,
-    is_router: bool,
+    precision: TensorPrecision,
+    gif_threshold: f32,
+}
+
+impl ManifestEntry {
+    /// True when this tensor goes through the FP16 passthrough path.
+    ///
+    /// TODO(phase-3): [`TensorPrecision::Preserve`] is currently aliased
+    /// to FP16 passthrough here. This is the single site of the
+    /// transitional alias; removal tracked in issue #6.
+    fn uses_fp16_passthrough(&self) -> bool {
+        matches!(
+            self.precision,
+            TensorPrecision::Fp16 | TensorPrecision::Preserve
+        )
+    }
 }
 
 /// Diagnostic statistics emitted after processing each shard / source file.
@@ -149,6 +210,9 @@ pub struct ShardStats {
 
 /// Run the full out-of-core quantization pipeline described by `config`.
 pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> {
+    let dissect_manifest = resolve_manifest(config)?;
+    maybe_warn_router_patterns_deprecated(dissect_manifest.as_ref(), config);
+
     let manifest = match config.input_format {
         QuantizationInputFormat::Safetensors => {
             let shards = collect_safetensor_shards(&config.input_dir)?;
@@ -158,7 +222,7 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
                     config.input_dir
                 )));
             }
-            build_manifest_safetensors(&shards, &config.router_patterns)?
+            build_manifest_safetensors(&shards, dissect_manifest.as_ref(), config)?
         }
         QuantizationInputFormat::NpyDir => {
             let paths = collect_npy_files(&config.input_dir)?;
@@ -168,7 +232,7 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
                     config.input_dir
                 )));
             }
-            build_manifest_npy(&paths, &config.router_patterns)?
+            build_manifest_npy(&paths, dissect_manifest.as_ref(), config)?
         }
     };
 
@@ -183,7 +247,10 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
         .map(|e| PackTensorHeader {
             name: e.tensor_name.clone(),
             shape: e.shape.clone(),
-            tensor_type: if e.is_router {
+            // TODO(phase-3): Preserve currently shares TENSOR_F16 with
+            // Fp16. Once source-dtype passthrough lands, introduce a
+            // dedicated TENSOR_PRESERVE constant. Tracked in issue #6.
+            tensor_type: if e.uses_fp16_passthrough() {
                 TENSOR_F16
             } else {
                 TENSOR_TERNARY
@@ -235,7 +302,7 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
         }
 
         let (packed, ternary_sparsity) = quantize_manifest_entry(entry, config)?;
-        if entry.is_router {
+        if entry.uses_fp16_passthrough() {
             shard_stats.tensors_fp16 += 1;
         } else {
             shard_stats.tensors_ternary += 1;
@@ -273,7 +340,7 @@ fn quantize_manifest_entry(
 
 fn quantize_safetensors_entry(
     entry: &ManifestEntry,
-    config: &QuantizationConfig,
+    _config: &QuantizationConfig,
 ) -> Result<(Vec<u8>, Option<f32>)> {
     let file = File::open(&entry.source_path).map_err(GrokOzempicError::Io)?;
     let mmap = unsafe { MmapOptions::new().map(&file).map_err(GrokOzempicError::Io)? };
@@ -288,22 +355,22 @@ fn quantize_safetensors_entry(
         )));
     }
 
-    if entry.is_router {
+    if entry.uses_fp16_passthrough() {
         let fp16_bytes = router_fp16_bytes(dtype, view.data())?;
         Ok((fp16_bytes, None))
     } else {
         let qt = match dtype {
             SourceDtype::F32 => {
                 let f32_slice = bytemuck_cast_f32(view.data());
-                quantize_f32(f32_slice, config.gif_threshold)
+                quantize_f32(f32_slice, entry.gif_threshold)
             }
             SourceDtype::F16 => {
                 let f16_slice: &[f16] = bytemuck_cast_f16(view.data());
-                quantize_f16(f16_slice, config.gif_threshold)
+                quantize_f16(f16_slice, entry.gif_threshold)
             }
             SourceDtype::BF16 => {
                 let f32_vals = bf16_bytes_to_f32(view.data());
-                quantize_f32(&f32_vals, config.gif_threshold)
+                quantize_f32(&f32_vals, entry.gif_threshold)
             }
             SourceDtype::Other => unreachable!(),
         };
@@ -314,7 +381,7 @@ fn quantize_safetensors_entry(
 
 fn quantize_npy_entry(
     entry: &ManifestEntry,
-    config: &QuantizationConfig,
+    _config: &QuantizationConfig,
 ) -> Result<(Vec<u8>, Option<f32>)> {
     let npy = MmapNpy::map_path(&entry.source_path)?;
     let dtype = npy_dtype_to_source(npy.dtype());
@@ -326,22 +393,22 @@ fn quantize_npy_entry(
     }
     let raw = npy.data();
 
-    if entry.is_router {
+    if entry.uses_fp16_passthrough() {
         let fp16_bytes = router_fp16_bytes(dtype, raw)?;
         Ok((fp16_bytes, None))
     } else {
         let qt = match dtype {
             SourceDtype::F32 => {
                 let f32_slice = bytemuck_cast_f32(raw);
-                quantize_f32(f32_slice, config.gif_threshold)
+                quantize_f32(f32_slice, entry.gif_threshold)
             }
             SourceDtype::F16 => {
                 let f16_slice: &[f16] = bytemuck_cast_f16(raw);
-                quantize_f16(f16_slice, config.gif_threshold)
+                quantize_f16(f16_slice, entry.gif_threshold)
             }
             SourceDtype::BF16 => {
                 let f32_vals = bf16_bytes_to_f32(raw);
-                quantize_f32(&f32_vals, config.gif_threshold)
+                quantize_f32(&f32_vals, entry.gif_threshold)
             }
             SourceDtype::Other => unreachable!(),
         };
@@ -369,9 +436,28 @@ fn router_fp16_bytes(dtype: SourceDtype, raw: &[u8]) -> Result<Vec<u8>> {
     Ok(b)
 }
 
+fn classify_and_decide(
+    name: &str,
+    dissect_manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) -> Result<(TensorClass, TensorPrecision, f32)> {
+    // selection.rs is the single source of truth for classification.
+    // When a manifest is supplied, router_patterns is ignored (the
+    // deprecation warning above already informed the caller).
+    let legacy_patterns: &[String] = if dissect_manifest.is_some() {
+        &[]
+    } else {
+        &config.router_patterns
+    };
+    let class = classify(name, dissect_manifest, legacy_patterns);
+    let (precision, gif_threshold) = precision_decide(&class, dissect_manifest, config)?;
+    Ok((class, precision, gif_threshold))
+}
+
 fn build_manifest_safetensors(
     shards: &[PathBuf],
-    patterns: &[String],
+    dissect_manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
 ) -> Result<Vec<ManifestEntry>> {
     let mut v = Vec::new();
     for shard in shards {
@@ -383,20 +469,26 @@ fn build_manifest_safetensors(
             if dtype == SourceDtype::Other {
                 continue;
             }
-            let is_router = is_router_tensor(&name, patterns);
+            let (_class, precision, gif_threshold) =
+                classify_and_decide(&name, dissect_manifest, config)?;
             let shape: Vec<u64> = view.shape().iter().map(|&d| d as u64).collect();
             v.push(ManifestEntry {
                 source_path: shard.clone(),
                 tensor_name: name,
                 shape,
-                is_router,
+                precision,
+                gif_threshold,
             });
         }
     }
     Ok(v)
 }
 
-fn build_manifest_npy(paths: &[PathBuf], patterns: &[String]) -> Result<Vec<ManifestEntry>> {
+fn build_manifest_npy(
+    paths: &[PathBuf],
+    dissect_manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) -> Result<Vec<ManifestEntry>> {
     let mut v = Vec::new();
     for path in paths {
         let npy = MmapNpy::map_path(path)?;
@@ -411,13 +503,15 @@ fn build_manifest_npy(paths: &[PathBuf], patterns: &[String]) -> Result<Vec<Mani
                 GrokOzempicError::InvalidConfig(format!("bad npy filename: {}", path.display()))
             })?;
         let tensor_name = npy_stem_to_tensor_name(stem);
-        let is_router = is_router_tensor(&tensor_name, patterns);
+        let (_class, precision, gif_threshold) =
+            classify_and_decide(&tensor_name, dissect_manifest, config)?;
         let shape: Vec<u64> = npy.shape().iter().map(|&d| d as u64).collect();
         v.push(ManifestEntry {
             source_path: path.clone(),
             tensor_name,
             shape,
-            is_router,
+            precision,
+            gif_threshold,
         });
     }
     Ok(v)
@@ -474,20 +568,50 @@ fn bf16_bytes_to_f32(raw: &[u8]) -> Vec<f32> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn router_classification_defaults() {
-        assert!(is_router_tensor("blk.0.moe_gate.weight", &[]));
-        assert!(is_router_tensor("model.layers.4.expert_router.weight", &[]));
-        assert!(is_router_tensor("transformer.h.1.routing.weight", &[]));
-        assert!(!is_router_tensor("blk.0.ffn_up.weight", &[]));
-        assert!(!is_router_tensor("blk.0.ffn_down.weight", &[]));
-    }
+    // Router-classification tests moved to src/core/selection.rs; this
+    // file no longer owns classification logic.
 
     #[test]
-    fn router_classification_custom_patterns() {
-        let patterns = vec!["special_router".to_string()];
-        assert!(is_router_tensor("blk.0.special_router.weight", &patterns));
-        assert!(!is_router_tensor("blk.0.gate.weight", &patterns));
+    fn deprecation_warning_fires_when_both_present() {
+        use crate::core::manifest::{
+            DissectManifest, ManifestDefaults, ManifestModel, MANIFEST_NAME_CONVENTION_V1,
+            MANIFEST_SCHEMA_VERSION,
+        };
+        let manifest = DissectManifest {
+            schema: "xai-dissect.manifest".into(),
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            model: ManifestModel {
+                family: "grok-1".into(),
+                source: "".into(),
+                tensor_name_convention: MANIFEST_NAME_CONVENTION_V1.into(),
+            },
+            produced_by: None,
+            defaults: ManifestDefaults::default(),
+            preserve: vec![],
+            fp16: vec![],
+            ternary_candidates: vec![],
+            blocks: vec![],
+        };
+
+        let config_with_patterns = QuantizationConfig {
+            router_patterns: vec!["legacy_router".into()],
+            ..Default::default()
+        };
+        assert!(should_warn_router_patterns_deprecated(
+            Some(&manifest),
+            &config_with_patterns,
+        ));
+
+        let config_empty = QuantizationConfig::default();
+        assert!(!should_warn_router_patterns_deprecated(
+            Some(&manifest),
+            &config_empty,
+        ));
+
+        assert!(!should_warn_router_patterns_deprecated(
+            None,
+            &config_with_patterns,
+        ));
     }
 
     #[test]

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -273,9 +273,19 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
         "oz.quantization_version".into(),
         PackMetaValue::U32(1),
     );
+    // Record the effective baseline gif_threshold so the artifact's
+    // provenance metadata reflects what was actually applied. When the
+    // manifest supplies a defaults.gif_threshold that overrides the
+    // config value, that manifest default is recorded here. Per-tensor
+    // overrides from ternary_candidates can differ, but this captures the
+    // pipeline-level default that governs the majority of tensors.
+    let effective_gif_threshold = dissect_manifest
+        .as_ref()
+        .and_then(|m| m.defaults.gif_threshold)
+        .unwrap_or(config.gif_threshold);
     metadata.insert(
         "oz.gif_threshold".into(),
-        PackMetaValue::Str(config.gif_threshold.to_string()),
+        PackMetaValue::Str(effective_gif_threshold.to_string()),
     );
     append_grok1_arch_metadata(&mut metadata);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,9 @@ pub enum GrokOzempicError {
         "manifest tensor_name_convention mismatch: got {got:?}, expected {expected:?}"
     )]
     ManifestNameConventionMismatch { got: String, expected: String },
+
+    #[error("unsupported manifest precision tier: {got:?}")]
+    ManifestInvalidPrecision { got: String },
 }
 
 pub type Result<T> = std::result::Result<T, GrokOzempicError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,12 @@ pub use crate::core::weight_pack::{
 pub use crate::core::weight_pack_read::{verify_pack_file, PackVerifyReport};
 pub use crate::core::quantizer::{quantize_f16, quantize_f32, QuantizedTensor};
 pub use crate::core::manifest::{
-    load_manifest, DissectManifest, Fp16Entry, ManifestBlock, ManifestDefaults, ManifestModel,
-    ManifestProducedBy, PreserveEntry, TernaryCandidate, MANIFEST_NAME_CONVENTION_V1,
+    embedded_grok1_baseline, load_manifest, parse_manifest_bytes, DissectManifest, Fp16Entry,
+    ManifestBlock, ManifestDefaults, ManifestModel, ManifestProducedBy, PreserveEntry,
+    TernaryCandidate, GROK1_BASELINE_JSON, MANIFEST_NAME_CONVENTION_V1,
     MANIFEST_SCHEMA_VERSION,
+};
+pub use crate::core::precision::{decide as precision_decide, parse_precision_str};
+pub use crate::core::selection::{
+    classify as selection_classify, glob_match, TensorClass, LEGACY_DEFAULT_ROUTER_PATTERNS,
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -73,10 +73,20 @@ pub struct QuantizationConfig {
     /// modules.
     ///
     /// Precedence (phase 2+): this explicit path > `GROK_OZEMPIC_MANIFEST`
-    /// env var > in-tree `dissect/grok-1/baseline.json` fallback > legacy
+    /// env var > in-tree `dissect/grok-1/baseline.json` fallback (only
+    /// when [`Self::use_embedded_baseline`] is `true`) > legacy
     /// `router_patterns` heuristic.
     #[serde(default)]
     pub manifest_path: Option<PathBuf>,
+    /// Opt in to the compiled-in non-authoritative Grok-1 baseline
+    /// manifest as a fallback when neither
+    /// [`Self::manifest_path`] nor `GROK_OZEMPIC_MANIFEST` is set.
+    ///
+    /// Default is `false` so upgrading from phase 1 preserves existing
+    /// legacy-heuristic behavior. Set to `true` for a Grok-1 export to
+    /// pick up the reference manifest without pointing at a file.
+    #[serde(default)]
+    pub use_embedded_baseline: bool,
 }
 
 impl Default for QuantizationConfig {
@@ -88,6 +98,7 @@ impl Default for QuantizationConfig {
             router_patterns: Vec::new(),
             input_format: QuantizationInputFormat::Safetensors,
             manifest_path: None,
+            use_embedded_baseline: false,
         }
     }
 }


### PR DESCRIPTION
## **User description**
Advances #6. **Does not close it** — phase 3 (final `Preserve` semantics and alias removal) remains open.

`grok-ozempic` now actually consumes the xai-dissect manifest inside `run_quantization` while preserving legacy behavior by default.

## What this PR does

- **`src/core/selection.rs`** (new) — single source of truth for tensor classification. `TensorClass` enum, `classify(name, manifest, legacy_patterns)`, segment-anchored `glob_match` where `*` = exactly one dotted segment. Manifest path uses strict `preserve > fp16 > ternary_candidates > default` precedence; `manifest.is_none()` path uses the legacy substring heuristic that previously lived in `stream.rs`.
- **`src/core/precision.rs`** (new) — `decide(class, manifest, config)` returns `(TensorPrecision, effective_gif_threshold)`. Threshold resolution: candidate.gif_threshold > manifest.defaults.gif_threshold > config.gif_threshold. Unknown `defaults.precision` strings hard-fail with `GrokOzempicError::ManifestInvalidPrecision`.
- **`src/core/stream.rs`** — rewired:
  - `is_router_tensor()` deleted; classification lives exclusively in `selection.rs`.
  - `resolve_manifest()` implements the documented precedence: `config.manifest_path` → `GROK_OZEMPIC_MANIFEST` env var → embedded Grok-1 baseline (opt-in via `use_embedded_baseline`) → `None`. Errors bubble; no silent fallthrough.
  - Single deprecation `eprintln!` fires when `router_patterns` is set alongside a manifest. Exposed as `should_warn_router_patterns_deprecated()` for testability.
  - `ManifestEntry` now carries `(precision, gif_threshold)`; per-tensor thresholds from the manifest flow into the ternary quantizer.
  - **One** localized `Preserve → FP16` alias site, marked `TODO(phase-3)` with a reference to #6 for removal.
- **`src/core/manifest.rs`** — adds `GROK1_BASELINE_JSON` via `include_str!`, `parse_manifest_bytes(bytes, label)` (shared with `load_manifest`), and `embedded_grok1_baseline()` that parses the embedded JSON exactly once via `OnceLock` and caches it for the process lifetime.
- **`src/types.rs`** — adds `use_embedded_baseline: bool` (`#[serde(default = false)]`). Keeps upgraders on legacy behavior unless they opt in, which matches "preserve current legacy behavior when no manifest is available".
- **`docs/dissect-manifest.md`** — tightens glob spec to "`*` matches exactly one dotted segment".
- **54 tests passing.** 12 selection tests, 11 precision tests, 3 new manifest tests (including `OnceLock` caching), 4 new integration tests in stream.rs (parity, divergence, precedence, env-var).

## Manifest precedence (implemented)

1. `QuantizationConfig.manifest_path` (explicit caller override).
2. `GROK_OZEMPIC_MANIFEST` environment variable.
3. Embedded Grok-1 baseline, **only when `use_embedded_baseline = true`**.
4. `None` → legacy `router_patterns` heuristic in `selection.rs`.

If any of steps 1–3 loads but fails validation, the error bubbles — we do not silently fall through to the next rung.

## Parity test design

Fixture `{moe_gate, expert_router, attn_router, ffn_up}` is deliberately chosen so the legacy substring heuristic and the embedded baseline manifest classify every tensor identically. Config `gif_threshold = 0.05` matches `baseline.json`'s `defaults.gif_threshold`, so ternary thresholds align too. Result: byte-identical GOZ1 output on both paths.

The divergence test then adds `blk.0.ffn_gate.weight` — a name the legacy heuristic false-matches via the `gate` substring but the baseline manifest (segment-anchored globs) does not — and asserts the two files differ. Documents the concrete value of the wiring.

Tests touching `GROK_OZEMPIC_MANIFEST` share an `ENV_TEST_MUTEX` to stay race-free under Cargo's parallel runner.

## Preserve tier — transitional alias

`TensorPrecision::Preserve` is still reserved at the pack-format level. The wiring unifies `Fp16` and `Preserve` through a single `uses_fp16_passthrough()` helper in `ManifestEntry` — the **only** site of the temporary alias, marked:

```rust
// TODO(phase-3): TensorPrecision::Preserve is currently aliased
// to FP16 passthrough here. This is the single site of the
// transitional alias; removal tracked in issue #6.
```

Phase 3 will either introduce a `TENSOR_PRESERVE` constant in the GOZ1 pack format or formalize the alias and retire the variant — that decision is open.

## Scope fence (out of this PR)

- No GOZ1 format changes.
- No CLI binary.
- No source-dtype passthrough path.
- No `rank` usage for ordering.
- No `manifest.blocks` consumption.
- No merging of `xai-dissect` into this repo.

All of the above remain tracked in #6. This PR should merge **without closing #6**.

## Commits

1. `docs: tighten manifest glob spec to single-segment wildcard`
2. `feat(selection): add TensorClass + glob-anchored classify()`
3. `feat(precision): add decide() with per-tensor threshold resolution`
4. `feat(manifest): expose embedded grok-1 baseline fallback`
5. `feat(stream): route classification/precision through selection + precision`
6. `test(stream): parity + divergence + precedence tests for manifest wiring`

## Tests

```
running 54 tests
...
test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```


___

## **CodeAnt-AI Description**
**Wire xai-dissect manifests into quantization and tighten tensor matching**

### What Changed
- Quantization now reads a manifest from the explicit path, then the `GROK_OZEMPIC_MANIFEST` environment variable, and only then an optional built-in Grok-1 fallback.
- Tensor selection now follows manifest rules first, with exact dotted-segment matching; `*` matches one segment only, so names like `ffn_gate` no longer get caught by loose substring matches.
- Manifest-defined precision and per-tensor GIF thresholds now apply during packing, and invalid precision values fail immediately instead of being ignored until a tensor happens to use them.
- When a manifest is present, legacy router patterns are ignored and a deprecation warning is shown.
- The output metadata now records the effective GIF threshold that was actually used.

### Impact
`✅ Fewer false-positive FP16 tensors`
`✅ Consistent manifest-driven quantization`
`✅ Clearer manifest errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=0EiRscpmwDWds8KVBMHEg6SCpoAB2qcewdCT8i6Q6qg&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
