### PR TITLE
feat(preserve): finalize Preserve = FP16-at-rest semantics for GOZ1 v1

### DIFF
--- a/docs/dissect-manifest.md
+++ b/docs/dissect-manifest.md
@@ -95,7 +95,7 @@ legacy field remains supported only for the manifest-less fallback path.
 
 | Tier           | Meaning                                                 |
 | -------------- | ------------------------------------------------------- |
-| `preserve`     | Keep source dtype. **Reserved in phase 1** — consumed by the pipeline in a later phase. During the transitional window this may be aliased to FP16 passthrough; the alias is temporary and tracked via a follow-up issue. |
+| `preserve`     | Routing-critical / no-touch tier. **GOZ1 v1: FP16-at-rest** — emits the same on-disk bytes as `fp16` (both use `TENSOR_F16`). Kept as a distinct tier to carry manifest intent (which list claimed the tensor) and to leave room for a future GOZ1 format version that may introduce true source-dtype passthrough. This is the **final, documented behavior** for GOZ1 v1, not a transitional shortcut. |
 | `fp16`         | Force FP16 passthrough (current router behavior).       |
 | `ternary_snn` | Ternary {-1, 0, +1} with GIF saliency threshold.         |
 

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -65,9 +65,10 @@ pub struct DissectManifest {
     #[serde(default)]
     pub defaults: ManifestDefaults,
 
-    /// Tensors that must keep their source precision (routing-critical
-    /// layers, etc.). Reserved in phase 1; not yet consumed by the
-    /// pipeline.
+    /// Routing-critical / no-touch tensors. Consumed by the
+    /// selection seam (`crate::core::selection::classify`) and mapped
+    /// to [`crate::types::TensorPrecision::Preserve`], which in GOZ1
+    /// v1 is FP16-at-rest (see that variant's docs).
     #[serde(default)]
     pub preserve: Vec<PreserveEntry>,
 

--- a/src/core/precision.rs
+++ b/src/core/precision.rs
@@ -9,6 +9,8 @@
 //!
 //! Precision tier resolution:
 //! - `TensorClass::Preserve`          → [`TensorPrecision::Preserve`]
+//!   (FP16-at-rest in GOZ1 v1; semantically distinct from `Fp16`,
+//!   identical on disk — see the `TensorPrecision::Preserve` docs).
 //! - `TensorClass::Fp16`              → [`TensorPrecision::Fp16`]
 //! - `TensorClass::TernaryCandidate`  → [`TensorPrecision::TernarySnN`]
 //! - `TensorClass::Default`           → parsed from

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -191,12 +191,14 @@ struct ManifestEntry {
 }
 
 impl ManifestEntry {
-    /// True when this tensor goes through the FP16 passthrough path.
+    /// True when this tensor is emitted as FP16 bytes in the GOZ1
+    /// tensor table (i.e. tagged `TENSOR_F16`).
     ///
-    /// TODO(phase-3): [`TensorPrecision::Preserve`] is currently aliased
-    /// to FP16 passthrough here. This is the single site of the
-    /// transitional alias; removal tracked in issue #6.
-    fn uses_fp16_passthrough(&self) -> bool {
+    /// In GOZ1 v1 both [`TensorPrecision::Fp16`] and
+    /// [`TensorPrecision::Preserve`] share the FP16-at-rest encoding
+    /// (see the `TensorPrecision::Preserve` doc for rationale). The
+    /// two tiers remain semantically distinct upstream of this point.
+    fn emits_fp16_bytes(&self) -> bool {
         matches!(
             self.precision,
             TensorPrecision::Fp16 | TensorPrecision::Preserve
@@ -253,10 +255,11 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
         .map(|e| PackTensorHeader {
             name: e.tensor_name.clone(),
             shape: e.shape.clone(),
-            // TODO(phase-3): Preserve currently shares TENSOR_F16 with
-            // Fp16. Once source-dtype passthrough lands, introduce a
-            // dedicated TENSOR_PRESERVE constant. Tracked in issue #6.
-            tensor_type: if e.uses_fp16_passthrough() {
+            // GOZ1 v1: Fp16 and Preserve share the TENSOR_F16 encoding
+            // by design (see TensorPrecision::Preserve). The semantic
+            // distinction lives in the manifest / classifier, not in
+            // the tensor table.
+            tensor_type: if e.emits_fp16_bytes() {
                 TENSOR_F16
             } else {
                 TENSOR_TERNARY
@@ -318,7 +321,7 @@ pub fn run_quantization(config: &QuantizationConfig) -> Result<Vec<ShardStats>> 
         }
 
         let (packed, ternary_sparsity) = quantize_manifest_entry(entry, config)?;
-        if entry.uses_fp16_passthrough() {
+        if entry.emits_fp16_bytes() {
             shard_stats.tensors_fp16 += 1;
         } else {
             shard_stats.tensors_ternary += 1;
@@ -371,8 +374,8 @@ fn quantize_safetensors_entry(
         )));
     }
 
-    if entry.uses_fp16_passthrough() {
-        let fp16_bytes = router_fp16_bytes(dtype, view.data())?;
+    if entry.emits_fp16_bytes() {
+        let fp16_bytes = encode_fp16_bytes(dtype, view.data())?;
         Ok((fp16_bytes, None))
     } else {
         let qt = match dtype {
@@ -409,8 +412,8 @@ fn quantize_npy_entry(
     }
     let raw = npy.data();
 
-    if entry.uses_fp16_passthrough() {
-        let fp16_bytes = router_fp16_bytes(dtype, raw)?;
+    if entry.emits_fp16_bytes() {
+        let fp16_bytes = encode_fp16_bytes(dtype, raw)?;
         Ok((fp16_bytes, None))
     } else {
         let qt = match dtype {
@@ -433,7 +436,10 @@ fn quantize_npy_entry(
     }
 }
 
-fn router_fp16_bytes(dtype: SourceDtype, raw: &[u8]) -> Result<Vec<u8>> {
+/// Encode raw source bytes as FP16 for tensors that emit through the
+/// GOZ1 `TENSOR_F16` slot (both `TensorPrecision::Fp16` and
+/// `TensorPrecision::Preserve` route here in GOZ1 v1).
+fn encode_fp16_bytes(dtype: SourceDtype, raw: &[u8]) -> Result<Vec<u8>> {
     let b = match dtype {
         SourceDtype::F16 => {
             let f16_slice: &[f16] = bytemuck_cast_f16(raw);
@@ -658,9 +664,9 @@ mod tests {
     /// precision of every tensor:
     ///
     /// - `blk.0.moe_gate.weight`      legacy: 'gate'/'moe_gate' substring →
-    ///   FP16. Baseline: preserve list → FP16 (transitional alias).
+    ///   FP16. Baseline: preserve list → FP16-at-rest (GOZ1 v1).
     /// - `blk.0.expert_router.weight` legacy: 'expert_router' → FP16.
-    ///   Baseline: preserve → FP16.
+    ///   Baseline: preserve → FP16-at-rest (GOZ1 v1).
     /// - `blk.0.attn_router.weight`   legacy: 'router' → FP16. Baseline:
     ///   fp16 list → FP16.
     /// - `blk.0.ffn_up.weight`        legacy: no match → ternary.
@@ -976,5 +982,89 @@ mod tests {
             goz1_bytes(&out_env),
             "env-var-supplied manifest must change classification vs legacy"
         );
+    }
+
+    /// Regression guard for the **final GOZ1-v1 semantic** of
+    /// `TensorPrecision::Preserve`: a tensor classified `Preserve`
+    /// (manifest `preserve` list) and the same tensor classified
+    /// `Fp16` (manifest `fp16` list) must produce **byte-identical**
+    /// GOZ1 output. The two tiers are semantically distinct upstream
+    /// but share the FP16-at-rest encoding on disk.
+    ///
+    /// If a future change introduces a separate `TENSOR_PRESERVE`
+    /// constant or a different on-disk encoding for `Preserve`, this
+    /// test will fail and force an explicit decision rather than
+    /// silent drift.
+    #[test]
+    fn preserve_and_fp16_tiers_emit_identical_goz1_bytes() {
+        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+
+        let dir = scratch_dir("preserve-fp16-input");
+        let ffn_up = [0.3f32, -0.3, 0.01, -0.01];
+        write_npy_f32(&dir.join("blk__0__ffn_up__weight.npy"), &[2, 2], &ffn_up);
+
+        // Manifest A: tensor lives in `preserve`.
+        let preserve_path = scratch_dir("preserve-manifest").join("m.json");
+        std::fs::write(
+            &preserve_path,
+            r#"{
+                "schema": "xai-dissect.manifest",
+                "schema_version": 1,
+                "model": {
+                    "family": "grok-1",
+                    "tensor_name_convention": "blk.{L}.{role}.weight"
+                },
+                "preserve": [ { "name": "blk.0.ffn_up.weight" } ]
+            }"#,
+        )
+        .unwrap();
+
+        // Manifest B: same tensor, but listed under `fp16`.
+        let fp16_path = scratch_dir("fp16-manifest").join("m.json");
+        std::fs::write(
+            &fp16_path,
+            r#"{
+                "schema": "xai-dissect.manifest",
+                "schema_version": 1,
+                "model": {
+                    "family": "grok-1",
+                    "tensor_name_convention": "blk.{L}.{role}.weight"
+                },
+                "fp16": [ { "name": "blk.0.ffn_up.weight" } ]
+            }"#,
+        )
+        .unwrap();
+
+        let out_preserve = scratch_dir("preserve-out").join("a.goz1");
+        let out_fp16 = scratch_dir("fp16-out").join("b.goz1");
+
+        let mut config = base_config(&dir, &out_preserve);
+        config.manifest_path = Some(preserve_path);
+        run_quantization(&config).expect("preserve-tier run");
+
+        let mut config = base_config(&dir, &out_fp16);
+        config.manifest_path = Some(fp16_path);
+        run_quantization(&config).expect("fp16-tier run");
+
+        let a = goz1_bytes(&out_preserve);
+        let b = goz1_bytes(&out_fp16);
+        if a != b {
+            let first_diff = a
+                .iter()
+                .zip(b.iter())
+                .position(|(x, y)| x != y)
+                .unwrap_or(a.len().min(b.len()));
+            panic!(
+                "Preserve and Fp16 tiers diverged: a.len={} b.len={} \
+                 first_diff_at={} a_byte={:?} b_byte={:?}. \
+                 In GOZ1 v1 they must emit identical FP16 bytes.",
+                a.len(),
+                b.len(),
+                first_diff,
+                a.get(first_diff),
+                b.get(first_diff),
+            );
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,20 +13,26 @@ pub enum TensorPrecision {
     TernarySnN,
     /// Keep original FP16 — used for MoE routing gates.
     Fp16,
-    /// Keep the tensor in its source dtype (routing-critical layers etc.).
+    /// Routing-critical / no-touch tier. Populated when the
+    /// `xai-dissect` manifest's `preserve` list matches a tensor
+    /// (typically MoE routers, expert gates, attention readouts).
     ///
-    /// **Reserved in phase 1.** This variant is declared so the
-    /// `xai-dissect` manifest contract can reference it, but it is **not
-    /// yet consumed** by [`crate::core::stream::run_quantization`]. A
-    /// follow-up PR will wire it through the selection / precision seams.
+    /// **GOZ1 v1 on-disk encoding:** identical FP16 bytes to
+    /// [`TensorPrecision::Fp16`] — both tiers serialize through the
+    /// same FP16 writer path and use `TENSOR_F16` in the GOZ1 tensor
+    /// table. This is the **final, documented behavior** for GOZ1 v1,
+    /// not a transitional shortcut.
     ///
-    /// **Temporary semantic shortcut:** during the transitional window
-    /// the wiring code may alias `Preserve` to FP16 passthrough. That
-    /// alias is explicitly temporary and must be removed once
-    /// source-dtype passthrough lands. See the phase 2/3 tracking issue.
-    //
-    // TODO(phase-3): remove any Preserve→FP16 alias once source-dtype
-    // passthrough is implemented in stream.rs + weight_pack.rs.
+    /// The variant is kept distinct from [`TensorPrecision::Fp16`] for
+    /// three reasons:
+    /// 1. **Manifest-intent traceability** — pipeline diagnostics can
+    ///    tell which manifest list claimed a tensor.
+    /// 2. **Policy guarantee** — `Preserve` signals "must never be
+    ///    ternary-quantized" even if a future policy change shifts the
+    ///    default for `Fp16`.
+    /// 3. **Forward compatibility** — a future GOZ1 format version may
+    ///    promote `Preserve` to true source-dtype passthrough
+    ///    (F32/BF16 kept as-is) without an API rename or migration.
     Preserve,
 }
 


### PR DESCRIPTION
## **User description**
Closes #6 (after this lands).

Phase 3 of the xai-dissect manifest integration. **Locks in the GOZ1-v1 behavior of `TensorPrecision::Preserve` as the final, documented semantic.**

## What this PR is (and is NOT)

This PR removes the *transitional framing* around `Preserve` (TODO(phase-3) comments, "reserved in phase 1", "temporary semantic shortcut", "transitional alias"). **It does NOT remove the shared FP16 on-disk encoding between `Preserve` and `Fp16` — that encoding is intentionally retained and is now documented as the final GOZ1-v1 behavior.**

## Final semantic (committed)

`TensorPrecision::Preserve` in GOZ1 v1:

- Remains a **distinct enum variant**.
- On disk: **identical FP16 bytes to `TensorPrecision::Fp16`**. Both tiers use `TENSOR_F16` in the GOZ1 tensor table.
- The distinction is **semantic, policy, and traceability** — not byte-layout:
  1. **Manifest-intent traceability** — pipeline diagnostics can tell which manifest list claimed a tensor.
  2. **Policy guarantee** — `Preserve` signals "must never be ternary-quantized" even if a future policy change shifts the default for `Fp16`.
  3. **Forward compatibility** — a future GOZ1 format version may promote `Preserve` to true source-dtype passthrough (F32/BF16 kept as-is) without an API rename or migration. That is **out of scope for this PR**.

## Code changes

- **`src/types.rs`** — rewrite the `TensorPrecision::Preserve` doc as final. Documents the FP16-at-rest encoding, the three reasons the variant is kept distinct, and the forward-compat door for a future GOZ1 format version.
- **`src/core/stream.rs`** — rename `ManifestEntry::uses_fp16_passthrough` → `emits_fp16_bytes` (precise, non-transitional). Rename `router_fp16_bytes` → `encode_fp16_bytes` (no longer router-specific). Delete both `TODO(phase-3)` comment blocks; replace with a one-line note explaining the shared encoding is by design.
- **`src/core/manifest.rs`** — refresh the `DissectManifest.preserve` field comment from "Reserved in phase 1; not yet consumed" to a description of the actual final wiring.
- **`src/core/precision.rs`** — tighten module-level doc to flag that `TensorClass::Preserve → TensorPrecision::Preserve` is FP16-at-rest in GOZ1 v1.
- **`docs/dissect-manifest.md`** — rewrite the `preserve` row of the Precision tiers table as the final GOZ1-v1 semantic, replacing the "transitional" framing.

## Tests

- **New:** `preserve_and_fp16_tiers_emit_identical_goz1_bytes` — builds two manifests (one listing the same tensor under `preserve`, the other under `fp16`) and asserts byte-identical GOZ1 output. Locks in the shared encoding so any future change must be deliberate.
- **Unchanged behavior:** all existing parity / divergence / precedence / env-var tests pass; only doc comments were updated where they referenced "transitional alias".
- **56 tests passing** (was 55 + 1 new regression).

## Verification

```
$ cargo test --lib
test result: ok. 56 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```
$ rg -n 'TODO\(phase-3\)|transitional alias|temporary alias|temporary semantic|aliased to FP16'
(no matches)
```

## What is NOT changed

- GOZ1 format — no new tensor type codes, no header changes.
- `weight_pack.rs` / `weight_pack_read.rs` — no writer/verifier surgery.
- `selection.rs` — `TensorClass::Preserve` was already correct.
- `dissect/grok-1/baseline.json` — unchanged.
- `xai-dissect` repo — untouched.
- No CLI, no `manifest.blocks` consumption, no `rank` ordering.

## After this lands

Issue #6 ("xai-dissect integration") can be closed cleanly. Recommend opening a separate tracking issue for any future GOZ1/GOZ2 source-dtype passthrough work — see closing comment on #6.


___

## **CodeAnt-AI Description**
Lock in `preserve` as a distinct tier with the same FP16 output as `fp16` in GOZ1 v1

### What Changed
- `preserve` is now documented as a final GOZ1 v1 behavior: it stays separate from `fp16`, but both produce identical FP16 bytes on disk
- Manifest and precision docs now describe `preserve` as routing-critical / no-touch, with clear reasons for keeping it distinct
- The manifest guide no longer describes `preserve` as reserved or transitional
- Added a regression test to ensure `preserve` and `fp16` continue to generate identical GOZ1 output

### Impact
`✅ Clearer preserve behavior`
`✅ Fewer manifest interpretation surprises`
`✅ Safer GOZ1 output stability`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=I0Mel681jTUYaEMeNAPHnRCopgiUQSUqsmNyBenzBD8&org=rmems)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
