### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pure Rust crate (no external services, databases, or Docker required).
+
+### Toolchain
+
+Requires Rust edition 2024 (Rust >= 1.85). The update script ensures the latest stable toolchain is installed.
+
+### Commands
+
+All CI-matching commands (see `.github/workflows/rust.yml`):
+
+| Task   | Command |
+|--------|---------|
+| Format | `cargo fmt --all -- --check` |
+| Lint   | `cargo clippy --all-targets --all-features -- -D warnings` |
+| Test   | `cargo test --all-targets --all-features` |
+| Build  | `cargo build --all-targets --all-features` |
+| Docs   | `cargo doc --no-deps --all-features` |
+
+### Running the CLI
+
+The binary requires the `cli` feature:
+
+```
+cargo run --features cli -- artifacts generate --manifest dissect/grok-1/baseline.json --output-dir /tmp/reports
+cargo run --features cli -- artifacts validate --report-dir /tmp/reports --manifest dissect/grok-1/baseline.json
+```
+
+### Notes
+
+- The crate uses edition 2024. If you see `edition is not supported` errors, run `rustup update stable`.
+- All tests are self-contained (no model weights needed). The embedded `dissect/grok-1/baseline.json` manifest is used as a fallback for testing.
+- The `cli` feature is not in the default feature set; use `--features cli` or `--all-features` to build/test the binary.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This is a pure Rust crate (no external services, databases, or Docker required).
 
 ### Toolchain
 
-Requires Rust edition 2024 (Rust >= 1.85). The update script ensures the latest stable toolchain is installed.
+Requires Rust edition 2024 (Rust >= 1.85). Ensure your toolchain is up to date using rustup.
 
 ### Commands
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included
- Toolchain requirements (Rust edition 2024, stable >= 1.85)
- CI-matching lint/test/build commands
- CLI usage examples with the embedded baseline manifest
- Non-obvious notes about the `cli` feature flag and edition 2024 compatibility

### Verification
All CI checks pass:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features` (63 tests pass)
- `cargo build --all-targets --all-features`
- `cargo doc --no-deps --all-features`

CLI demo (artifact generation and validation with baseline manifest):

[cli_demo.log](https://cursor.com/agents/bc-4eb3b553-d947-443a-bf84-55c3b5331d2a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_demo.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eb3b553-d947-443a-bf84-55c3b5331d2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eb3b553-d947-443a-bf84-55c3b5331d2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

