### PR TITLE
research: embedding τ sweeps for spiking-sparse GOZ1 (#51 / RM-201)

### DIFF
--- a/reports/grok-1-tau-sweep/results.md
+++ b/reports/grok-1-tau-sweep/results.md
@@ -100,15 +100,16 @@ quantize-goz1 --manifest dissect/grok-1/baseline.json --gif-threshold 0.5 ...
 → oz.gif_threshold = 0.05        # pack metadata records what actually applied
 ```
 
-**Rule for sweeps:** use a manifest without `defaults.gif_threshold` (then the
-CLI flag controls the multiplier), or bake the per-run value into `defaults`.
-The driver script (`scripts/tau_sweep_embedding.sh`) derives such a manifest
-from `baseline.json` at runtime; nothing under `dissect/` is modified
-(xai-dissect stays authoritative).
+**Rule for sweeps:** strip **both** `defaults.gif_threshold` **and** any
+`ternary_candidates[].gif_threshold` (per-tensor wins over defaults and CLI;
+`oz.gif_threshold` metadata only records defaults||config, so it cannot detect
+per-tensor overrides). The driver derives such a manifest from `baseline.json`
+at runtime; nothing under `dissect/` is modified (xai-dissect stays authoritative).
 **Always check `oz.gif_threshold` in the pack metadata** — it records the
-effective baseline multiplier, which is how you catch this trap after the fact.
+effective baseline multiplier for the defaults/CLI path.
 The sweep driver (`scripts/tau_sweep_embedding.sh`) **fails the run** if pack
-metadata does not match the requested TAU or if any invalid trit codes appear.
+metadata does not match the requested TAU (compared at CLI `f32` precision) or
+if any invalid trit codes appear.
 
 ## Second tensor family: blocked-by-export (evidence)
 

--- a/reports/grok-1-tau-sweep/results.md
+++ b/reports/grok-1-tau-sweep/results.md
@@ -107,6 +107,8 @@ from `baseline.json` at runtime; nothing under `dissect/` is modified
 (xai-dissect stays authoritative).
 **Always check `oz.gif_threshold` in the pack metadata** — it records the
 effective baseline multiplier, which is how you catch this trap after the fact.
+The sweep driver (`scripts/tau_sweep_embedding.sh`) **fails the run** if pack
+metadata does not match the requested TAU or if any invalid trit codes appear.
 
 ## Second tensor family: blocked-by-export (evidence)
 

--- a/reports/grok-1-tau-sweep/results.md
+++ b/reports/grok-1-tau-sweep/results.md
@@ -1,0 +1,186 @@
+# Grok-1 embedding τ (gif_threshold) sweep — spiking-sparse GOZ1
+
+- **GitHub:** #51
+- **Linear:** RM-201
+- **Host:** ShipOfTheseus (32 cores, 60 GiB RAM)
+- **Date:** 2026-08-01
+- **Agent:** Claude Fable 5
+- **Branch:** `claude/fable5-51-tau-sweep`
+
+## Question
+
+GH #39 / RM-190 packed `embedding.slot_00.token_embedding` at the default
+`gif_threshold = 0.05` and got ~4.17% zeros — a **dense, sign-like** pack, not
+spiking-sparse activity. Is that the weight distribution or the knob? Answer:
+**the knob.** This report sweeps τ on the real embedding, measures exact trit
+histograms by reading the GOZ1 packs back, and maps τ → sparsity so the next
+multi-tensor run can *choose* its sparsity regime.
+
+## Target
+
+| Field | Value |
+|-------|--------|
+| Logical tensor | `embedding.slot_00.token_embedding` |
+| Shape / dtype | `(131072, 6144)` f32 — 805,306,368 elements |
+| Source | `~/.models/xai-grok-1/ckpt-0/tensor00000_000` (official pickle → `.npy` via `scripts/export_grok1_embedding_npy.py`) |
+| Quantizer | `τ = gif_threshold × rms`; `|w| < τ → 0`, `w ≥ τ → +1`, `w ≤ −τ → −1` (`src/core/quantizer.rs`) |
+| Compute path | CPU `quantizer::quantize_f32` via `run_quantization` / `quantize-goz1` — no myelin / CUDA |
+| Measurement | `scripts/goz1_trit_histogram.py` (new; stdlib-only GOZ1 readback, exact trit counts) |
+| Weight rms | 0.012758015 (f64 accumulation over all elements) |
+| Tail shape | kurtosis 3.60 (Gaussian = 3.0) → near-Gaussian, slightly heavy-tailed |
+
+## Sweep results (measured from packs)
+
+Each row is one `quantize-goz1` run against a manifest **without**
+`defaults.gif_threshold` (see trap below), `--input-format npy --verify`,
+followed by exact trit counts from GOZ1 readback. GNU time 1.9 (`/usr/bin/time -v`).
+
+| τ | zeros | zeros % | +1 % | −1 % | Gaussian pred. % | pack bytes | wall | max RSS |
+|-----|------------|---------|---------|---------|---------|-------------|---------|---------|
+| 0.0 | 0 | 0.0000 | 49.7377 | 50.2623 | 0.0000 | 201,327,136 | 5.73 s | 6.17 GiB |
+| 0.05 | 33,567,192 | 4.1683 | 47.6529 | 48.1788 | 3.9878 | 201,327,136 | 5.96 s | 6.19 GiB |
+| 0.1 | 67,043,353 | 8.3252 | 45.5760 | 46.0988 | 7.9656 | 201,327,136 | 6.17 s | 6.19 GiB |
+| 0.2 | 133,281,944 | 16.5505 | 41.4683 | 41.9812 | 15.8519 | 201,327,136 | 6.62 s | 6.18 GiB |
+| 0.3 | 197,917,581 | 24.5767 | 37.4624 | 37.9610 | 23.5823 | 201,327,136 | 6.65 s | 6.19 GiB |
+| 0.5 | 319,850,852 | 39.7179 | 29.9150 | 30.3671 | 38.2925 | 201,327,136 | 7.14 s | 6.19 GiB |
+| 0.7 | 428,572,307 | 53.2185 | 23.1931 | 23.5884 | 51.6073 | 201,327,136 | 7.01 s | 6.18 GiB |
+| 1.0 | 561,416,253 | 69.7146 | 14.9950 | 15.2903 | 68.2689 | 201,327,136 | 4.84 s | 6.19 GiB |
+
+Validation:
+
+- **τ = 0.0 control**: exactly 0 zeros — pure sign pack (`w ≥ 0 → +1`), as the
+  gate predicts. The +1/−1 split (49.74/50.26) shows a slight negative skew.
+- **τ = 0.05 control**: 4.1683% zeros and `file_size=201327136` — reproduces
+  GH #39 exactly, validating the new histogram script against known ground truth.
+- Trit totals equal 805,306,368 and invalid `0b11` codes are 0 in every pack.
+- An independent npy-side prediction (numpy, chunked `P(|w| < τ·rms)`) matches
+  the pack-side measurement to 4 decimal places at **all eight** τ values.
+- Pack size is τ-independent by design (2 bits/trit regardless of value);
+  sparsity is a *kernel-side* win (event-driven skip), not a *storage* win in GOZ1 v1.
+- `oz.gif_threshold` pack metadata matched the CLI τ in every sweep run.
+
+### τ → sparsity map (from |w|/rms quantiles, 1e-4 bin resolution)
+
+| target zeros | required τ |
+|--------------|------------|
+| 25% | ≈ 0.31 |
+| 50% | ≈ 0.65 |
+| 75% | ≈ 1.12 |
+| 90% | ≈ 1.63 |
+| 95% | ≈ 1.97 |
+
+The embedding is near-Gaussian, so `zeros(τ) ≈ erf(τ/√2)` is a good first-order
+model (measured runs ~0.2–1.5 pp above Gaussian; heavier-than-Gaussian center).
+
+## ⚠ The manifest τ trap (documented + demonstrated)
+
+Threshold precedence in `src/core/precision.rs::resolve_threshold`:
+
+1. per-tensor `gif_threshold` on a `ternary_candidates` entry
+2. **`manifest.defaults.gif_threshold`** ← `dissect/grok-1/baseline.json` bakes `0.05` here
+3. `config.gif_threshold` (CLI `--gif-threshold`)
+
+So with the stock baseline manifest, **CLI `--gif-threshold` is silently
+ignored**. Demonstrated live:
+
+```text
+quantize-goz1 --manifest dissect/grok-1/baseline.json --gif-threshold 0.5 ...
+→ zeros = 33,567,192 (4.1683%)   # identical, trit-for-trit, to τ=0.05
+→ oz.gif_threshold = 0.05        # pack metadata records what actually applied
+```
+
+**Rule for sweeps:** use a manifest without `defaults.gif_threshold` (then the
+CLI flag controls τ), or bake the per-run τ into `defaults`. The driver script
+(`scripts/tau_sweep_embedding.sh`) derives such a manifest from `baseline.json`
+at runtime; nothing under `dissect/` is modified (xai-dissect stays authoritative).
+**Always check `oz.gif_threshold` in the pack metadata** — it records the
+effective baseline τ, which is how you catch this trap after the fact.
+
+## Second tensor family: blocked-by-export (evidence)
+
+`xai-dissect dissect` over official ckpt-0 shards shows **no f32/bf16 expert or
+attention weights exist in the checkpoint** — the official Grok-1 release ships
+them 8-bit quantized:
+
+| Shard | Role | Dtype | Shape | Interpretation |
+|-------|------|-------|-------|----------------|
+| `tensor00000_000` | tensor | f32 | (131072, 6144) | token embedding (swept above) |
+| `tensor00001_000` | tensor | f32 | (6144,) | norm/scale vector (preserve-tier) |
+| `tensor00002_000` | quant.weight | **int8** | (8, 6144, 32768) | MoE expert up-proj, 8 experts |
+| `tensor00003_000` | quant.weight | **int8** | (8, 32768, 6144) | MoE expert down-proj |
+| `tensor00005_000` | quant.weight | **int8** | (6144, 1024) | attention proj (kv-width) |
+| `tensor00006_000` | quant.weight | **int8** | (6144, 6144) | attention proj (full-width) |
+| `tensor00013_000` | tensor | f32 | (6144, 8) | MoE router — **preserve, never ternary** |
+
+Blockers, precisely:
+
+1. `scripts/export_grok1_embedding_npy.py` is f32-only by design (stdlib, one
+   tensor per invocation) — it cannot export int8 payloads.
+2. Even with an exporter, the float-only stream path rejects int8
+   (`stream.rs`: unsupported dtype; int8 arrives via artifact wrapping, not
+   quantization).
+3. Meaningful GIF-ternary on experts requires **dequantized** values
+   (int8 × scale → f32) — a new export capability, out of scope here.
+
+The only other exportable f32 matrix is the router, and router ternary is an
+explicit non-goal (#51) — routing readout must stay preserve.
+
+## Per-tier τ policy draft (input to #48 / RM-196)
+
+| Tier | Recommendation | Rationale |
+|------|----------------|-----------|
+| Embedding | Dense sign-like is *acceptable* (τ ∈ [0, 0.05]) **unless** event-driven embedding lookup is the goal; then τ ≈ 0.65 for ~50% zeros. | Embedding rows are read once per token (lookup, not GEMV); sparsity buys little compute unless the runtime skips zero trits inside fused kernels. Sign information is the dominant signal. |
+| MoE experts | Target **event-driven**: τ for 50–75% zeros (≈ 0.65–1.12 *if* expert weights are near-Gaussian — must be re-measured after dequant export; official weights are int8). | Experts dominate FLOPs and memory traffic; zero-skipping GEMV is where spiking-sparse pays. Per-expert rms (slice of the (8, …) tensor) rather than whole-tensor rms should be evaluated. |
+| Attention proj | Intermediate: start τ ≈ 0.3–0.5 (25–40% zeros) and validate quality before pushing higher. | Attention is more sensitive to weight perturbation than MoE experts in most PTQ literature; be conservative until measured. |
+| Router / gates | **Preserve (fp16). Never ternary. No τ.** | Routing decisions collapse under sign-only weights; explicit non-goal. |
+| Norm/scale vectors | Preserve. | Tiny (6144 floats), quality-critical. |
+
+**When is dense sign-like OK?** When the consumer is a dense ternary kernel
+(sign-GEMV) or a lookup — compression is already 16× and zeros add nothing.
+**When is sparsity required?** When the runtime is event-driven (skip zero
+trits): then zeros% is the compute-reduction knob, and τ should be *chosen per
+tier from a target sparsity*, not left at the 0.05 legacy default. The
+`defaults.gif_threshold: 0.05` in `baseline.json` should be treated as a
+sign-pack default, not an SNN default.
+
+Caveats: these τ values are calibrated on the **embedding** distribution
+(near-Gaussian, kurtosis 3.6). Expert/attention distributions may differ —
+re-run this sweep per tier once a dequant export exists. No quality (perplexity
+/ downstream) claims are made here; this is distribution + packing science only.
+
+## Reproduce
+
+```bash
+cargo build --release --features cli --locked
+
+# Full sweep (export → 8 packs → histograms); packs+logs under
+# ~/.models/xai-grok-1/artifacts/tau-sweep/, stage cleaned up on exit
+scripts/tau_sweep_embedding.sh
+# or e.g.: TAUS="0.05 0.65" scripts/tau_sweep_embedding.sh
+
+# Exact trit histogram of any GOZ1 pack
+python3 scripts/goz1_trit_histogram.py PACK.goz1 [--json]
+
+# Trap demo (CLI τ ignored under stock baseline manifest)
+target/release/grok-ozempic quantize-goz1 \
+  --input-dir ~/.models/xai-grok-1/export-npy \
+  --output /tmp/trap-demo.goz1 \
+  --manifest dissect/grok-1/baseline.json \
+  --input-format npy --gif-threshold 0.5 --verify
+python3 scripts/goz1_trit_histogram.py /tmp/trap-demo.goz1   # → 4.1683%, oz.gif_threshold=0.05
+```
+
+The rms/kurtosis/τ-quantile numbers came from a one-off chunked numpy pass over
+the exported npy (`np.load(..., mmap_mode="r")`; f64 accumulation for `Σw²`,
+`Σw⁴`; 160,000-bin histogram of `|w|/rms` on `[0, 16)` for quantiles) — numpy
+is a host-side analysis convenience only, not a pipeline dependency.
+
+## Relation to open work
+
+- **#48 / RM-196 (multi-tensor epic):** per-tier τ table above is the policy
+  input; expert/attention sweeps are blocked on an int8-dequant export step.
+- **#40 / RM-191 (V2 name bridge):** untouched here. Note the trap compounds
+  with #40's risk: a preserve-name mismatch would send routers into default
+  ternary *at whatever τ defaults carry* — both bugs hide in `defaults`.
+- Packs (8 × 192 MiB) and logs remain under
+  `~/.models/xai-grok-1/artifacts/tau-sweep/` — host-only, never committed.

--- a/reports/grok-1-tau-sweep/results.md
+++ b/reports/grok-1-tau-sweep/results.md
@@ -23,7 +23,7 @@ multi-tensor run can *choose* its sparsity regime.
 | Logical tensor | `embedding.slot_00.token_embedding` |
 | Shape / dtype | `(131072, 6144)` f32 — 805,306,368 elements |
 | Source | `~/.models/xai-grok-1/ckpt-0/tensor00000_000` (official pickle → `.npy` via `scripts/export_grok1_embedding_npy.py`) |
-| Quantizer | `τ = gif_threshold × rms`; `|w| < τ → 0`, `w ≥ τ → +1`, `w ≤ −τ → −1` (`src/core/quantizer.rs`) |
+| Quantizer | weight-space `τ = gif_threshold × rms`; `abs(w) < τ → 0`, `w ≥ τ → +1`, `w ≤ −τ → −1` (`src/core/quantizer.rs`) |
 | Compute path | CPU `quantizer::quantize_f32` via `run_quantization` / `quantize-goz1` — no myelin / CUDA |
 | Measurement | `scripts/goz1_trit_histogram.py` (new; stdlib-only GOZ1 readback, exact trit counts) |
 | Weight rms | 0.012758015 (f64 accumulation over all elements) |
@@ -31,11 +31,17 @@ multi-tensor run can *choose* its sparsity regime.
 
 ## Sweep results (measured from packs)
 
+**Notation:** columns labeled `gif_threshold` are the dimensionless CLI /
+manifest multiplier (`--gif-threshold`). The actual weight-space firing
+threshold is `τ = gif_threshold × rms` (for this embedding,
+`rms ≈ 0.012758`, so `gif_threshold = 0.65` ⇒ `τ ≈ 0.00829`). Tables below
+report the CLI multiplier unless stated otherwise.
+
 Each row is one `quantize-goz1` run against a manifest **without**
 `defaults.gif_threshold` (see trap below), `--input-format npy --verify`,
 followed by exact trit counts from GOZ1 readback. GNU time 1.9 (`/usr/bin/time -v`).
 
-| τ | zeros | zeros % | +1 % | −1 % | Gaussian pred. % | pack bytes | wall | max RSS |
+| gif_threshold | zeros | zeros % | +1 % | −1 % | Gaussian pred. % | pack bytes | wall | max RSS |
 |-----|------------|---------|---------|---------|---------|-------------|---------|---------|
 | 0.0 | 0 | 0.0000 | 49.7377 | 50.2623 | 0.0000 | 201,327,136 | 5.73 s | 6.17 GiB |
 | 0.05 | 33,567,192 | 4.1683 | 47.6529 | 48.1788 | 3.9878 | 201,327,136 | 5.96 s | 6.19 GiB |
@@ -48,20 +54,24 @@ followed by exact trit counts from GOZ1 readback. GNU time 1.9 (`/usr/bin/time -
 
 Validation:
 
-- **τ = 0.0 control**: exactly 0 zeros — pure sign pack (`w ≥ 0 → +1`), as the
-  gate predicts. The +1/−1 split (49.74/50.26) shows a slight negative skew.
-- **τ = 0.05 control**: 4.1683% zeros and `file_size=201327136` — reproduces
-  GH #39 exactly, validating the new histogram script against known ground truth.
+- **gif_threshold = 0.0 control**: exactly 0 zeros — pure sign pack
+  (`w ≥ 0 → +1`), as the gate predicts. The +1/−1 split (49.74/50.26) shows a
+  slight negative skew.
+- **gif_threshold = 0.05 control**: 4.1683% zeros and `file_size=201327136` —
+  reproduces GH #39 exactly, validating the new histogram script against known
+  ground truth.
 - Trit totals equal 805,306,368 and invalid `0b11` codes are 0 in every pack.
-- An independent npy-side prediction (numpy, chunked `P(|w| < τ·rms)`) matches
-  the pack-side measurement to 4 decimal places at **all eight** τ values.
-- Pack size is τ-independent by design (2 bits/trit regardless of value);
-  sparsity is a *kernel-side* win (event-driven skip), not a *storage* win in GOZ1 v1.
-- `oz.gif_threshold` pack metadata matched the CLI τ in every sweep run.
+- An independent npy-side prediction (numpy, chunked
+  `P(abs(w) < gif_threshold·rms)`) matches the pack-side measurement to 4
+  decimal places at **all eight** gif_threshold values.
+- Pack size is gif_threshold-independent by design (2 bits/trit regardless of
+  value); sparsity is a *kernel-side* win (event-driven skip), not a *storage*
+  win in GOZ1 v1.
+- `oz.gif_threshold` pack metadata matched the CLI multiplier in every sweep run.
 
-### τ → sparsity map (from |w|/rms quantiles, 1e-4 bin resolution)
+### gif_threshold → sparsity map (from abs(w)/rms quantiles, 1e-4 bin resolution)
 
-| target zeros | required τ |
+| target zeros | required gif_threshold |
 |--------------|------------|
 | 25% | ≈ 0.31 |
 | 50% | ≈ 0.65 |
@@ -69,8 +79,9 @@ Validation:
 | 90% | ≈ 1.63 |
 | 95% | ≈ 1.97 |
 
-The embedding is near-Gaussian, so `zeros(τ) ≈ erf(τ/√2)` is a good first-order
-model (measured runs ~0.2–1.5 pp above Gaussian; heavier-than-Gaussian center).
+The embedding is near-Gaussian, so
+`zeros(gif_threshold) ≈ erf(gif_threshold/√2)` is a good first-order model
+(measured runs ~0.2–1.5 pp above Gaussian; heavier-than-Gaussian center).
 
 ## ⚠ The manifest τ trap (documented + demonstrated)
 
@@ -85,16 +96,17 @@ ignored**. Demonstrated live:
 
 ```text
 quantize-goz1 --manifest dissect/grok-1/baseline.json --gif-threshold 0.5 ...
-→ zeros = 33,567,192 (4.1683%)   # identical, trit-for-trit, to τ=0.05
+→ zeros = 33,567,192 (4.1683%)   # identical, trit-for-trit, to gif_threshold=0.05
 → oz.gif_threshold = 0.05        # pack metadata records what actually applied
 ```
 
 **Rule for sweeps:** use a manifest without `defaults.gif_threshold` (then the
-CLI flag controls τ), or bake the per-run τ into `defaults`. The driver script
-(`scripts/tau_sweep_embedding.sh`) derives such a manifest from `baseline.json`
-at runtime; nothing under `dissect/` is modified (xai-dissect stays authoritative).
+CLI flag controls the multiplier), or bake the per-run value into `defaults`.
+The driver script (`scripts/tau_sweep_embedding.sh`) derives such a manifest
+from `baseline.json` at runtime; nothing under `dissect/` is modified
+(xai-dissect stays authoritative).
 **Always check `oz.gif_threshold` in the pack metadata** — it records the
-effective baseline τ, which is how you catch this trap after the fact.
+effective baseline multiplier, which is how you catch this trap after the fact.
 
 ## Second tensor family: blocked-by-export (evidence)
 
@@ -129,24 +141,25 @@ explicit non-goal (#51) — routing readout must stay preserve.
 
 | Tier | Recommendation | Rationale |
 |------|----------------|-----------|
-| Embedding | Dense sign-like is *acceptable* (τ ∈ [0, 0.05]) **unless** event-driven embedding lookup is the goal; then τ ≈ 0.65 for ~50% zeros. | Embedding rows are read once per token (lookup, not GEMV); sparsity buys little compute unless the runtime skips zero trits inside fused kernels. Sign information is the dominant signal. |
-| MoE experts | Target **event-driven**: τ for 50–75% zeros (≈ 0.65–1.12 *if* expert weights are near-Gaussian — must be re-measured after dequant export; official weights are int8). | Experts dominate FLOPs and memory traffic; zero-skipping GEMV is where spiking-sparse pays. Per-expert rms (slice of the (8, …) tensor) rather than whole-tensor rms should be evaluated. |
-| Attention proj | Intermediate: start τ ≈ 0.3–0.5 (25–40% zeros) and validate quality before pushing higher. | Attention is more sensitive to weight perturbation than MoE experts in most PTQ literature; be conservative until measured. |
-| Router / gates | **Preserve (fp16). Never ternary. No τ.** | Routing decisions collapse under sign-only weights; explicit non-goal. |
+| Embedding | Dense sign-like is *acceptable* (gif_threshold ∈ [0, 0.05]) **unless** event-driven embedding lookup is the goal; then gif_threshold ≈ 0.65 for ~50% zeros. | Embedding rows are read once per token (lookup, not GEMV); sparsity buys little compute unless the runtime skips zero trits inside fused kernels. Sign information is the dominant signal. |
+| MoE experts | Target **event-driven**: gif_threshold for 50–75% zeros (≈ 0.65–1.12 *if* expert weights are near-Gaussian — must be re-measured after dequant export; official weights are int8). | Experts dominate FLOPs and memory traffic; zero-skipping GEMV is where spiking-sparse pays. Per-expert rms (slice of the (8, …) tensor) rather than whole-tensor rms should be evaluated. |
+| Attention proj | Intermediate: start gif_threshold ≈ 0.3–0.5 (25–40% zeros) and validate quality before pushing higher. | Attention is more sensitive to weight perturbation than MoE experts in most PTQ literature; be conservative until measured. |
+| Router / gates | **Preserve (fp16). Never ternary. No gif_threshold.** | Routing decisions collapse under sign-only weights; explicit non-goal. |
 | Norm/scale vectors | Preserve. | Tiny (6144 floats), quality-critical. |
 
 **When is dense sign-like OK?** When the consumer is a dense ternary kernel
 (sign-GEMV) or a lookup — compression is already 16× and zeros add nothing.
 **When is sparsity required?** When the runtime is event-driven (skip zero
-trits): then zeros% is the compute-reduction knob, and τ should be *chosen per
-tier from a target sparsity*, not left at the 0.05 legacy default. The
-`defaults.gif_threshold: 0.05` in `baseline.json` should be treated as a
+trits): then zeros% is the compute-reduction knob, and gif_threshold should be
+*chosen per tier from a target sparsity*, not left at the 0.05 legacy default.
+The `defaults.gif_threshold: 0.05` in `baseline.json` should be treated as a
 sign-pack default, not an SNN default.
 
-Caveats: these τ values are calibrated on the **embedding** distribution
-(near-Gaussian, kurtosis 3.6). Expert/attention distributions may differ —
-re-run this sweep per tier once a dequant export exists. No quality (perplexity
-/ downstream) claims are made here; this is distribution + packing science only.
+Caveats: these gif_threshold values are calibrated on the **embedding**
+distribution (near-Gaussian, kurtosis 3.6). Expert/attention distributions may
+differ — re-run this sweep per tier once a dequant export exists. No quality
+(perplexity / downstream) claims are made here; this is distribution + packing
+science only.
 
 ## Reproduce
 
@@ -160,8 +173,10 @@ scripts/tau_sweep_embedding.sh
 
 # Exact trit histogram of any GOZ1 pack
 python3 scripts/goz1_trit_histogram.py PACK.goz1 [--json]
+# human + JSON artifact from one analysis:
+# python3 scripts/goz1_trit_histogram.py PACK.goz1 --json-out hist.json
 
-# Trap demo (CLI τ ignored under stock baseline manifest)
+# Trap demo (CLI gif_threshold ignored under stock baseline manifest)
 target/release/grok-ozempic quantize-goz1 \
   --input-dir ~/.models/xai-grok-1/export-npy \
   --output /tmp/trap-demo.goz1 \
@@ -170,17 +185,20 @@ target/release/grok-ozempic quantize-goz1 \
 python3 scripts/goz1_trit_histogram.py /tmp/trap-demo.goz1   # → 4.1683%, oz.gif_threshold=0.05
 ```
 
-The rms/kurtosis/τ-quantile numbers came from a one-off chunked numpy pass over
-the exported npy (`np.load(..., mmap_mode="r")`; f64 accumulation for `Σw²`,
-`Σw⁴`; 160,000-bin histogram of `|w|/rms` on `[0, 16)` for quantiles) — numpy
-is a host-side analysis convenience only, not a pipeline dependency.
+The rms/kurtosis/gif_threshold-quantile numbers came from a one-off chunked
+numpy pass over the exported npy (`np.load(..., mmap_mode="r")`; f64
+accumulation for `Σw²`, `Σw⁴`; 160,000-bin histogram of `abs(w)/rms` on
+`[0, 16)` for quantiles) — numpy is a host-side analysis convenience only, not
+a pipeline dependency.
 
 ## Relation to open work
 
-- **#48 / RM-196 (multi-tensor epic):** per-tier τ table above is the policy
-  input; expert/attention sweeps are blocked on an int8-dequant export step.
+- **#48 / RM-196 (multi-tensor epic):** per-tier gif_threshold table above is
+  the policy input; expert/attention sweeps are blocked on an int8-dequant
+  export step.
 - **#40 / RM-191 (V2 name bridge):** untouched here. Note the trap compounds
   with #40's risk: a preserve-name mismatch would send routers into default
-  ternary *at whatever τ defaults carry* — both bugs hide in `defaults`.
+  ternary *at whatever gif_threshold defaults carry* — both bugs hide in
+  `defaults`.
 - Packs (8 × 192 MiB) and logs remain under
   `~/.models/xai-grok-1/artifacts/tau-sweep/` — host-only, never committed.

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -131,6 +131,35 @@ def _num_elements(shape: list[int]) -> int:
     return n
 
 
+def _apply_lut_counts(
+    chunk: bytes, zeros: int, pos: int, neg: int, invalid: int
+) -> tuple[int, int, int, int]:
+    """Accumulate trit totals for full payload bytes via the 4-trit LUT."""
+    for value, count in Counter(chunk).items():
+        z, p, m, bad = _LUT[value]
+        zeros += z * count
+        pos += p * count
+        neg += m * count
+        invalid += bad * count
+    return zeros, pos, neg, invalid
+
+
+def _count_trailing_trits(last_byte: int, n_trits: int) -> tuple[int, int, int, int]:
+    """Decode the final partial byte (1–3 LSB-first trits); ignore pad bits."""
+    zeros = pos = neg = invalid = 0
+    for i in range(n_trits):
+        t = (last_byte >> (2 * i)) & 0b11
+        if t == 0b00:
+            zeros += 1
+        elif t == 0b01:
+            pos += 1
+        elif t == 0b10:
+            neg += 1
+        else:
+            invalid += 1
+    return zeros, pos, neg, invalid
+
+
 def histogram_ternary(f, abs_offset: int, n_elements: int) -> dict[str, int]:
     """Count trits for one ternary blob of ``n_elements`` values."""
     nbytes = (n_elements + 3) // 4
@@ -138,31 +167,43 @@ def histogram_ternary(f, abs_offset: int, n_elements: int) -> dict[str, int]:
     zeros = pos = neg = invalid = 0
     remaining = nbytes
     last_byte: int | None = None
+    pad = n_elements % 4
     while remaining > 0:
         chunk = _read_exact(f, min(CHUNK, remaining))
         remaining -= len(chunk)
-        if remaining == 0 and n_elements % 4 != 0:
+        if remaining == 0 and pad != 0:
             last_byte = chunk[-1]
             chunk = chunk[:-1]
-        # Single-pass byte frequencies (avoids re-scanning the chunk per unique value).
-        for value, count in Counter(chunk).items():
-            z, p, m, bad = _LUT[value]
-            zeros += z * count
-            pos += p * count
-            neg += m * count
-            invalid += bad * count
+        zeros, pos, neg, invalid = _apply_lut_counts(chunk, zeros, pos, neg, invalid)
     if last_byte is not None:
-        for i in range(n_elements % 4):
-            t = (last_byte >> (2 * i)) & 0b11
-            if t == 0b00:
-                zeros += 1
-            elif t == 0b01:
-                pos += 1
-            elif t == 0b10:
-                neg += 1
-            else:
-                invalid += 1
+        z, p, m, bad = _count_trailing_trits(last_byte, pad)
+        zeros += z
+        pos += p
+        neg += m
+        invalid += bad
     return {"zeros": zeros, "pos": pos, "neg": neg, "invalid": invalid}
+
+
+def _type_name(tensor_type: int, name: str) -> str:
+    if tensor_type == TENSOR_TERNARY:
+        return "ternary"
+    if tensor_type == TENSOR_F16:
+        return "f16"
+    raise Goz1Error(
+        f"unsupported tensor_type {tensor_type} for {name} "
+        f"(expected {TENSOR_F16}=f16 or {TENSOR_TERNARY}=ternary)"
+    )
+
+
+def _analyze_ternary(f, abs_offset: int, name: str, n: int) -> dict[str, object]:
+    hist = histogram_ternary(f, abs_offset, n)
+    total = hist["zeros"] + hist["pos"] + hist["neg"] + hist["invalid"]
+    if total != n:
+        raise Goz1Error(f"trit count {total} != num_elements {n} for {name}")
+    return {
+        "histogram": hist,
+        "sparsity": hist["zeros"] / n if n else 1.0,
+    }
 
 
 def analyze(path: Path) -> dict:
@@ -171,31 +212,16 @@ def analyze(path: Path) -> dict:
         out_tensors = []
         for t in tensors:
             n = _num_elements(t["shape"])
-            tt = t["tensor_type"]
-            if tt == TENSOR_TERNARY:
-                type_name = "ternary"
-            elif tt == TENSOR_F16:
-                type_name = "f16"
-            else:
-                raise Goz1Error(
-                    f"unsupported tensor_type {tt} for {t['name']} "
-                    f"(expected {TENSOR_F16}=f16 or {TENSOR_TERNARY}=ternary)"
-                )
             entry: dict[str, object] = {
                 "name": t["name"],
                 "shape": t["shape"],
                 "num_elements": n,
-                "type": type_name,
+                "type": _type_name(t["tensor_type"], t["name"]),
             }
-            if tt == TENSOR_TERNARY:
-                hist = histogram_ternary(f, data_start + t["data_offset"], n)
-                total = hist["zeros"] + hist["pos"] + hist["neg"] + hist["invalid"]
-                if total != n:
-                    raise Goz1Error(
-                        f"trit count {total} != num_elements {n} for {t['name']}"
-                    )
-                entry["histogram"] = hist
-                entry["sparsity"] = hist["zeros"] / n if n else 1.0
+            if t["tensor_type"] == TENSOR_TERNARY:
+                entry.update(
+                    _analyze_ternary(f, data_start + t["data_offset"], t["name"], n)
+                )
             out_tensors.append(entry)
     return {
         "file": str(path),
@@ -206,31 +232,34 @@ def analyze(path: Path) -> dict:
     }
 
 
+def _print_ternary_human(t: dict) -> None:
+    shape = "x".join(str(d) for d in t["shape"])
+    h = t["histogram"]
+    n = t["num_elements"]
+    print(f"  {t['name']}  [{shape}]  n={n}")
+    if n == 0:
+        inv = f"  INVALID={h['invalid']}" if h["invalid"] else ""
+        print(f"    empty tensor (zeros=0, +1=0, -1=0); sparsity=1.0 by convention{inv}")
+        return
+    inv = f"  INVALID={h['invalid']}" if h["invalid"] else ""
+    print(
+        f"    zeros={h['zeros']} ({100.0 * h['zeros'] / n:.4f}%)  "
+        f"+1={h['pos']} ({100.0 * h['pos'] / n:.4f}%)  "
+        f"-1={h['neg']} ({100.0 * h['neg'] / n:.4f}%){inv}"
+    )
+
+
 def _print_human(result: dict) -> None:
     print(f"{result['file']}  ({result['file_size']} bytes, version {result['version']})")
     gif = result["metadata"].get("oz.gif_threshold")
     if gif is not None:
         print(f"  oz.gif_threshold = {gif}")
     for t in result["tensors"]:
-        shape = "x".join(str(d) for d in t["shape"])
         if t["type"] != "ternary":
+            shape = "x".join(str(d) for d in t["shape"])
             print(f"  {t['name']}  [{shape}]  f16/preserve (not histogrammed)")
             continue
-        h = t["histogram"]
-        n = t["num_elements"]
-        print(f"  {t['name']}  [{shape}]  n={n}")
-        if n == 0:
-            print(
-                "    empty tensor (zeros=0, +1=0, -1=0); sparsity=1.0 by convention"
-                + (f"  INVALID={h['invalid']}" if h["invalid"] else "")
-            )
-            continue
-        print(
-            f"    zeros={h['zeros']} ({100.0 * h['zeros'] / n:.4f}%)  "
-            f"+1={h['pos']} ({100.0 * h['pos'] / n:.4f}%)  "
-            f"-1={h['neg']} ({100.0 * h['neg'] / n:.4f}%)"
-            + (f"  INVALID={h['invalid']}" if h["invalid"] else "")
-        )
+        _print_ternary_human(t)
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Trit histogram for GOZ1 packed checkpoints (GH #51 / Linear RM-201).
+
+Reads a ``.goz1`` file produced by ``quantize-goz1`` / ``run_quantization``
+and reports, per ``TENSOR_TERNARY`` tensor, the exact counts of 0 / +1 / -1
+trits — i.e. the measured sparsity of the GIF ternary gate. FP16/preserve
+tensors are listed but not histogrammed.
+
+Layout mirrors ``src/core/weight_pack.rs`` / ``weight_pack_read.rs``:
+
+* magic ``GOZ1`` (LE u32), version u32, tensor_count u64, meta_count u64
+* metadata entries: key (u64 len + utf8), vtype u32 (0=u32, 1=str), value
+* tensor table: name (u64 len + utf8), ndim u32, dims u64*ndim,
+  tensor_type u32 (0=f16, 1=ternary), data_offset u64 (relative)
+* header padded to DATA_ALIGNMENT=32; each blob padded to 32 too
+* ternary payload: 2 bits per trit, 4 per byte, LSB-first;
+  0b00=0, 0b01=+1, 0b10=-1; final byte zero-padded
+
+Stdlib-only (project convention for scripts/). Usage::
+
+    python3 scripts/goz1_trit_histogram.py PACK.goz1 [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+from pathlib import Path
+
+DATA_ALIGNMENT = 32
+META_U32 = 0
+META_STR = 1
+TENSOR_F16 = 0
+TENSOR_TERNARY = 1
+MAGIC = b"GOZ1"
+CHUNK = 64 * 1024 * 1024
+
+# Per byte value: counts of (zero, +1, -1) among its four 2-bit trits.
+# 0b11 never appears in packs written by encode_trit; count it as "invalid".
+_LUT: list[tuple[int, int, int, int]] = []
+for b in range(256):
+    z = p = m = bad = 0
+    for shift in (0, 2, 4, 6):
+        t = (b >> shift) & 0b11
+        if t == 0b00:
+            z += 1
+        elif t == 0b01:
+            p += 1
+        elif t == 0b10:
+            m += 1
+        else:
+            bad += 1
+    _LUT.append((z, p, m, bad))
+
+
+class Goz1Error(ValueError):
+    """Malformed GOZ1 input."""
+
+
+def _read_exact(f, n: int) -> bytes:
+    b = f.read(n)
+    if len(b) != n:
+        raise Goz1Error(f"unexpected EOF (wanted {n} bytes, got {len(b)})")
+    return b
+
+
+def _read_u32(f) -> int:
+    return struct.unpack("<I", _read_exact(f, 4))[0]
+
+
+def _read_u64(f) -> int:
+    return struct.unpack("<Q", _read_exact(f, 8))[0]
+
+
+def _read_str(f) -> str:
+    n = _read_u64(f)
+    return _read_exact(f, n).decode("utf-8")
+
+
+def _align_up(n: int, align: int) -> int:
+    return (n + align - 1) // align * align
+
+
+def read_header(f) -> tuple[int, dict[str, object], list[dict], int]:
+    """Parse header; return (version, metadata, tensor infos, data_start)."""
+    if _read_exact(f, 4) != MAGIC:
+        raise Goz1Error("bad magic (expected GOZ1)")
+    version = _read_u32(f)
+    tensor_count = _read_u64(f)
+    meta_count = _read_u64(f)
+
+    metadata: dict[str, object] = {}
+    for _ in range(meta_count):
+        key = _read_str(f)
+        vtype = _read_u32(f)
+        if vtype == META_U32:
+            metadata[key] = _read_u32(f)
+        elif vtype == META_STR:
+            metadata[key] = _read_str(f)
+        else:
+            raise Goz1Error(f"unsupported metadata value type {vtype}")
+
+    tensors: list[dict] = []
+    for _ in range(tensor_count):
+        name = _read_str(f)
+        ndim = _read_u32(f)
+        shape = [_read_u64(f) for _ in range(ndim)]
+        tensor_type = _read_u32(f)
+        data_offset = _read_u64(f)
+        tensors.append(
+            {
+                "name": name,
+                "shape": shape,
+                "tensor_type": tensor_type,
+                "data_offset": data_offset,
+            }
+        )
+
+    data_start = _align_up(f.tell(), DATA_ALIGNMENT)
+    return version, metadata, tensors, data_start
+
+
+def _num_elements(shape: list[int]) -> int:
+    n = 1
+    for d in shape:
+        n *= d
+    return n
+
+
+def histogram_ternary(f, abs_offset: int, n_elements: int) -> dict[str, int]:
+    """Count trits for one ternary blob of ``n_elements`` values."""
+    nbytes = (n_elements + 3) // 4
+    f.seek(abs_offset)
+    zeros = pos = neg = invalid = 0
+    remaining = nbytes
+    last_byte: int | None = None
+    while remaining > 0:
+        chunk = _read_exact(f, min(CHUNK, remaining))
+        remaining -= len(chunk)
+        if remaining == 0 and n_elements % 4 != 0:
+            last_byte = chunk[-1]
+            chunk = chunk[:-1]
+        for value, count in ((v, chunk.count(v)) for v in set(chunk)):
+            z, p, m, bad = _LUT[value]
+            zeros += z * count
+            pos += p * count
+            neg += m * count
+            invalid += bad * count
+    if last_byte is not None:
+        for i in range(n_elements % 4):
+            t = (last_byte >> (2 * i)) & 0b11
+            if t == 0b00:
+                zeros += 1
+            elif t == 0b01:
+                pos += 1
+            elif t == 0b10:
+                neg += 1
+            else:
+                invalid += 1
+    return {"zeros": zeros, "pos": pos, "neg": neg, "invalid": invalid}
+
+
+def analyze(path: Path) -> dict:
+    with path.open("rb") as f:
+        version, metadata, tensors, data_start = read_header(f)
+        out_tensors = []
+        for t in tensors:
+            n = _num_elements(t["shape"])
+            entry: dict[str, object] = {
+                "name": t["name"],
+                "shape": t["shape"],
+                "num_elements": n,
+                "type": "ternary" if t["tensor_type"] == TENSOR_TERNARY else "f16",
+            }
+            if t["tensor_type"] == TENSOR_TERNARY:
+                hist = histogram_ternary(f, data_start + t["data_offset"], n)
+                total = hist["zeros"] + hist["pos"] + hist["neg"] + hist["invalid"]
+                if total != n:
+                    raise Goz1Error(
+                        f"trit count {total} != num_elements {n} for {t['name']}"
+                    )
+                entry["histogram"] = hist
+                entry["sparsity"] = hist["zeros"] / n if n else 1.0
+            out_tensors.append(entry)
+    return {
+        "file": str(path),
+        "file_size": path.stat().st_size,
+        "version": version,
+        "metadata": metadata,
+        "tensors": out_tensors,
+    }
+
+
+def _print_human(result: dict) -> None:
+    print(f"{result['file']}  ({result['file_size']} bytes, version {result['version']})")
+    gif = result["metadata"].get("oz.gif_threshold")
+    if gif is not None:
+        print(f"  oz.gif_threshold = {gif}")
+    for t in result["tensors"]:
+        shape = "x".join(str(d) for d in t["shape"])
+        if t["type"] != "ternary":
+            print(f"  {t['name']}  [{shape}]  f16/preserve (not histogrammed)")
+            continue
+        h = t["histogram"]
+        n = t["num_elements"]
+        print(f"  {t['name']}  [{shape}]  n={n}")
+        print(
+            f"    zeros={h['zeros']} ({100.0 * h['zeros'] / n:.4f}%)  "
+            f"+1={h['pos']} ({100.0 * h['pos'] / n:.4f}%)  "
+            f"-1={h['neg']} ({100.0 * h['neg'] / n:.4f}%)"
+            + (f"  INVALID={h['invalid']}" if h["invalid"] else "")
+        )
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("pack", type=Path, help="path to .goz1 file")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    args = ap.parse_args(argv)
+    try:
+        result = analyze(args.pack)
+    except (OSError, Goz1Error) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    if args.json:
+        json.dump(result, sys.stdout, indent=2)
+        print()
+    else:
+        _print_human(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -303,6 +303,32 @@ def _print_human(result: dict) -> None:
         _print_ternary_human(t)
 
 
+def _json_out_conflicts_with_pack(json_out: Path, pack_path: Path) -> bool:
+    """True if --json-out would overwrite the input pack (path or same inode)."""
+    out_path = json_out.expanduser()
+    out_resolved = out_path.resolve()
+    if out_resolved == pack_path:
+        return True
+    if not out_path.exists():
+        return False
+    try:
+        return out_resolved.samefile(pack_path)
+    except OSError:
+        return False
+
+
+def _emit_result(result: dict, *, as_json: bool, json_out: Path | None) -> None:
+    if json_out is not None:
+        json_out.expanduser().write_text(
+            json.dumps(result, indent=2) + "\n", encoding="utf-8"
+        )
+    if as_json:
+        json.dump(result, sys.stdout, indent=2)
+        print()
+    else:
+        _print_human(result)
+
+
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("pack", type=Path, help="path to .goz1 file")
@@ -315,34 +341,18 @@ def main(argv: list[str]) -> int:
     args = ap.parse_args(argv)
     try:
         pack_path = args.pack.expanduser().resolve()
-        if args.json_out is not None:
-            # Reject same path / same inode (hard links, symlinks to the pack).
-            out_path = args.json_out.expanduser()
-            out_resolved = out_path.resolve()
-            same = out_resolved == pack_path
-            if not same and out_path.exists():
-                try:
-                    same = out_resolved.samefile(pack_path)
-                except OSError:
-                    same = False
-            if same:
-                raise Goz1Error(
-                    f"--json-out {args.json_out} resolves to the input pack; "
-                    "refusing to overwrite the GOZ1 artifact"
-                )
+        if args.json_out is not None and _json_out_conflicts_with_pack(
+            args.json_out, pack_path
+        ):
+            raise Goz1Error(
+                f"--json-out {args.json_out} resolves to the input pack; "
+                "refusing to overwrite the GOZ1 artifact"
+            )
         result = analyze(pack_path)
     except (OSError, Goz1Error) as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
-    if args.json_out is not None:
-        args.json_out.expanduser().write_text(
-            json.dumps(result, indent=2) + "\n", encoding="utf-8"
-        )
-    if args.json:
-        json.dump(result, sys.stdout, indent=2)
-        print()
-    else:
-        _print_human(result)
+    _emit_result(result, as_json=args.json, json_out=args.json_out)
     return 0
 
 

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -195,6 +195,45 @@ def _type_name(tensor_type: int, name: str) -> str:
     )
 
 
+def _payload_nbytes(tensor_type: int, n_elements: int, name: str) -> int:
+    if tensor_type == TENSOR_TERNARY:
+        return (n_elements + 3) // 4
+    if tensor_type == TENSOR_F16:
+        return n_elements * 2
+    raise Goz1Error(
+        f"unsupported tensor_type {tensor_type} for {name} "
+        f"(expected {TENSOR_F16}=f16 or {TENSOR_TERNARY}=ternary)"
+    )
+
+
+def _validate_tensor_layout(
+    tensors: list[dict], data_start: int, file_size: int
+) -> None:
+    """Match weight_pack_read::verify_pack_file cumulative offsets + bounds."""
+    expected_rel = 0
+    for i, t in enumerate(tensors):
+        name = t["name"]
+        off = t["data_offset"]
+        if off != expected_rel:
+            raise Goz1Error(
+                f"tensor {i} ({name}) data_offset {off} != expected cumulative {expected_rel}"
+            )
+        n = _num_elements(t["shape"])
+        nbytes = _payload_nbytes(t["tensor_type"], n, name)
+        abs_off = data_start + off
+        end = abs_off + nbytes
+        if end > file_size:
+            raise Goz1Error(
+                f"tensor {i} ({name}) blob end {end} exceeds file size {file_size}"
+            )
+        expected_rel = _align_up(expected_rel + nbytes, DATA_ALIGNMENT)
+    if data_start + expected_rel > file_size:
+        raise Goz1Error(
+            f"declared tensor payloads need {expected_rel} bytes past data start; "
+            f"file has {file_size - data_start}"
+        )
+
+
 def _analyze_ternary(f, abs_offset: int, name: str, n: int) -> dict[str, object]:
     hist = histogram_ternary(f, abs_offset, n)
     total = hist["zeros"] + hist["pos"] + hist["neg"] + hist["invalid"]
@@ -207,8 +246,10 @@ def _analyze_ternary(f, abs_offset: int, name: str, n: int) -> dict[str, object]
 
 
 def analyze(path: Path) -> dict:
+    file_size = path.stat().st_size
     with path.open("rb") as f:
         version, metadata, tensors, data_start = read_header(f)
+        _validate_tensor_layout(tensors, data_start, file_size)
         out_tensors = []
         for t in tensors:
             n = _num_elements(t["shape"])
@@ -225,7 +266,7 @@ def analyze(path: Path) -> dict:
             out_tensors.append(entry)
     return {
         "file": str(path),
-        "file_size": path.stat().st_size,
+        "file_size": file_size,
         "version": version,
         "metadata": metadata,
         "tensors": out_tensors,
@@ -273,12 +314,30 @@ def main(argv: list[str]) -> int:
     )
     args = ap.parse_args(argv)
     try:
-        result = analyze(args.pack)
+        pack_path = args.pack.expanduser().resolve()
+        if args.json_out is not None:
+            # Reject same path / same inode (hard links, symlinks to the pack).
+            out_path = args.json_out.expanduser()
+            out_resolved = out_path.resolve()
+            same = out_resolved == pack_path
+            if not same and out_path.exists():
+                try:
+                    same = out_resolved.samefile(pack_path)
+                except OSError:
+                    same = False
+            if same:
+                raise Goz1Error(
+                    f"--json-out {args.json_out} resolves to the input pack; "
+                    "refusing to overwrite the GOZ1 artifact"
+                )
+        result = analyze(pack_path)
     except (OSError, Goz1Error) as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
     if args.json_out is not None:
-        args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+        args.json_out.expanduser().write_text(
+            json.dumps(result, indent=2) + "\n", encoding="utf-8"
+        )
     if args.json:
         json.dump(result, sys.stdout, indent=2)
         print()

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -28,6 +28,7 @@ import argparse
 import json
 import struct
 import sys
+from collections import Counter
 from pathlib import Path
 
 DATA_ALIGNMENT = 32
@@ -143,7 +144,8 @@ def histogram_ternary(f, abs_offset: int, n_elements: int) -> dict[str, int]:
         if remaining == 0 and n_elements % 4 != 0:
             last_byte = chunk[-1]
             chunk = chunk[:-1]
-        for value, count in ((v, chunk.count(v)) for v in set(chunk)):
+        # Single-pass byte frequencies (avoids re-scanning the chunk per unique value).
+        for value, count in Counter(chunk).items():
             z, p, m, bad = _LUT[value]
             zeros += z * count
             pos += p * count
@@ -169,13 +171,23 @@ def analyze(path: Path) -> dict:
         out_tensors = []
         for t in tensors:
             n = _num_elements(t["shape"])
+            tt = t["tensor_type"]
+            if tt == TENSOR_TERNARY:
+                type_name = "ternary"
+            elif tt == TENSOR_F16:
+                type_name = "f16"
+            else:
+                raise Goz1Error(
+                    f"unsupported tensor_type {tt} for {t['name']} "
+                    f"(expected {TENSOR_F16}=f16 or {TENSOR_TERNARY}=ternary)"
+                )
             entry: dict[str, object] = {
                 "name": t["name"],
                 "shape": t["shape"],
                 "num_elements": n,
-                "type": "ternary" if t["tensor_type"] == TENSOR_TERNARY else "f16",
+                "type": type_name,
             }
-            if t["tensor_type"] == TENSOR_TERNARY:
+            if tt == TENSOR_TERNARY:
                 hist = histogram_ternary(f, data_start + t["data_offset"], n)
                 total = hist["zeros"] + hist["pos"] + hist["neg"] + hist["invalid"]
                 if total != n:
@@ -207,6 +219,12 @@ def _print_human(result: dict) -> None:
         h = t["histogram"]
         n = t["num_elements"]
         print(f"  {t['name']}  [{shape}]  n={n}")
+        if n == 0:
+            print(
+                "    empty tensor (zeros=0, +1=0, -1=0); sparsity=1.0 by convention"
+                + (f"  INVALID={h['invalid']}" if h["invalid"] else "")
+            )
+            continue
         print(
             f"    zeros={h['zeros']} ({100.0 * h['zeros'] / n:.4f}%)  "
             f"+1={h['pos']} ({100.0 * h['pos'] / n:.4f}%)  "
@@ -218,13 +236,20 @@ def _print_human(result: dict) -> None:
 def main(argv: list[str]) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("pack", type=Path, help="path to .goz1 file")
-    ap.add_argument("--json", action="store_true", help="emit JSON instead of text")
+    ap.add_argument("--json", action="store_true", help="emit JSON on stdout instead of text")
+    ap.add_argument(
+        "--json-out",
+        type=Path,
+        help="write JSON to this path (still prints human text unless --json)",
+    )
     args = ap.parse_args(argv)
     try:
         result = analyze(args.pack)
     except (OSError, Goz1Error) as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
+    if args.json_out is not None:
+        args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
     if args.json:
         json.dump(result, sys.stdout, indent=2)
         print()

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -349,10 +349,12 @@ def main(argv: list[str]) -> int:
                 "refusing to overwrite the GOZ1 artifact"
             )
         result = analyze(pack_path)
+        # Write failures (missing parent dir, permissions, full disk) stay in
+        # the same controlled error path as analyze().
+        _emit_result(result, as_json=args.json, json_out=args.json_out)
     except (OSError, Goz1Error) as e:
         print(f"error: {e}", file=sys.stderr)
         return 1
-    _emit_result(result, as_json=args.json, json_out=args.json_out)
     return 0
 
 

--- a/scripts/tau_sweep_embedding.sh
+++ b/scripts/tau_sweep_embedding.sh
@@ -40,9 +40,11 @@ fi
 }
 
 # Fresh disk-backed stage; never wipe caller-owned dirs.
+# Parent must exist before mktemp -d with a template path; ART/logs before tee.
+mkdir -p "$HOME/.models/xai-grok-1" "$ART/logs"
 WORK="$(mktemp -d "$HOME/.models/xai-grok-1/tau-sweep-stage.XXXXXX")"
 STAGE="$WORK/npy"
-mkdir -p "$STAGE" "$ART/logs"
+mkdir -p "$STAGE"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
 
@@ -88,9 +90,9 @@ for TAU in $TAUS; do
     --input-format npy \
     --gif-threshold "$TAU" \
     --verify 2>&1 | tee "$LOG"
-  python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" --json \
-    >"$ART/logs/tau-${TAU}.hist.json"
-  python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" | tee -a "$LOG"
+  # One pack analysis: JSON artifact + human summary (no double full-file scan).
+  python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" \
+    --json-out "$ART/logs/tau-${TAU}.hist.json" | tee -a "$LOG"
 done
 
 echo "== done; packs + logs under $ART"

--- a/scripts/tau_sweep_embedding.sh
+++ b/scripts/tau_sweep_embedding.sh
@@ -66,17 +66,28 @@ if [ "${#NPYS[@]}" -ne 1 ] ||
   exit 1
 fi
 
-# Sweep manifest = baseline.json minus defaults.gif_threshold (CLI controls τ).
+# Sweep manifest: strip every gif_threshold so CLI --gif-threshold wins.
+# resolve_threshold precedence is per-tensor candidate > defaults > config;
+# oz.gif_threshold metadata only records defaults||config, so per-tensor
+# overrides would silently beat CLI and still pass the fidelity check.
 MANI="$WORK/sweep-manifest.json"
 python3 - "$REPO/dissect/grok-1/baseline.json" "$MANI" <<'PYEOF'
 import json, sys
 src, dst = sys.argv[1], sys.argv[2]
 with open(src) as f:
     m = json.load(f)
-m["defaults"].pop("gif_threshold", None)
+m.setdefault("defaults", {}).pop("gif_threshold", None)
+stripped = 0
+for entry in m.get("ternary_candidates") or []:
+    if isinstance(entry, dict) and "gif_threshold" in entry:
+        entry.pop("gif_threshold", None)
+        stripped += 1
 with open(dst, "w") as f:
     json.dump(m, f, indent=2)
-print(f"sweep manifest -> {dst} (defaults: {m['defaults']})")
+print(
+    f"sweep manifest -> {dst} "
+    f"(defaults: {m.get('defaults')}; stripped {stripped} per-tensor gif_threshold)"
+)
 PYEOF
 
 for TAU in $TAUS; do
@@ -95,22 +106,23 @@ for TAU in $TAUS; do
   python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" \
     --json-out "$HIST_JSON" | tee -a "$LOG"
 
-  # Enforce τ fidelity: pack metadata must match CLI TAU; no invalid trit codes.
+  # Enforce τ fidelity: pack metadata must match CLI TAU (f32); no invalid trits.
   python3 - "$HIST_JSON" "$TAU" <<'PYEOF' | tee -a "$LOG"
-import json, sys
+import json, struct, sys
 path, tau_s = sys.argv[1], sys.argv[2]
-want = float(tau_s)
+# CLI parses --gif-threshold as f32; metadata serializes that f32.
+want = struct.unpack("<f", struct.pack("<f", float(tau_s)))[0]
 with open(path) as f:
     hist = json.load(f)
 raw = hist.get("metadata", {}).get("oz.gif_threshold")
 if raw is None:
     print(f"error: pack missing oz.gif_threshold metadata (wanted gif_threshold={want})", file=sys.stderr)
     sys.exit(1)
-got = float(raw)
-if abs(got - want) > 1e-9:
+got = struct.unpack("<f", struct.pack("<f", float(raw)))[0]
+if got != want:
     print(
         f"error: effective oz.gif_threshold={got} != requested TAU={want} "
-        f"(manifest default may have overridden CLI)",
+        f"(manifest default/per-tensor may have overridden CLI)",
         file=sys.stderr,
     )
     sys.exit(1)

--- a/scripts/tau_sweep_embedding.sh
+++ b/scripts/tau_sweep_embedding.sh
@@ -91,8 +91,39 @@ for TAU in $TAUS; do
     --gif-threshold "$TAU" \
     --verify 2>&1 | tee "$LOG"
   # One pack analysis: JSON artifact + human summary (no double full-file scan).
+  HIST_JSON="$ART/logs/tau-${TAU}.hist.json"
   python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" \
-    --json-out "$ART/logs/tau-${TAU}.hist.json" | tee -a "$LOG"
+    --json-out "$HIST_JSON" | tee -a "$LOG"
+
+  # Enforce τ fidelity: pack metadata must match CLI TAU; no invalid trit codes.
+  python3 - "$HIST_JSON" "$TAU" <<'PYEOF' | tee -a "$LOG"
+import json, sys
+path, tau_s = sys.argv[1], sys.argv[2]
+want = float(tau_s)
+with open(path) as f:
+    hist = json.load(f)
+raw = hist.get("metadata", {}).get("oz.gif_threshold")
+if raw is None:
+    print(f"error: pack missing oz.gif_threshold metadata (wanted gif_threshold={want})", file=sys.stderr)
+    sys.exit(1)
+got = float(raw)
+if abs(got - want) > 1e-9:
+    print(
+        f"error: effective oz.gif_threshold={got} != requested TAU={want} "
+        f"(manifest default may have overridden CLI)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+for t in hist.get("tensors", []):
+    if t.get("type") != "ternary":
+        continue
+    inv = int(t.get("histogram", {}).get("invalid", 0))
+    if inv:
+        print(f"error: tensor {t['name']} has {inv} invalid trit codes", file=sys.stderr)
+        sys.exit(1)
+    zeros_pct = 100.0 * t["histogram"]["zeros"] / t["num_elements"] if t["num_elements"] else 0.0
+    print(f"  ok: oz.gif_threshold={got} matches TAU={want}; zeros%={zeros_pct:.4f}")
+PYEOF
 done
 
 echo "== done; packs + logs under $ART"

--- a/scripts/tau_sweep_embedding.sh
+++ b/scripts/tau_sweep_embedding.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# τ (gif_threshold) sweep on the sole Grok-1 token embedding — GH #51 / RM-201.
+#
+# For each τ: quantize-goz1 with a manifest that has NO defaults.gif_threshold
+# (so the CLI --gif-threshold actually controls the quantize τ — the stock
+# dissect/grok-1/baseline.json bakes defaults.gif_threshold=0.05 which
+# silently overrides the CLI, see src/core/precision.rs), then read the pack
+# back with scripts/goz1_trit_histogram.py for exact trit counts.
+#
+# Weights and packs stay under ~/.models (never committed). The 3 GiB npy
+# stage is a fresh mktemp dir on disk (not /tmp tmpfs) and is removed on exit.
+#
+# Usage:
+#   scripts/tau_sweep_embedding.sh                 # default τ set
+#   TAUS="0.05 0.2" scripts/tau_sweep_embedding.sh # custom τ set
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CKPT="${CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
+ART="${ART:-$HOME/.models/xai-grok-1/artifacts}/tau-sweep"
+TAUS="${TAUS:-0.0 0.05 0.1 0.2 0.3 0.5 0.7 1.0}"
+BIN="$REPO/target/release/grok-ozempic"
+
+if command -v gtime >/dev/null 2>&1; then
+  TIME_V=(gtime -v)
+elif [ "$(uname -s)" = Darwin ]; then
+  TIME_V=(/usr/bin/time -l)
+else
+  TIME_V=(/usr/bin/time -v)
+fi
+
+[ -x "$BIN" ] || {
+  echo "error: $BIN missing; run: cargo build --release --features cli --locked" >&2
+  exit 1
+}
+[ -f "$CKPT/tensor00000_000" ] || {
+  echo "error: embedding shard not found under $CKPT" >&2
+  exit 1
+}
+
+# Fresh disk-backed stage; never wipe caller-owned dirs.
+WORK="$(mktemp -d "$HOME/.models/xai-grok-1/tau-sweep-stage.XXXXXX")"
+STAGE="$WORK/npy"
+mkdir -p "$STAGE" "$ART/logs"
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+echo "== export embedding npy -> $STAGE"
+"${TIME_V[@]}" python3 "$REPO/scripts/export_grok1_embedding_npy.py" \
+  --shard "$CKPT/tensor00000_000" \
+  --output-dir "$STAGE" 2>&1 | tee "$ART/logs/export.log"
+
+# Guard: exactly the sole embedding npy (quantize-goz1 packs every .npy).
+NPYS=()
+while IFS= read -r f; do
+  [ -n "$f" ] && NPYS+=("$f")
+done <<EOF
+$(find "$STAGE" -maxdepth 1 -name '*.npy' | sort)
+EOF
+if [ "${#NPYS[@]}" -ne 1 ] ||
+  [ "$(basename "${NPYS[0]}")" != "embedding__slot_00__token_embedding.npy" ]; then
+  echo "error: expected sole embedding__slot_00__token_embedding.npy in $STAGE; found: ${NPYS[*]:-none}" >&2
+  exit 1
+fi
+
+# Sweep manifest = baseline.json minus defaults.gif_threshold (CLI controls τ).
+MANI="$WORK/sweep-manifest.json"
+python3 - "$REPO/dissect/grok-1/baseline.json" "$MANI" <<'PYEOF'
+import json, sys
+src, dst = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    m = json.load(f)
+m["defaults"].pop("gif_threshold", None)
+with open(dst, "w") as f:
+    json.dump(m, f, indent=2)
+print(f"sweep manifest -> {dst} (defaults: {m['defaults']})")
+PYEOF
+
+for TAU in $TAUS; do
+  OUT="$ART/goz1-tau-${TAU}.goz1"
+  LOG="$ART/logs/tau-${TAU}.log"
+  echo "== tau=$TAU -> $OUT"
+  "${TIME_V[@]}" "$BIN" quantize-goz1 \
+    --input-dir "$STAGE" \
+    --output "$OUT" \
+    --manifest "$MANI" \
+    --input-format npy \
+    --gif-threshold "$TAU" \
+    --verify 2>&1 | tee "$LOG"
+  python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" --json \
+    >"$ART/logs/tau-${TAU}.hist.json"
+  python3 "$REPO/scripts/goz1_trit_histogram.py" "$OUT" | tee -a "$LOG"
+done
+
+echo "== done; packs + logs under $ART"


### PR DESCRIPTION
## **User description**

**Agent:** Claude Code: Fable 5 · **Issue:** [rmems/worktree-hive#75](<https://github.com/rmems/worktree-hive/issues/75>) / Linear [rmems/worktree-hive#75](<https://github.com/rmems/worktree-hive/issues/75>) · research + reports only (no Rust changes, no [#40](<https://github.com/rmems/grok-ozempic/issues/40>), no kernels)

## What this answers

[#39](<https://github.com/rmems/grok-ozempic/issues/39>)'s \~4.17% zeros at the default `gif_threshold=0.05` was **the knob, not the distribution**. Eight τ values on the real 805,306,368-element token embedding, measured by exact trit readback of each GOZ1 pack:

<!-- linear:table-colwidths:160,160,160,160,160 -->
| τ | zeros % | +1 % | −1 % | Gaussian pred. % |
| -- | -- | -- | -- | -- |
| 0.0 | 0.0000 | 49.7377 | 50.2623 | 0.0000 |
| 0.05 | 4.1683 | 47.6529 | 48.1788 | 3.9878 |
| 0.1 | 8.3252 | 45.5760 | 46.0988 | 7.9656 |
| 0.2 | 16.5505 | 41.4683 | 41.9812 | 15.8519 |
| 0.3 | 24.5767 | 37.4624 | 37.9610 | 23.5823 |
| 0.5 | 39.7179 | 29.9150 | 30.3671 | 38.2925 |
| 0.7 | 53.2185 | 23.1931 | 23.5884 | 51.6073 |
| 1.0 | 69.7146 | 14.9950 | 15.2903 | 68.2689 |

All packs 201,327,136 bytes (`--verify`; size is τ-independent — 2 bits/trit). τ=0.05 reproduces [#39](<https://github.com/rmems/grok-ozempic/issues/39>) exactly; τ=0.0 is a pure sign pack (0 zeros). Independent npy-side prediction matches pack-side measurement to 4 decimals at all eight τ. Embedding is near-Gaussian (rms 0.012758, kurtosis 3.60). **τ→sparsity map:** 50% → τ≈0.65, 75% → τ≈1.12, 90% → τ≈1.63.

## ⚠ Trap documented + demonstrated live

`baseline.json` bakes `defaults.gif_threshold: 0.05`, and `precision.rs` gives manifest defaults precedence over the CLI — so `--gif-threshold 0.5` with the stock manifest produced a pack **trit-for-trit identical** to τ=0.05, with `oz.gif_threshold=0.05` in the pack metadata. Sweeps must use a manifest without `defaults.gif_threshold` (the driver derives one at runtime; `dissect/` untouched).

## Blocked-by-export (evidence in report)

xai-dissect shows official ckpt-0 ships **all** expert/attention weights as int8 `quant.weight` (e.g. `tensor00002_000` int8 `(8, 6144, 32768)`). No f32/bf16 exists to sweep; the only other f32 matrix is the `(6144, 8)` router — preserve-tier, explicitly non-goal. Expert/attention sweeps need an int8×scale dequant exporter first.

## Files

* `reports/grok-1-tau-sweep/results.md` — full tables, wall/RSS, per-tier τ policy draft, repro commands
* `scripts/goz1_trit_histogram.py` — stdlib-only exact trit histogram via GOZ1 readback
* `scripts/tau_sweep_embedding.sh` — reproducible sweep driver

## What remains for multi-tensor (rmems/grok-ozempic#48)

1. int8 dequant export for one expert slice + one attention proj, then re-run this sweep per tier (distributions may differ from the embedding).
2. [#40](<https://github.com/rmems/grok-ozempic/issues/40>) / [RM-191](https://linear.app/rpd-34/issue/RM-191/grok-ozempic-gh40-v2-structural-name-bridge-for-stream) (V2 name bridge) before multi-tensor tiering — note the trap compounds with [#40](<https://github.com/rmems/grok-ozempic/issues/40>): preserve-name mismatches fall to default ternary at whatever τ `defaults` carries.

Packs/logs live under `~/.models/xai-grok-1/artifacts/tau-sweep/` (host-only; no weights committed).

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

## Summary by cubic

Ran an 8-point τ (`gif_threshold`) sweep on the Grok-1 token embedding, measured exact GOZ1 trit histograms, and mapped τ to sparsity to guide spiking-sparse choices. Documents a manifest precedence trap that was overriding CLI τ; supports Linear [rmems/worktree-hive#75](<https://github.com/rmems/worktree-hive/issues/75>).

* **New Features**
  * Added `scripts/goz1_trit_histogram.py` to read GOZ1 packs and count exact 0/+1/−1 trits.
  * Added `scripts/tau_sweep_embedding.sh` for a reproducible sweep with a derived manifest.
  * Added `reports/grok-1-tau-sweep/results.md` with tables, τ→sparsity mapping, and repro commands.
* **Migration**
  * Use a manifest without `defaults.gif_threshold` so CLI `--gif-threshold` applies; verify `oz.gif_threshold` in pack metadata.

Written for commit 4ccf4f7e4dbae5b07157e1d38302f0b5483f44eb. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

---

## **CodeAnt-AI Description**

Measure GOZ1 sparsity across embedding thresholds and make τ sweeps reproducible

### What Changed

* Added a command that reads GOZ1 packs and reports exact zero, +1, and −1 trit counts, sparsity, invalid values, tensor metadata, and JSON output.
* Added a reproducible embedding threshold sweep that avoids the manifest default overriding the requested CLI threshold, verifies each pack, and saves readable logs and histogram results.
* Documented measured embedding sparsity from 0% to 69.7146% across thresholds 0.0–1.0, while pack size remains unchanged.
* Documented the effective-threshold manifest trap, confirmed that expert and attention sweeps are blocked by int8-only checkpoint weights, and provided initial per-tier threshold guidance.

### Impact

`✅ Exact GOZ1 sparsity measurements`  <br>`✅ Reproducible embedding threshold sweeps`  <br>`✅ Fewer misleading CLI threshold results`

<details><summary>💡 Usage Guide</summary>

### Checking Your Pull Request

Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI

Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:

```
@codeant-ai ask: Your question here
```

This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example

```
@codeant-ai ask: Can you suggest a safer alternative to storing this secret?
```

### Preserve Org Learnings with CodeAnt

You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:

```
@codeant-ai: Your feedback here
```

This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example

```
@codeant-ai: Do not flag unused imports.
```

### Retrigger review

Ask CodeAnt AI to review the PR again, by typing:

```
@codeant-ai: review
```

### Check Your Repository Health

To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](<https://app.codeant.ai>). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>