### PR TITLE
feat: V2 structural name bridge for resolve_manifest (#40 / RM-191)

### DIFF
--- a/.claude/commands/quantize-embed.md
+++ b/.claude/commands/quantize-embed.md
@@ -52,7 +52,7 @@ if [ "${#NPYS[@]}" -ne 1 ] || [ "$(basename "${NPYS[0]}")" != "embedding__slot_0
 fi
 ```
 
-## 2. Pack GOZ1 (V1 baseline until #40)
+## 2. Pack GOZ1 (V2 structural manifest since #40)
 
 ```bash
 ART="${ART:-$HOME/.models/xai-grok-1/artifacts}"
@@ -61,7 +61,7 @@ cargo build --release --features cli --locked &&
 "${TIME_V[@]}" ./target/release/grok-ozempic quantize-goz1 \
   --input-dir "$STAGE" \
   --output "$ART/grok1-first-embed.goz1" \
-  --manifest dissect/grok-1/baseline.json \
+  --manifest dissect/grok-1/structural-manifest.json \
   --input-format npy \
   --verify
 # Clean the 3 GiB stage now for persistent shells; the trap remains fail-safe.
@@ -77,4 +77,4 @@ trap - EXIT
 - Stage dir had only the embedding `.npy`
 - Wall / max RSS from `TIME_V`
 
-Do **not** use `structural-manifest.json` for runtime pack until #40 is done.
+`structural-manifest.json` (V2) is the runtime manifest since #40 — the export stem `embedding__slot_00__token_embedding` maps to the structural ternary candidate `embedding.slot_00.token_embedding`. V2 hard-errors on any name it does not match; fall back to V1 `baseline.json` only for legacy `blk.*`-named inputs.

--- a/.claude/rules/goz1-pipeline.md
+++ b/.claude/rules/goz1-pipeline.md
@@ -34,13 +34,24 @@ cargo run --release --features cli --locked -- quantize-goz1 \
   --verify
 ```
 
-**Safetensors directory** (do not use `--input-format npy`; use the manifest whose convention matches the tensor names):
+**Safetensors — structural names** (V2):
 
 ```bash
 cargo run --release --features cli --locked -- quantize-goz1 \
   --input-dir /path/to/safetensors-dir \
   --output /path/to/out.goz1 \
   --manifest dissect/grok-1/structural-manifest.json \
+  --input-format safetensors \
+  --verify
+```
+
+**Safetensors — legacy `blk.*` names** (V1; do not pair with V2):
+
+```bash
+cargo run --release --features cli --locked -- quantize-goz1 \
+  --input-dir /path/to/safetensors-dir \
+  --output /path/to/out.goz1 \
+  --manifest dissect/grok-1/baseline.json \
   --input-format safetensors \
   --verify
 ```

--- a/.claude/rules/goz1-pipeline.md
+++ b/.claude/rules/goz1-pipeline.md
@@ -23,29 +23,29 @@ Default stem mapping: `embedding__slot_00__token_embedding.npy` → logical `emb
 
 ## Real pack recipes
 
-**NPY directory** (JAX export path):
+**NPY directory** (JAX export path; stems are structural, so prefer the V2 structural manifest):
 
 ```bash
 cargo run --release --features cli --locked -- quantize-goz1 \
   --input-dir /path/to/npy-dir \
   --output /path/to/out.goz1 \
-  --manifest dissect/grok-1/baseline.json \
+  --manifest dissect/grok-1/structural-manifest.json \
   --input-format npy \
   --verify
 ```
 
-**Safetensors directory** (do not use `--input-format npy`):
+**Safetensors directory** (do not use `--input-format npy`; use the manifest whose convention matches the tensor names):
 
 ```bash
 cargo run --release --features cli --locked -- quantize-goz1 \
   --input-dir /path/to/safetensors-dir \
   --output /path/to/out.goz1 \
-  --manifest dissect/grok-1/baseline.json \
+  --manifest dissect/grok-1/structural-manifest.json \
   --input-format safetensors \
   --verify
 ```
 
-Until #40 / RM-191 lands, **runtime** packs use V1 `baseline.json` (default ternary). Prefer `--verify`.
+Since #40 / RM-191, **runtime** packs prefer the V2 `structural-manifest.json` whenever tensor names are structural (`block_{NNN}.slot_{SS}.{kind}`, export-script stems). V2 is fail-closed: an unmatched name hard-errors instead of defaulting to ternary. For legacy `blk.*`-named inputs use V1 `baseline.json` (defaults fallthrough allowed). Prefer `--verify`. Authoritative structural names / planning surface: `~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/` (tests honor `GROK_OZEMPIC_DISSECT_RUN`).
 
 **Evidence sources:**
 

--- a/.claude/rules/manifests.md
+++ b/.claude/rules/manifests.md
@@ -4,10 +4,10 @@
 
 | File | Convention | Runtime `quantize-goz1` / `stream::resolve_manifest` |
 |------|------------|------------------------------------------------------|
-| `dissect/grok-1/baseline.json` | V1 | **Accepted** today |
-| `dissect/grok-1/structural-manifest.json` | V2 `block_{NNN}.slot_{SS}.{kind}` | **Rejected** until #40 |
+| `dissect/grok-1/baseline.json` | V1 | **Accepted** (defaults fallthrough allowed) |
+| `dissect/grok-1/structural-manifest.json` | V2 `block_{NNN}.slot_{SS}.{kind}` | **Accepted** (#40 / RM-191) — fail-closed |
 
-V2 is valid for **alignment / dry-run** (`src/core/alignment.rs`, embedded structural fixture). `stream::resolve_manifest` hard-errors on `MANIFEST_NAME_CONVENTION_V2` until checkpoint↔structural name translation (or structural-named inputs) is wired — GitHub **#40** / Linear **RM-191**.
+V2 requires **structural-named inputs** (export-script npy stems, `__` → `.`). Under a V2 manifest, a tensor matching no explicit rule is a **hard error** (`ManifestV2UnmatchedTensor`) — never a `defaults` fallthrough. That is the #40 guarantee: routers/norms cannot be silently ternary-quantized by a name-convention mismatch. V2 also remains valid for **alignment / dry-run** (`src/core/alignment.rs`, embedded structural fixture).
 
 ## Classification order
 
@@ -23,7 +23,7 @@ Example of a **real** V1 vs V2 string mismatch (router preserve):
 | V1 baseline preserve (different convention) | `blk.*.moe_gate.weight` / `blk.*.expert_router.weight` |
 | NPY file → logical name | stem `embedding__slot_00__token_embedding` → logical `embedding.slot_00.token_embedding` (`__` → `.`); that logical name **is** a V2 ternary candidate, not a preserve mismatch |
 
-If the stream classifies checkpoint/logical names against the wrong convention’s rule list, preserve entries never match → default `ternary_snn` wins incorrectly. That is what #40’s name bridge must prevent.
+If the stream classifies checkpoint/logical names against the wrong convention’s rule list, preserve entries never match. Under V1 that silently defaults to `ternary_snn`; under V2 the run **aborts** on the first unmatched tensor (`ManifestV2UnmatchedTensor`) — the #40 name-bridge guarantee.
 
 ## Authority
 

--- a/.claude/skills/goz1-quantize/SKILL.md
+++ b/.claude/skills/goz1-quantize/SKILL.md
@@ -32,8 +32,24 @@ description: Pack Grok weights into GOZ1 via quantize-goz1 / run_quantization. U
 
 ## Commands
 
+Pick the manifest that matches the **tensor-name convention** of the inputs.
+V2 is fail-closed (unmatched names hard-error); V1 allows defaults fallthrough.
+
+**Structural-named npy** (export-script stems, `block_*.slot_*.{kind}`):
+
 ```bash
 cargo run --features cli -- quantize-goz1 --help
+cargo run --release --features cli -- quantize-goz1 \
+  --input-dir "$OUT" \
+  --output "$ART/model.goz1" \
+  --manifest dissect/grok-1/structural-manifest.json \
+  --input-format npy \
+  --verify
+```
+
+**Legacy `blk.*` names** (V1 baseline):
+
+```bash
 cargo run --release --features cli -- quantize-goz1 \
   --input-dir "$OUT" \
   --output "$ART/model.goz1" \

--- a/.claude/skills/goz1-quantize/SKILL.md
+++ b/.claude/skills/goz1-quantize/SKILL.md
@@ -15,7 +15,7 @@ description: Pack Grok weights into GOZ1 via quantize-goz1 / run_quantization. U
 
 1. **No pickle inputs** to `quantize-goz1` — export with `scripts/export_grok1_embedding_npy.py` first.
 2. Prefer `--input-format npy` for JAX-export paths; safetensors also supported.
-3. Runtime manifest: **`dissect/grok-1/baseline.json`** until #40; structural V2 is alignment-only today.
+3. Runtime manifest: prefer **`dissect/grok-1/structural-manifest.json`** (V2, #40) for structural-named inputs — fail-closed on unmatched names; V1 `baseline.json` for legacy `blk.*` names.
 4. Use `--verify` on real packs.
 5. Cloud VMs lack multi-GiB home checkpoints — code/tests only unless weights are mounted.
 

--- a/.claude/skills/structural-manifest/SKILL.md
+++ b/.claude/skills/structural-manifest/SKILL.md
@@ -11,27 +11,26 @@ description: V2 structural xai-dissect manifests, alignment dry-run, and the #40
 |-------|---------------------|
 | Parse (`manifest.rs`) | Allowed |
 | Alignment / dry-run (`alignment.rs`) | Used heavily |
-| Runtime stream `resolve_manifest` | **Rejected** until GH **#40** / Linear **RM-191** |
+| Runtime stream `resolve_manifest` | **Accepted** (GH **#40** / Linear **RM-191**) — fail-closed on unmatched names |
 
-Constant: `MANIFEST_NAME_CONVENTION_V2 = "block_{NNN}.slot_{SS}.{kind}"` in `src/core/manifest.rs`.
+Constant: `MANIFEST_NAME_CONVENTION_V2 = "block_{NNN}.slot_{SS}.{kind}"` in `src/core/manifest.rs`. Under a V2 manifest, a tensor matching no explicit rule aborts with `ManifestV2UnmatchedTensor` (no `defaults` fallthrough) — inputs must be structural-named (export-script npy stems, `__` → `.`). Authoritative structural names: `~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/`.
 
 ## Fixture
 
 `dissect/grok-1/structural-manifest.json` — preserve includes routers (`block_*.slot_11.router`), norms, etc.; defaults `ternary_snn` + `gif_threshold` 0.05.
 
-## Implementation checklist (#40)
+## Bridge design (landed in #40)
 
-1. Map checkpoint / npy logical names ↔ structural names **or** accept structural-named inputs.
-2. Stop rejecting V2 in `stream::resolve_manifest` once safe.
-3. Keep V1 baseline path working.
-4. Tests must prove routers/norms **preserve**, embedding can ternary under structural rules.
-5. Update README/docs to prefer structural-manifest for real quant after merge.
+1. Accepts structural-named inputs (export-script npy stems); no checkpoint↔structural translation table in this crate.
+2. `stream::resolve_manifest` loads V2 like V1; classification is fail-closed under V2 (`ManifestV2UnmatchedTensor` on any unmatched name).
+3. V1 baseline path unchanged (defaults fallthrough still allowed).
+4. Tests: `v2_structural_manifest_end_to_end_npy`, `v2_manifest_fails_closed_on_unmatched_name`, `v2_manifest_accepted_via_env_var`, plus the path-gated `run3_conversion_manifest_names_fully_classified` oracle against the latest xai-dissect run.
 
 ## Do not
 
 - Invent schema fields (xai-dissect is authoritative)
 - Quietly reclassify preserve tensors as ternary
-- Force structural-manifest through `quantize-goz1` before the bridge exists (expect hard error)
+- Feed legacy `blk.*`-named inputs to a V2 manifest (expect `ManifestV2UnmatchedTensor` — use V1 `baseline.json` for those)
 
 ## Related
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,8 @@ Key docs: `docs/ARCHITECTURE.md`, `docs/dissect-manifest.md`, `docs/grok1-saaq-a
 ### Critical pipeline facts
 
 1. Official Grok-1 pickle shards are **not** accepted by `quantize-goz1` — export npy first.
-2. Runtime V2 structural manifests are **rejected** in `resolve_manifest` until **#40 / RM-191**.
-3. Use `dissect/grok-1/baseline.json` for real packs today; structural-manifest is alignment/dry-run.
+2. Runtime V2 structural manifests are **accepted** in `resolve_manifest` (**#40 / RM-191**); V2 requires structural-named inputs and hard-errors on any unmatched tensor (no defaults fallthrough).
+3. Prefer `dissect/grok-1/structural-manifest.json` for real packs when inputs are structural-named (export-script npy stems); `baseline.json` (V1) remains for legacy `blk.*` names. Authoritative structural names: `~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/`.
 4. Preserve > fp16 > ternary_candidates > defaults — a name mismatch that ternary-quantizes routers/norms is a classification bug (fix the matcher; do not paper over with defaults).
 
 ### Open critical path

--- a/docs/dissect-manifest.md
+++ b/docs/dissect-manifest.md
@@ -5,8 +5,9 @@ analysis produced by the upstream [`xai-dissect`](https://github.com/rmems/xai-d
 repository, without depending on it as a runtime crate.
 
 This document freezes **schema v1**. The loader and runtime resolution path in
-`stream::resolve_manifest` are active; V2 structural naming is still rejected
-for runtime GOZ1 packs until #40 / RM-191.
+`stream::resolve_manifest` are active; V2 structural naming
+(`block_{NNN}.slot_{SS}.{kind}`) is accepted for runtime GOZ1 packs as of
+#40 / RM-191, with a fail-closed rule for unmatched tensors (see below).
 
 ## Authority and source of truth
 
@@ -29,9 +30,21 @@ Runtime resolution is implemented in `stream::resolve_manifest` (first hit wins)
    automatically just because it exists on disk.
 4. Otherwise `None` → legacy `router_patterns` substring heuristic in selection.
 
-**V2 structural naming** (`block_{NNN}.slot_{SS}.{kind}`) parses for alignment /
-dry-run but is **rejected** by `resolve_manifest` for runtime GOZ1 packs until
-GitHub #40 / RM-191 (checkpoint↔structural name bridge).
+**V2 structural naming** (`block_{NNN}.slot_{SS}.{kind}`) is accepted by
+`resolve_manifest` for runtime GOZ1 packs (GitHub #40 / RM-191). V2 requires
+**structural-named inputs** (e.g. npy stems from
+`scripts/export_grok1_embedding_npy.py`, `__` → `.`): under a V2 manifest a
+tensor that matches **no explicit rule hard-errors**
+(`ManifestV2UnmatchedTensor`) instead of falling through to `defaults` — this
+is what keeps routers/norms from being silently ternary-quantized on a name
+mismatch. V1 manifests keep defaults fallthrough.
+
+The authoritative source of structural names and planning surface is the
+latest xai-dissect run
+(`~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/`,
+override with `GROK_OZEMPIC_DISSECT_RUN`); the in-tree
+`dissect/grok-1/structural-manifest.json` is the non-authoritative policy
+reference consumed by `--manifest`.
 
 ## Manifest precedence over legacy `router_patterns`
 
@@ -122,11 +135,17 @@ Reject with typed errors rather than best-effort parse:
 
 Unknown top-level fields are **tolerated** for forward compatibility.
 
-### Runtime GOZ1 stream (`resolve_manifest`)
+### Runtime GOZ1 stream (V2 fail-closed classification)
 
-Even when a V2 manifest **parses**, `stream::resolve_manifest` **rejects** V2
-for live `quantize-goz1` / `run_quantization` until #40. Alignment and dry-run
-may still load embedded V2 fixtures via other entry points (`alignment.rs`).
+`stream::resolve_manifest` accepts both V1 and V2 manifests (#40 / RM-191).
+Under a **V2** manifest, classification is fail-closed: any input tensor that
+matches no `preserve` / `fp16` / `ternary_candidates` rule aborts the run with
+`GrokOzempicError::ManifestV2UnmatchedTensor` naming the tensor. V2 manifests
+are authored for full explicit coverage, so an unmatched name means the inputs
+do not follow the structural convention (or a rule is missing) — the exact
+scenario that would otherwise ternary-quantize a router/norm via `defaults`.
+Alignment and dry-run continue to load embedded V2 fixtures via their own
+entry points (`alignment.rs`).
 
 ## Versioning
 

--- a/docs/dissect-manifest.md
+++ b/docs/dissect-manifest.md
@@ -7,7 +7,7 @@ repository, without depending on it as a runtime crate.
 This document freezes **schema v1**. The loader and runtime resolution path in
 `stream::resolve_manifest` are active; V2 structural naming
 (`block_{NNN}.slot_{SS}.{kind}`) is accepted for runtime GOZ1 packs as of
-#40 / RM-191, with a fail-closed rule for unmatched tensors (see below).
+GitHub #40 / RM-191, with a fail-closed rule for unmatched tensors (see below).
 
 ## Authority and source of truth
 

--- a/src/bin/grok-ozempic/main.rs
+++ b/src/bin/grok-ozempic/main.rs
@@ -131,7 +131,9 @@ enum Commands {
         #[arg(long)]
         output: PathBuf,
 
-        /// Optional xai-dissect manifest JSON (V1 names for runtime quantize)
+        /// Optional xai-dissect manifest JSON: V1 `blk.*` names or V2 structural
+        /// `block_{NNN}.slot_{SS}.{kind}` names. V2 requires structural-named
+        /// inputs and hard-errors on any unmatched tensor (no defaults fallthrough)
         #[arg(long)]
         manifest: Option<PathBuf>,
 

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -89,6 +89,18 @@ pub struct DissectManifest {
     pub blocks: Vec<ManifestBlock>,
 }
 
+impl DissectManifest {
+    /// True when this manifest declares the V2 structural naming convention
+    /// ([`MANIFEST_NAME_CONVENTION_V2`], `block_{NNN}.slot_{SS}.{kind}`).
+    ///
+    /// Runtime classification treats V2 manifests fail-closed: a tensor that
+    /// matches no explicit rule is a hard error instead of falling through to
+    /// `defaults` (see `crate::core::stream`).
+    pub fn is_structural_v2(&self) -> bool {
+        self.model.tensor_name_convention == MANIFEST_NAME_CONVENTION_V2
+    }
+}
+
 /// Model identity carried in the manifest.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ManifestModel {
@@ -176,8 +188,8 @@ pub struct ManifestBlock {
 /// - the JSON is malformed ([`GrokOzempicError::ManifestParse`]),
 /// - `schema_version` is not [`MANIFEST_SCHEMA_VERSION`]
 ///   ([`GrokOzempicError::ManifestSchemaVersion`]),
-/// - `model.tensor_name_convention` is not
-///   [`MANIFEST_NAME_CONVENTION_V1`]
+/// - `model.tensor_name_convention` is neither
+///   [`MANIFEST_NAME_CONVENTION_V1`] nor [`MANIFEST_NAME_CONVENTION_V2`]
 ///   ([`GrokOzempicError::ManifestNameConventionMismatch`]).
 ///
 /// Unknown top-level fields are tolerated.

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -505,6 +505,11 @@ fn build_manifest_safetensors(
             if dtype == SourceDtype::Other {
                 // i8/Other covered for alignment via structural manifest (see grok1_inventory NOTE);
                 // skipped in float stream; int8 via artifact wraps. Kilo agent xAI/Grok Build 0.1 (Codex P1 PR#26).
+                // Under V2 still classify the name so fail-closed applies to *all* present tensors
+                // (including unsupported dtypes) before the intentional skip — GH #40 / RM-191.
+                if dissect_manifest.is_some_and(|m| m.is_structural_v2()) {
+                    let _ = classify_and_decide(&name, dissect_manifest, config)?;
+                }
                 continue;
             }
             let (_class, precision, gif_threshold) =
@@ -531,16 +536,20 @@ fn build_manifest_npy(
     for path in paths {
         let npy = MmapNpy::map_path(path)?;
         let dtype = npy_dtype_to_source(npy.dtype());
-        if dtype == SourceDtype::Other {
-            // i8/Other from xai-dissect inventory covered in structural manifest for alignment only
-            // (grok1_inventory.rs NOTE + structural _i8_streaming_note). Skipped here; enter via artifact wraps.
-            // Kilo agent xAI/Grok Build 0.1 (Codex P1 on PR #26).
-            continue;
-        }
         let stem = path.file_stem().and_then(|s| s.to_str()).ok_or_else(|| {
             GrokOzempicError::InvalidConfig(format!("bad npy filename: {}", path.display()))
         })?;
         let tensor_name = npy_stem_to_tensor_name(stem);
+        if dtype == SourceDtype::Other {
+            // i8/Other from xai-dissect inventory covered in structural manifest for alignment only
+            // (grok1_inventory.rs NOTE + structural _i8_streaming_note). Skipped here; enter via artifact wraps.
+            // Kilo agent xAI/Grok Build 0.1 (Codex P1 on PR #26).
+            // Under V2 still classify the name so fail-closed applies before the skip (GH #40 / RM-191).
+            if dissect_manifest.is_some_and(|m| m.is_structural_v2()) {
+                let _ = classify_and_decide(&tensor_name, dissect_manifest, config)?;
+            }
+            continue;
+        }
         let (_class, precision, gif_threshold) =
             classify_and_decide(&tensor_name, dissect_manifest, config)?;
         let shape: Vec<u64> = npy.shape().iter().map(|&d| d as u64).collect();
@@ -592,6 +601,19 @@ fn bytemuck_cast_f16(raw: &[u8]) -> &[f16] {
 /// `#[cfg(test)]` test module can refer to it via `super::`.
 #[cfg(test)]
 static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Clears `MANIFEST_ENV_VAR` on drop so a panicking test cannot leak the
+/// env into sibling tests (guard is only meaningful under `ENV_TEST_MUTEX`).
+#[cfg(test)]
+struct ManifestEnvGuard;
+
+#[cfg(test)]
+impl Drop for ManifestEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: callers hold `ENV_TEST_MUTEX` for the lifetime of this guard.
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+    }
+}
 
 fn bf16_bytes_to_f32(raw: &[u8]) -> Vec<f32> {
     assert_eq!(raw.len() % 2, 0, "bf16 data length must be a multiple of 2");
@@ -653,6 +675,43 @@ mod tests {
         for v in data {
             bytes.extend_from_slice(&v.to_le_bytes());
         }
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&bytes).unwrap();
+    }
+
+    /// Minimal i8 `.npy` (descr `<i1`) so `SourceDtype::Other` is exercised
+    /// without needing safetensors fixtures.
+    fn write_npy_i8(path: &std::path::Path, shape: &[usize], data: &[i8]) {
+        use std::io::Write as _;
+        let expected: usize = shape.iter().product();
+        assert_eq!(expected, data.len(), "data length must match shape");
+        let shape_str = if shape.is_empty() {
+            "()".to_string()
+        } else if shape.len() == 1 {
+            format!("({},)", shape[0])
+        } else {
+            let inner = shape
+                .iter()
+                .map(|d| d.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("({inner})")
+        };
+        let dict = format!("{{'descr': '<i1', 'fortran_order': False, 'shape': {shape_str}, }}");
+        let magic = b"\x93NUMPY";
+        let preamble_len = magic.len() + 1 + 1 + 2;
+        let raw_header_len = dict.len();
+        let total_unpadded = preamble_len + raw_header_len;
+        let pad = (64 - (total_unpadded % 64)) % 64;
+        let header_len = raw_header_len + pad;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(magic);
+        bytes.push(1);
+        bytes.push(0);
+        bytes.extend_from_slice(&(header_len as u16).to_le_bytes());
+        bytes.extend_from_slice(dict.as_bytes());
+        bytes.extend(std::iter::repeat_n(b' ', pad));
+        bytes.extend(data.iter().map(|&v| v as u8));
         let mut f = std::fs::File::create(path).unwrap();
         f.write_all(&bytes).unwrap();
     }
@@ -1186,6 +1245,31 @@ mod tests {
         }
     }
 
+    /// Unsupported dtypes are skipped by the float stream, but under V2 their
+    /// names must still be classified so a legacy/misspelled stem cannot
+    /// silently disappear past fail-closed (Codex/CodeAnt on PR #55).
+    #[test]
+    fn v2_manifest_fails_closed_on_unmatched_other_dtype() {
+        let dir = scratch_dir("v2-fail-closed-other-input");
+        write_npy_i8(
+            &dir.join("blk__0__moe_gate__weight.npy"),
+            &[4],
+            &[1i8, -1, 0, 2],
+        );
+        let out = scratch_dir("v2-fail-closed-other-out").join("bad.goz1");
+
+        let mut config = base_config(&dir, &out);
+        config.manifest_path = Some(in_tree_structural_manifest());
+        let err = run_quantization(&config)
+            .expect_err("unmatched Other-dtype name under V2 must fail closed");
+        match err {
+            GrokOzempicError::ManifestV2UnmatchedTensor { ref name } => {
+                assert_eq!(name, "blk.0.moe_gate.weight");
+            }
+            other => panic!("expected ManifestV2UnmatchedTensor, got {other:?}"),
+        }
+    }
+
     /// The `GROK_OZEMPIC_MANIFEST` env path accepts V2 structural
     /// manifests too (same policy as the explicit `manifest_path`).
     #[test]
@@ -1195,13 +1279,12 @@ mod tests {
         let out = scratch_dir("v2-env-out").join("v2env.goz1");
 
         let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        // SAFETY: mutation guarded by the env test mutex.
+        // SAFETY: mutation guarded by the env test mutex; ManifestEnvGuard
+        // clears the var even if run_quantization panics.
+        let _env_guard = super::ManifestEnvGuard;
         unsafe { std::env::set_var(MANIFEST_ENV_VAR, in_tree_structural_manifest()) };
         let config = base_config(&dir, &out);
-        let result = run_quantization(&config);
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
-
-        let stats = result.expect("V2 manifest via env var must be accepted");
+        let stats = run_quantization(&config).expect("V2 manifest via env var must be accepted");
         assert_structural_fixture_stats(&stats);
     }
 

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -92,6 +92,21 @@ pub fn append_grok1_arch_metadata(meta: &mut BTreeMap<String, PackMetaValue>) {
 /// is `None`.
 pub const MANIFEST_ENV_VAR: &str = "GROK_OZEMPIC_MANIFEST";
 
+/// Path from `GROK_OZEMPIC_MANIFEST`, or a test-only override.
+///
+/// Under `cfg(test)`, unit tests inject a path (or force unset) via
+/// `test_manifest_env` so they never call process-wide `set_var` /
+/// `remove_var` (unsafe on Unix when other threads may read the env).
+fn manifest_env_path() -> Option<String> {
+    #[cfg(test)]
+    if let Some(forced) = test_manifest_env::current() {
+        return forced;
+    }
+    std::env::var(MANIFEST_ENV_VAR)
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
 /// Resolve the xai-dissect manifest that governs this `run_quantization`
 /// call.
 ///
@@ -109,9 +124,7 @@ fn resolve_manifest(config: &QuantizationConfig) -> Result<Option<DissectManifes
     if let Some(path) = &config.manifest_path {
         return Ok(Some(load_manifest(path)?));
     }
-    if let Ok(env_path) = std::env::var(MANIFEST_ENV_VAR)
-        && !env_path.is_empty()
-    {
+    if let Some(env_path) = manifest_env_path() {
         let p = std::path::PathBuf::from(env_path);
         return Ok(Some(load_manifest(&p)?));
     }
@@ -121,6 +134,53 @@ fn resolve_manifest(config: &QuantizationConfig) -> Result<Option<DissectManifes
         return Ok(Some(embedded_grok1_baseline()?.clone()));
     }
     Ok(None)
+}
+
+/// Test-only injection for [`manifest_env_path`] — thread-local so parallel
+/// tests do not race and so no process `set_var` is required.
+#[cfg(test)]
+mod test_manifest_env {
+    use std::cell::RefCell;
+
+    thread_local! {
+        /// `None` = use real process env.
+        /// `Some(None)` = force unset.
+        /// `Some(Some(path))` = force this path.
+        static OVERRIDE: RefCell<Option<Option<String>>> = const { RefCell::new(None) };
+    }
+
+    pub(super) fn current() -> Option<Option<String>> {
+        OVERRIDE.with(|c| c.borrow().clone())
+    }
+
+    /// Restores the previous override on drop (including panic unwind).
+    pub(super) struct Guard {
+        prev: Option<Option<String>>,
+    }
+
+    impl Guard {
+        pub(super) fn set(path: impl Into<String>) -> Self {
+            let path = path.into();
+            let prev = OVERRIDE.with(|c| c.borrow().clone());
+            OVERRIDE.with(|c| *c.borrow_mut() = Some(Some(path)));
+            Self { prev }
+        }
+
+        pub(super) fn unset() -> Self {
+            let prev = OVERRIDE.with(|c| c.borrow().clone());
+            OVERRIDE.with(|c| *c.borrow_mut() = Some(None));
+            Self { prev }
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            let prev = self.prev.take();
+            // `prev` was `Option<Option<String>>` stored as the cell value;
+            // restore it even when it was `None` (no override).
+            OVERRIDE.with(|c| *c.borrow_mut() = prev);
+        }
+    }
 }
 
 /// Return `true` if a deprecation warning about `router_patterns`
@@ -596,25 +656,6 @@ fn bytemuck_cast_f16(raw: &[u8]) -> &[f16] {
     unsafe { std::slice::from_raw_parts(raw.as_ptr().cast::<f16>(), raw.len() / 2) }
 }
 
-/// Serialises env-var mutations across tests that touch
-/// `GROK_OZEMPIC_MANIFEST`. Declared at the module level so the
-/// `#[cfg(test)]` test module can refer to it via `super::`.
-#[cfg(test)]
-static ENV_TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// Clears `MANIFEST_ENV_VAR` on drop so a panicking test cannot leak the
-/// env into sibling tests (guard is only meaningful under `ENV_TEST_MUTEX`).
-#[cfg(test)]
-struct ManifestEnvGuard;
-
-#[cfg(test)]
-impl Drop for ManifestEnvGuard {
-    fn drop(&mut self) {
-        // SAFETY: callers hold `ENV_TEST_MUTEX` for the lifetime of this guard.
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
-    }
-}
-
 fn bf16_bytes_to_f32(raw: &[u8]) -> Vec<f32> {
     assert_eq!(raw.len() % 2, 0, "bf16 data length must be a multiple of 2");
     raw.chunks_exact(2)
@@ -864,10 +905,8 @@ mod tests {
     /// byte-identical GOZ1 output.
     #[test]
     fn parity_legacy_vs_baseline_is_byte_identical() {
-        // Hold ENV_TEST_MUTEX so a parallel env-var test cannot leak
-        // GROK_OZEMPIC_MANIFEST into the legacy run below.
-        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+        // Force-unset so a real process env cannot leak into the legacy path.
+        let _env = super::test_manifest_env::Guard::unset();
 
         let dir = scratch_dir("parity-input");
         write_parity_fixture(&dir);
@@ -908,8 +947,7 @@ mod tests {
     /// value of the manifest wiring.
     #[test]
     fn divergence_on_ffn_gate_false_positive() {
-        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+        let _env = super::test_manifest_env::Guard::unset();
 
         let dir = scratch_dir("diverge-input");
         write_parity_fixture(&dir);
@@ -985,22 +1023,22 @@ mod tests {
         let out_a = scratch_dir("prec-out-a").join("a.goz1");
         let out_b = scratch_dir("prec-out-b").join("b.goz1");
 
-        // Serialize env-var mutations for test-safety.
-        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        // SAFETY: mutation guarded by the single-threaded test mutex.
-        unsafe { std::env::set_var(MANIFEST_ENV_VAR, &env_path) };
-
         // A: explicit + env — explicit must win.
-        let mut config = base_config(&dir, &out_a);
-        config.manifest_path = Some(explicit_path.clone());
-        run_quantization(&config).expect("explicit+env run");
+        {
+            let _env = super::test_manifest_env::Guard::set(env_path.to_string_lossy());
+            let mut config = base_config(&dir, &out_a);
+            config.manifest_path = Some(explicit_path.clone());
+            run_quantization(&config).expect("explicit+env run");
+        }
 
         // B: explicit only — same explicit manifest, no env. Should
         // produce identical bytes to A if explicit truly won.
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
-        let mut config = base_config(&dir, &out_b);
-        config.manifest_path = Some(explicit_path.clone());
-        run_quantization(&config).expect("explicit only run");
+        {
+            let _env = super::test_manifest_env::Guard::unset();
+            let mut config = base_config(&dir, &out_b);
+            config.manifest_path = Some(explicit_path.clone());
+            run_quantization(&config).expect("explicit only run");
+        }
 
         let a = goz1_bytes(&out_a);
         let b = goz1_bytes(&out_b);
@@ -1038,17 +1076,19 @@ mod tests {
         let out_legacy = scratch_dir("env-out-legacy").join("a.goz1");
         let out_env = scratch_dir("env-out-env").join("b.goz1");
 
-        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        // Legacy run (env var unset).
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
-        let config = base_config(&dir, &out_legacy);
-        run_quantization(&config).expect("legacy run");
+        // Legacy run (env path forced unset).
+        {
+            let _env = super::test_manifest_env::Guard::unset();
+            let config = base_config(&dir, &out_legacy);
+            run_quantization(&config).expect("legacy run");
+        }
 
         // Env-var run.
-        unsafe { std::env::set_var(MANIFEST_ENV_VAR, &env_path) };
-        let config = base_config(&dir, &out_env);
-        run_quantization(&config).expect("env var run");
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+        {
+            let _env = super::test_manifest_env::Guard::set(env_path.to_string_lossy());
+            let config = base_config(&dir, &out_env);
+            run_quantization(&config).expect("env var run");
+        }
 
         assert_ne!(
             goz1_bytes(&out_legacy),
@@ -1070,8 +1110,7 @@ mod tests {
     /// silent drift.
     #[test]
     fn preserve_and_fp16_tiers_emit_identical_goz1_bytes() {
-        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+        let _env = super::test_manifest_env::Guard::unset();
 
         let dir = scratch_dir("preserve-fp16-input");
         let ffn_up = [0.3f32, -0.3, 0.01, -0.01];
@@ -1278,11 +1317,9 @@ mod tests {
         write_structural_fixture(&dir);
         let out = scratch_dir("v2-env-out").join("v2env.goz1");
 
-        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
-        // SAFETY: mutation guarded by the env test mutex; ManifestEnvGuard
-        // clears the var even if run_quantization panics.
-        let _env_guard = super::ManifestEnvGuard;
-        unsafe { std::env::set_var(MANIFEST_ENV_VAR, in_tree_structural_manifest()) };
+        // Thread-local env override — no process set_var (Codacy/CodeRabbit).
+        let _env =
+            super::test_manifest_env::Guard::set(in_tree_structural_manifest().to_string_lossy());
         let config = base_config(&dir, &out);
         let stats = run_quantization(&config).expect("V2 manifest via env var must be accepted");
         assert_structural_fixture_stats(&stats);

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -24,9 +24,7 @@ use safetensors::SafeTensors;
 
 use crate::{
     core::{
-        manifest::{
-            DissectManifest, MANIFEST_NAME_CONVENTION_V2, embedded_grok1_baseline, load_manifest,
-        },
+        manifest::{DissectManifest, embedded_grok1_baseline, load_manifest},
         npy::{MmapNpy, NpyDtype, npy_stem_to_tensor_name},
         precision::decide as precision_decide,
         quantizer::{convert_f32_to_f16_bytes, passthrough_f16, quantize_f16, quantize_f32},
@@ -109,27 +107,13 @@ pub const MANIFEST_ENV_VAR: &str = "GROK_OZEMPIC_MANIFEST";
 ///    [`crate::core::selection::classify`].
 fn resolve_manifest(config: &QuantizationConfig) -> Result<Option<DissectManifest>> {
     if let Some(path) = &config.manifest_path {
-        let m = load_manifest(path)?;
-        if m.model.tensor_name_convention == MANIFEST_NAME_CONVENTION_V2 {
-            return Err(GrokOzempicError::ManifestNameConventionMismatch {
-                got: m.model.tensor_name_convention.clone(),
-                expected: "V1 only for runtime quantization (block_{NNN}.slot_{SS}.{kind} / V2 structural naming is accepted only for embedded alignment verification in core/alignment.rs until checkpoint-to-structural name translation is added in npy/stream build_manifest_*; see Codex P1 review on PR #26)".to_string(),
-            });
-        }
-        return Ok(Some(m));
+        return Ok(Some(load_manifest(path)?));
     }
     if let Ok(env_path) = std::env::var(MANIFEST_ENV_VAR)
         && !env_path.is_empty()
     {
         let p = std::path::PathBuf::from(env_path);
-        let m = load_manifest(&p)?;
-        if m.model.tensor_name_convention == MANIFEST_NAME_CONVENTION_V2 {
-            return Err(GrokOzempicError::ManifestNameConventionMismatch {
-                got: m.model.tensor_name_convention.clone(),
-                expected: "V1 only for runtime quantization (block_{NNN}.slot_{SS}.{kind} / V2 structural naming is accepted only for embedded alignment verification in core/alignment.rs until checkpoint-to-structural name translation is added in npy/stream build_manifest_*; see Codex P1 review on PR #26)".to_string(),
-            });
-        }
-        return Ok(Some(m));
+        return Ok(Some(load_manifest(&p)?));
     }
     if config.use_embedded_baseline {
         // Embedded baseline: clone once so callers own a DissectManifest.
@@ -488,6 +472,16 @@ fn classify_and_decide(
         &config.router_patterns
     };
     let class = classify(name, dissect_manifest, legacy_patterns);
+    // V2 structural manifests are fail-closed: they are authored for full
+    // explicit coverage, so a Default classification means the input name
+    // does not follow the structural convention (or a rule is missing).
+    // Falling through to defaults here is how routers/norms would get
+    // silently ternary-quantized — hard-error instead (GH #40 / RM-191).
+    if matches!(class, TensorClass::Default)
+        && dissect_manifest.is_some_and(|m| m.is_structural_v2())
+    {
+        return Err(GrokOzempicError::ManifestV2UnmatchedTensor { name: name.into() });
+    }
     let (precision, gif_threshold) = precision_decide(&class, dissect_manifest, config)?;
     Ok((class, precision, gif_threshold))
 }
@@ -1085,6 +1079,186 @@ mod tests {
                 a.get(first_diff),
                 b.get(first_diff),
             );
+        }
+    }
+
+    // ---------- V2 structural manifest bridge (GH #40 / RM-191) ----------
+
+    fn in_tree_structural_manifest() -> std::path::PathBuf {
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("dissect/grok-1/structural-manifest.json")
+    }
+
+    /// Structural-named npy fixture, one tensor per file so per-file
+    /// `ShardStats` is an exact per-tensor classification oracle.
+    ///
+    /// Expected classes under `dissect/grok-1/structural-manifest.json`:
+    /// - `block_000.slot_11.router`            preserve  → fp16-at-rest
+    /// - `block_000.slot_07.block_norm`        preserve  → fp16-at-rest
+    /// - `block_000.slot_00.moe_expert.gate`   ternary candidate
+    /// - `embedding.slot_00.token_embedding`   ternary candidate
+    fn write_structural_fixture(dir: &std::path::Path) {
+        write_npy_f32(
+            &dir.join("block_000__slot_00__moe_expert__gate.npy"),
+            &[2, 2],
+            &[0.1f32, -0.2, 0.3, -0.4],
+        );
+        write_npy_f32(
+            &dir.join("block_000__slot_07__block_norm.npy"),
+            &[2, 2],
+            &[1.0f32, -1.0, 0.5, -0.5],
+        );
+        write_npy_f32(
+            &dir.join("block_000__slot_11__router.npy"),
+            &[2, 2],
+            &[0.05f32, 0.9, -0.05, -0.9],
+        );
+        write_npy_f32(
+            &dir.join("embedding__slot_00__token_embedding.npy"),
+            &[2, 2],
+            &[0.3f32, -0.3, 0.01, -0.01],
+        );
+    }
+
+    fn assert_structural_fixture_stats(stats: &[ShardStats]) {
+        assert_eq!(stats.len(), 4, "one ShardStats per npy file");
+        for s in stats {
+            let stem = s
+                .shard_path
+                .file_stem()
+                .and_then(|f| f.to_str())
+                .expect("utf-8 stem");
+            let preserved = stem.contains("router") || stem.contains("block_norm");
+            if preserved {
+                assert_eq!(
+                    (s.tensors_fp16, s.tensors_ternary),
+                    (1, 0),
+                    "{stem} must be preserved (fp16-at-rest), not ternary"
+                );
+            } else {
+                assert_eq!(
+                    (s.tensors_ternary, s.tensors_fp16),
+                    (1, 0),
+                    "{stem} must be a ternary candidate"
+                );
+            }
+        }
+    }
+
+    /// End-to-end: the in-tree V2 structural manifest drives a real
+    /// `run_quantization` over structural-named npy inputs — routers and
+    /// norms are preserved, embedding and MoE gate go ternary.
+    #[test]
+    fn v2_structural_manifest_end_to_end_npy() {
+        let dir = scratch_dir("v2-e2e-input");
+        write_structural_fixture(&dir);
+        let out = scratch_dir("v2-e2e-out").join("v2.goz1");
+
+        let mut config = base_config(&dir, &out);
+        config.manifest_path = Some(in_tree_structural_manifest());
+        let stats = run_quantization(&config).expect("V2 structural manifest must be accepted");
+        assert_structural_fixture_stats(&stats);
+    }
+
+    /// Fail-closed regression for the #40 disaster scenario: legacy-named
+    /// inputs against a V2 structural manifest must hard-error on the
+    /// unmatched tensor instead of silently ternary-quantizing it through
+    /// `defaults.precision`.
+    #[test]
+    fn v2_manifest_fails_closed_on_unmatched_name() {
+        let dir = scratch_dir("v2-fail-closed-input");
+        write_npy_f32(
+            &dir.join("blk__0__moe_gate__weight.npy"),
+            &[2, 2],
+            &[0.1f32, -0.2, 0.3, -0.4],
+        );
+        let out = scratch_dir("v2-fail-closed-out").join("bad.goz1");
+
+        let mut config = base_config(&dir, &out);
+        config.manifest_path = Some(in_tree_structural_manifest());
+        let err = run_quantization(&config)
+            .expect_err("V1-named input under a V2 manifest must fail closed");
+        match err {
+            GrokOzempicError::ManifestV2UnmatchedTensor { ref name } => {
+                assert_eq!(name, "blk.0.moe_gate.weight");
+            }
+            other => panic!("expected ManifestV2UnmatchedTensor, got {other:?}"),
+        }
+    }
+
+    /// The `GROK_OZEMPIC_MANIFEST` env path accepts V2 structural
+    /// manifests too (same policy as the explicit `manifest_path`).
+    #[test]
+    fn v2_manifest_accepted_via_env_var() {
+        let dir = scratch_dir("v2-env-input");
+        write_structural_fixture(&dir);
+        let out = scratch_dir("v2-env-out").join("v2env.goz1");
+
+        let _lock = super::ENV_TEST_MUTEX.lock().unwrap();
+        // SAFETY: mutation guarded by the env test mutex.
+        unsafe { std::env::set_var(MANIFEST_ENV_VAR, in_tree_structural_manifest()) };
+        let config = base_config(&dir, &out);
+        let result = run_quantization(&config);
+        unsafe { std::env::remove_var(MANIFEST_ENV_VAR) };
+
+        let stats = result.expect("V2 manifest via env var must be accepted");
+        assert_structural_fixture_stats(&stats);
+    }
+
+    /// Path-gated oracle against the latest authoritative xai-dissect run:
+    /// every `structural_name` in run3's `conversion-manifest.json` must
+    /// classify to an explicit rule of the in-tree structural manifest
+    /// (routers/norms preserve, everything else ternary, zero Default).
+    ///
+    /// Skips (passes trivially) when the run directory is absent, e.g. CI.
+    /// Override the location with `GROK_OZEMPIC_DISSECT_RUN`.
+    #[test]
+    fn run3_conversion_manifest_names_fully_classified() {
+        let run_dir = std::env::var("GROK_OZEMPIC_DISSECT_RUN")
+            .map(std::path::PathBuf::from)
+            .ok()
+            .or_else(|| {
+                std::env::var("HOME").ok().map(|h| {
+                    std::path::PathBuf::from(h).join(
+                        "rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0",
+                    )
+                })
+            });
+        let Some(conversion) = run_dir.map(|d| d.join("conversion-manifest.json")) else {
+            eprintln!("skip: no GROK_OZEMPIC_DISSECT_RUN and no HOME");
+            return;
+        };
+        if !conversion.is_file() {
+            eprintln!(
+                "skip: {} not present (xai-dissect run not mounted)",
+                conversion.display()
+            );
+            return;
+        }
+
+        let bytes = std::fs::read(&conversion).expect("read conversion manifest");
+        let doc: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("conversion manifest JSON");
+        let tensors = doc["tensors"].as_array().expect("tensors array");
+        assert_eq!(tensors.len(), 770, "run3 must list all 770 tensors");
+
+        let manifest = load_manifest(&in_tree_structural_manifest()).expect("structural manifest");
+        assert!(manifest.is_structural_v2());
+
+        for t in tensors {
+            let name = t["structural_name"].as_str().expect("structural_name");
+            let kind = t["kind"].as_str().expect("kind");
+            let class = classify(name, Some(&manifest), &[]);
+            match kind {
+                "router" | "block_norm" | "final_norm" => assert!(
+                    matches!(class, TensorClass::Preserve { .. }),
+                    "{name} (kind {kind}) must be Preserve, got {class:?}"
+                ),
+                _ => assert!(
+                    matches!(class, TensorClass::TernaryCandidate { .. }),
+                    "{name} (kind {kind}) must be TernaryCandidate, got {class:?}"
+                ),
+            }
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,14 @@ pub enum GrokOzempicError {
     #[error("unsupported manifest precision tier: {got:?}")]
     ManifestInvalidPrecision { got: String },
 
+    #[error(
+        "tensor {name:?} matches no rule in the V2 structural manifest; refusing defaults \
+         fallthrough so preserve tensors (routers/norms) cannot be silently ternary-quantized. \
+         Use structural input names (block_{{NNN}}.slot_{{SS}}.{{kind}}, e.g. export-script npy \
+         stems) or supply a V1 manifest for legacy-named inputs"
+    )]
+    ManifestV2UnmatchedTensor { name: String },
+
     #[error("artifact validation error: {0}")]
     ArtifactValidation(String),
 


### PR DESCRIPTION
## **User description**

**Agent:** Claude Code: Claude Fable 5 · **Issue:** [#40](<https://github.com/rmems/grok-ozempic/issues/40>) / Linear [RM-191](https://linear.app/rpd-34/issue/RM-191/grok-ozempic-gh40-v2-structural-name-bridge-for-stream) · beads `goz-5a7hun`

Closes [#40](<https://github.com/rmems/grok-ozempic/issues/40>).

## Design: accept V2 for structural-named inputs, fail-closed

Of the two options in the issue ("checkpoint↔structural name map OR accept V2 when inputs already use structural names"), this lands **accept-V2**:

* The npy export path already emits structural logical names (`scripts/export_grok1_embedding_npy.py` stems, `__` → `.` → `embedding.slot_00.token_embedding`), and `selection::classify` / `glob_match` are convention-agnostic with existing V2 pattern tests.
* A checkpoint↔structural translation table would be invented authoritative naming data — xai-dissect owns that. The authoritative map already exists externally in `LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/conversion-manifest.json` and is consumed here as a **test oracle only** (per review discussion), not as runtime input.

**Safety property (the point of** [#40](<https://github.com/rmems/grok-ozempic/issues/40>)**):** under a V2 manifest, any tensor classifying to `TensorClass::Default` is a hard error (`ManifestV2UnmatchedTensor`) instead of a `defaults` fallthrough. V2 manifests are authored for full explicit coverage (770/770 in alignment tests), so an unmatched name always means a naming mismatch — exactly the scenario that would silently ternary-quantize routers/norms. Both failure modes now abort loudly: legacy `blk.*` inputs against V2, and typo'd/missing V2 rules. V1 manifests keep defaults fallthrough — no V1 behavior change.

## Changes

* `stream::resolve_manifest`: drop the two V2 rejection blocks (explicit path + env var); precedence chain unchanged, embedded baseline stays V1 opt-in.
* `stream::classify_and_decide`: fail-closed guard at the single choke point shared by npy and safetensors builds.
* `error.rs`: new typed `ManifestV2UnmatchedTensor { name }` with remediation hint.
* `manifest.rs`: `DissectManifest::is_structural_v2()` helper; stale loader doc fixed.
* CLI `--manifest` help updated; docs/rules/skills/commands flipped to prefer `structural-manifest.json` for structural-named real packs (V1 `baseline.json` remains for legacy names).

## Test evidence

* `v2_structural_manifest_end_to_end_npy` — real `run_quantization` over structural npy names with the in-tree V2 manifest: router + block_norm → fp16/preserve, embedding + moe gate → ternary (per-file `ShardStats`, one tensor per file).
* `v2_manifest_fails_closed_on_unmatched_name` — legacy-named npy + V2 manifest errors with the tensor name; no silent ternary (the [#40](<https://github.com/rmems/grok-ozempic/issues/40>) disaster regression).
* `v2_manifest_accepted_via_env_var` — `GROK_OZEMPIC_MANIFEST` path accepts V2 with identical policy.
* `run3_conversion_manifest_names_fully_classified` — path-gated oracle: all **770** `structural_name`s from the latest xai-dissect run classify to explicit rules (routers/norms Preserve, rest TernaryCandidate, zero Default); skips when the run dir is absent (CI), override with `GROK_OZEMPIC_DISSECT_RUN`. Verified locally against `grok1_run3_20260802T023050Z`.
* CLI smoke: `quantize-goz1 --manifest dissect/grok-1/structural-manifest.json --input-format npy --verify` → `4 tensors: 2 ternary, 2 fp16/preserve`, `GOZ1 verify ok`; legacy-named input aborts with the typed error.
* Full matrix green: `fmt --check`, `clippy --all-targets --all-features --locked -D warnings`, `test --all-targets --all-features --locked` (133 tests), `build`, `doc`.

## Residual risks

* HF-community safetensors names are neither V1 `blk.*` nor structural — under a V2 manifest they now fail loudly instead of silently ternary-quantizing; a translation layer (if ever wanted) belongs upstream in xai-dissect.
* `run3` `quant-plan.json` defers `token_embedding` for pilot runs; this PR keeps embedding a ternary candidate per the in-tree manifest and [#39](<https://github.com/rmems/grok-ozempic/issues/39>) continuity. Pilot policy consumption is rmems/grok-ozempic#53 (`goz-le7zjc`), unblocked by this PR.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

## Summary by cubic

Accept V2 structural manifests for runtime packs and add a fail-closed check to stop silent ternary quantization on name mismatches. This implements Linear [RM-191](https://linear.app/rpd-34/issue/RM-191/grok-ozempic-gh40-v2-structural-name-bridge-for-stream) and makes `dissect/grok-1/structural-manifest.json` the preferred manifest for structural-named inputs.

* **New Features**
  * `resolve_manifest` now loads V2 (`block_{NNN}.slot_{SS}.{kind}`) manifests alongside V1.
  * Fail-closed classification under V2 with `ManifestV2UnmatchedTensor` for unmatched names.
  * `DissectManifest::is_structural_v2()` helper; CLI help updated.
  * Tests for end-to-end V2 npy packs, env var acceptance, and a path-gated oracle against the latest xai-dissect run.
* **Migration**
  * Use `dissect/grok-1/structural-manifest.json` when inputs are structural-named (npy export stems, `__` → `.`).
  * Keep `dissect/grok-1/baseline.json` (V1) for legacy `blk.*` names.
  * Under V2, unmatched tensors hard-error (no defaults fallthrough). Use `--verify` for packs.

Written for commit f1f6f2f7cb0fe50fbe70f7e843bd2fb85efd76a7. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

---

## **CodeAnt-AI Description**

Accept structural V2 manifests for runtime quantization while preventing unsafe tensor fallthrough

### What Changed

* Runtime quantization now accepts V2 structural manifests for structural-named inputs, including NPY exports and environment-selected manifests.
* Unmatched tensors under a V2 manifest now stop the run with a clear error instead of falling through to default ternary quantization.
* V1 manifests and legacy `blk.*` inputs retain their existing behavior.
* Added end-to-end checks confirming routers and norms remain preserved while embedding and MoE gate tensors use ternary quantization, plus coverage and environment-variable checks.
* Updated command guidance and documentation to recommend the V2 structural manifest for structural-named inputs.

### Impact

`✅ Prevented silent ternary quantization of routers and norms`  <br>`✅ Structural NPY packs can use explicit V2 tensor rules`  <br>`✅ Clear errors for mismatched tensor names`

<details><summary>💡 Usage Guide</summary>

### Checking Your Pull Request

Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI

Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:

```
@codeant-ai ask: Your question here
```

This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example

```
@codeant-ai ask: Can you suggest a safer alternative to storing this secret?
```

### Preserve Org Learnings with CodeAnt

You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:

```
@codeant-ai: Your feedback here
```

This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example

```
@codeant-ai: Do not flag unused imports.
```

### Retrigger review

Ask CodeAnt AI to review the PR again, by typing:

```
@codeant-ai: review
```

### Check Your Repository Health

To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](<https://app.codeant.ai>). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>