### PR TITLE
chore: suppress the beads export diff in review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# The beads export is a generated cache of GitHub + Linear (see CLAUDE.md).
+# It stores one JSON object per issue per line, averaging ~2.8 KB per line, so
+# a single status change rewrites a whole line and GitHub renders it inline as
+# a multi-KB diff. Suppress it in review rather than untracking the file: the
+# export is what lets an agent recover project context with no network access
+# and no API tokens.
+#
+#   -diff                  git/GitHub report "Binary files differ" instead of
+#                          dumping the JSON into every diff
+#   linguist-generated     GitHub collapses it by default in PRs and drops it
+#                          from repository language stats
+#
+# This is presentation only. The file is still tracked, still committed by the
+# beads hooks, and `git show`/`bd export` are unaffected. On a merge conflict
+# the rule is unchanged: re-export, never hand-merge.
+.beads/issues.jsonl -diff linguist-generated=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,13 @@ two disagree, GitHub/Linear wins and the export is refreshed.
 
 - `.beads/interactions.jsonl` is **not** tracked: a short log with little context
   value, so committing it is per-commit churn for no recovery benefit.
+- Its diff is **suppressed in review**, not its content: `.gitattributes` marks
+  `.beads/issues.jsonl` as `-diff linguist-generated=true`, so git and GitHub
+  report "Binary files differ" and collapse it in PRs. One issue per ~2.8 KB
+  line means a single status change otherwise renders as a ~26 KB diff. The file
+  is still tracked and still committed by the hooks -- read it with
+  `git show <rev>:.beads/issues.jsonl`, or `git diff --text` to force a textual
+  diff when you actually want one.
 - Let the beads hooks re-export; don't hand-edit the JSONL. On a rebase/merge
   conflict in it, **re-export instead of merging by hand** (`bd export`, or just
   commit and let the hook do it). Hand-edit only if the export is corrupt and


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code

## Summary

Adds a `.gitattributes` marking `.beads/issues.jsonl` as `-diff linguist-generated=true`, so the beads export stops flooding PR review. **Presentation only — the file stays tracked.**

## Why

The export stores one JSON object per issue per line, averaging **~2,854 bytes per line**, and this repo had **no `.gitattributes` at all**. So a single `status` field change rewrites an entire line and GitHub renders it inline, uncollapsed.

Measured on a real one-field edit:

| | diff size |
|---|---|
| Today | **25,855 bytes** |
| With this change | **153 bytes** (`Binary files … differ`) |

A **169×** reduction for the same logical change. `--numstat` also reports binary rather than inflating line counts, and GitHub collapses the file by default in PRs and drops it from language stats.

That mismatch is why the export feels noisy out of proportion to its content — it's only ~0.6% of added *lines* across the last 100 commits, but 23 of the last 65 commits carry a multi-KB unreadable diff.

## Why not untrack it

Deliberately keeping it tracked. `bd` is **not** installed on every agent surface — it is absent from the Claude Code cloud VM, verified this session — so the committed export remains the only way an agent with no network access and no API tokens can recover issue context. That is the #67 decision (`8a1e4a7`) and it still holds. This removes the review cost without giving up the recovery path.

Only 4 of the 23 beads-touching commits were beads-only, so it is mostly riding along with real work rather than generating standalone churn commits.

## Escape hatches (documented in `CLAUDE.md`)

* `git show <rev>:.beads/issues.jsonl` — full content at any revision
* `git diff --text` — forces a real textual diff, verified working

Merge policy is unchanged: on conflict, **re-export, never hand-merge**.

## Test plan

- [X] `git check-attr diff linguist-generated -- .beads/issues.jsonl` → `diff: unset`, `linguist-generated: true`
- [X] Control file (`scripts/grok1_multiblock_lib.py`) → both `unspecified`, unaffected
- [X] Real one-field edit, with vs without the file: 153 vs 25,855 bytes
- [X] `git diff --text` still produces the textual diff

## Non-goals

* Untracking the export or changing beads sync scope
* Merge-driver changes (`-merge` would suit the documented re-export rule, but it is a behaviour change and not what was asked for — happy to add separately)
* `Cargo.lock` or any other generated file — easy to add here if wanted

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuYSRWDXVJGs7P1eob4weo)_


___

## **CodeAnt-AI Description**
Suppress generated issue-export noise in pull request reviews

### What Changed
- Git and GitHub now collapse `.beads/issues.jsonl` and show it as a generated file instead of displaying large inline JSON diffs
- The issue export remains tracked, committed, and available for recovery; users can still view its contents or force a full text diff when needed
- Contributor guidance now explains the review behavior and recommends re-exporting after merge conflicts instead of manually merging the file

### Impact
`✅ Smaller pull request diffs`
`✅ Faster review of changes unrelated to issue exports`
`✅ Issue context remains available offline`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses diffs for the beads export while keeping it tracked. Previously `.beads/issues.jsonl` produced large inline JSONL diffs; now Git/GitHub treat it as binary and collapse it by default.

- Adds `.gitattributes` entry: `.beads/issues.jsonl -diff linguist-generated=true` and documents usage in `CLAUDE.md`.
- Cuts a typical one-field edit from ~25 KB inline diff to a 153 B “Binary files differ” entry (~169×).
- `git --numstat` reports binary; GitHub collapses the file and excludes it from language stats.
- The file stays tracked for offline context. To inspect it: `git show <rev>:.beads/issues.jsonl` or force text with `git diff --text`. On conflicts, re-export; never hand-merge.

<sup>Written for commit 28e0482a36cd17045993dd559afa87a89b3dfe8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

