### PR TITLE
docs: publish the verified Grok-1 first-experiment runbook (#41 / RM-188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ For `ternary_snn` candidates, the quantizer applies a saliency threshold:
 
 ### Two CLI paths: SAAQ metadata vs GOZ1 weight packing
 
+**SAAQ** means **Spiking Adaptive Activity Quantization**, terminology coined
+by this project's creator. In the commands below, “SAAQ metadata” names the
+structural planning/index pipeline; it is not shorthand for a GOZ1 weight file.
+
 | Path | Commands | Reads weights? |
 |------|----------|----------------|
 | **SAAQ metadata** | `validate-ingest`, `smoke-grok1`, `convert-grok1`, `validate-grok1-artifact` | Index/metadata only; may hash full shards if `checksums.json` is present under `--checkpoint` |
@@ -110,12 +114,14 @@ Official `xai-org/grok-1` `ckpt-0` shards are JAX **pickle** frames.
 [RM-189](https://linear.app/rpd-34/issue/RM-189)):
 
 ```bash
-# Customize CKPT / OUT for your machine (defaults also use ~/.models/xai-grok-1/...)
-CKPT="${CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
-OUT="${OUT:-$HOME/.models/xai-grok-1/export-npy}"
+# Override these variables when the checkpoint or outputs live elsewhere.
+GROK1_CKPT="${GROK1_CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
+GROK1_NPY="${GROK1_NPY:-$HOME/.models/xai-grok-1/export-npy}"
+GROK1_ARTIFACTS="${GROK1_ARTIFACTS:-$HOME/.models/xai-grok-1/artifacts}"
+mkdir -p "$GROK1_NPY" "$GROK1_ARTIFACTS"
 python3 scripts/export_grok1_embedding_npy.py \
-  --shard "$CKPT/tensor00000_000" \
-  --output-dir "$OUT"
+  --shard "$GROK1_CKPT/tensor00000_000" \
+  --output-dir "$GROK1_NPY"
 ```
 
 This writes `embedding__slot_00__token_embedding.npy` (logical name
@@ -126,18 +132,26 @@ directory as `--input-dir` to `quantize-goz1` below.
 
 Streams tensors through `run_quantization` into a GOZ1 file
 ([#38](https://github.com/rmems/grok-ozempic/issues/38) / Linear
-[RM-193](https://linear.app/rpd-34/issue/RM-193)) — now **GOZ1 v2** with per-tensor reconstruction scale:
+[RM-193](https://linear.app/rpd-34/issue/RM-193)). Current writes use **GOZ1
+v3**, which includes per-tensor reconstruction scale and applied-threshold
+fields:
 
 ```bash
 cargo run --features cli -- quantize-goz1 \
-  --input-dir /path/to/npy \
-  --output /tmp/model.goz1 \
+  --input-dir "$GROK1_NPY" \
+  --output "$GROK1_ARTIFACTS/grok1-first-embed.goz1" \
   --manifest dissect/grok-1/structural-manifest.json \
   --input-format npy \
   --verify
 ```
 
-GOZ1 v2 (`version=2`) appends `scale: f32` + `sentinel 0x5CA1E021` per tensor row so `value = scale × payload` reconstructs without the checkpoint. `TENSOR_TERNARY` stores reconstruction-optimal `α* = Σ(w·t)/count(fired)` (signed, not `Σ|w|`), `TENSOR_F16` stores `1.0`, fully-sparse stores `0.0`; non-finite/negative (ternary) and non-`1.0` (fp16) are rejected at write and at `--verify`. v1 packs remain readable via `entry["scale"] is None` oracle fallback. See [`docs/goz1-format.md`](docs/goz1-format.md).
+GOZ1 v2 introduced `scale: f32` + `sentinel 0x5CA1E021` per tensor row so
+`value = scale × payload` reconstructs without the checkpoint. Current v3 also
+stores `gif_threshold` and the applied absolute threshold. `TENSOR_TERNARY`
+uses the reconstruction-optimal scale; `TENSOR_F16` uses `1.0`; fully sparse
+tensors use `0.0`. Writers and `--verify` reject invalid scales and threshold
+metadata. Older v1/v2 packs remain readable under their versioned layouts. See
+[`docs/goz1-format.md`](docs/goz1-format.md).
 
 ## Developer verification
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Official `xai-org/grok-1` `ckpt-0` shards are JAX **pickle** frames.
 GROK1_CKPT="${GROK1_CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
 GROK1_NPY="${GROK1_NPY:-$HOME/.models/xai-grok-1/export-npy}"
 GROK1_ARTIFACTS="${GROK1_ARTIFACTS:-$HOME/.models/xai-grok-1/artifacts}"
+GROK1_MANIFEST="${GROK1_MANIFEST:-dissect/grok-1/structural-manifest.json}"
 mkdir -p "$GROK1_NPY" "$GROK1_ARTIFACTS"
 python3 scripts/export_grok1_embedding_npy.py \
   --shard "$GROK1_CKPT/tensor00000_000" \
@@ -140,7 +141,7 @@ fields:
 cargo run --features cli -- quantize-goz1 \
   --input-dir "$GROK1_NPY" \
   --output "$GROK1_ARTIFACTS/grok1-first-embed.goz1" \
-  --manifest dissect/grok-1/structural-manifest.json \
+  --manifest "$GROK1_MANIFEST" \
   --input-format npy \
   --verify
 ```

--- a/README.md
+++ b/README.md
@@ -116,18 +116,23 @@ Official `xai-org/grok-1` `ckpt-0` shards are JAX **pickle** frames.
 ```bash
 # Override these variables when the checkpoint or outputs live elsewhere.
 GROK1_CKPT="${GROK1_CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
-GROK1_NPY="${GROK1_NPY:-$HOME/.models/xai-grok-1/export-npy}"
+GROK1_NPY="${GROK1_NPY:-$(mktemp -d "${TMPDIR:-/tmp}/grok1-first-embed.XXXXXX")}"
 GROK1_ARTIFACTS="${GROK1_ARTIFACTS:-$HOME/.models/xai-grok-1/artifacts}"
 GROK1_MANIFEST="${GROK1_MANIFEST:-dissect/grok-1/structural-manifest.json}"
 mkdir -p "$GROK1_NPY" "$GROK1_ARTIFACTS"
 python3 scripts/export_grok1_embedding_npy.py \
   --shard "$GROK1_CKPT/tensor00000_000" \
   --output-dir "$GROK1_NPY"
+
+FOUND_NPY="$(find "$GROK1_NPY" -maxdepth 1 -type f -name '*.npy' -printf '%f\n')"
+test "$FOUND_NPY" = "embedding__slot_00__token_embedding.npy"
 ```
 
 This writes `embedding__slot_00__token_embedding.npy` (logical name
 `embedding.slot_00.token_embedding` after `__` → `.` stem mapping). Pass that
-directory as `--input-dir` to `quantize-goz1` below.
+fresh, single-tensor directory as `--input-dir` to `quantize-goz1` below. If
+you override `GROK1_NPY`, the `test` deliberately fails when that directory
+contains missing or additional NPY tensors.
 
 ### GOZ1 packing (`quantize-goz1`)
 

--- a/docs/first-quantization-target.md
+++ b/docs/first-quantization-target.md
@@ -26,8 +26,12 @@ substring guess.
 Official Grok-1 checkpoint shards are JAX pickle frames. The real-weight
 `quantize-goz1` path accepts safetensors or a flat NPY directory, not pickle.
 Run [`scripts/export_grok1_embedding_npy.py`](../scripts/export_grok1_embedding_npy.py)
-before packing the official embedding shard. The exporter validates the known
-offset, byte count, dtype, and shape, and writes a stream-compatible `.npy`.
+before packing the official embedding shard. With a working `xai-dissect`, the
+exporter discovers the layout independently. Otherwise, for the exact
+`tensor00000_000` basename only, it uses the measured offset, dtype, and shape
+recorded above and verifies that the assumed byte range fits before writing a
+stream-compatible `.npy`; that fallback is not a source-identity or checksum
+validation.
 
 This requirement is independent of the metadata-only SAAQ commands. The two
 pipelines have different outputs:
@@ -63,6 +67,8 @@ dense/sign-like rather than strongly sparse.
 
 The immutable measurements and exact historical command are in
 [`reports/grok-1-first-embed-goz1/results.md`](../reports/grok-1-first-embed-goz1/results.md).
+The exact trit counts and threshold sweep are in
+[`reports/grok-1-tau-sweep/results.md`](../reports/grok-1-tau-sweep/results.md).
 New packs use the current GOZ1 version 3 writer, which adds per-tensor
 reconstruction scale and applied-threshold fields; see
 [`goz1-format.md`](./goz1-format.md). Do not compare the old artifact's version

--- a/docs/first-quantization-target.md
+++ b/docs/first-quantization-target.md
@@ -1,111 +1,91 @@
-# First Quantization Target for `grok-ozempic`
+# Verified first quantization target for `grok-ozempic`
 
-This document defines the first bounded quantization target for [`grok-ozempic`](../README.md) under GitHub issue `#14` / Linear `MET-76`. It is now implemented as part of the combined Grok-1 SAAQ artifact flow documented in [`grok1-saaq-artifact-flow.md`](./grok1-saaq-artifact-flow.md).
+This document records the observed contract for the first real Grok-1 weight
+experiment. It replaces the pre-implementation plan from GitHub #14 / Linear
+MET-76. For the copyable end-to-end commands, see the
+[Grok-1 SAAQ artifact flow](./grok1-saaq-artifact-flow.md).
 
-## Goal
+## Physical-to-logical mapping
 
-Select one concrete first quantization target that is:
+The official `xai-org/grok-1` `ckpt-0` token embedding is known and measured:
 
-- explicit enough to anchor validation and artifact expectations
-- small enough to land in one implementation PR
-- compatible with the existing GOZ1 export contract
+| Layer | Value |
+|---|---|
+| Physical checkpoint shard | `tensor00000_000` |
+| Pickle payload offset | `151` (`0x97`) |
+| Source dtype and shape | f32 `(131072, 6144)` |
+| Exported NPY filename | `embedding__slot_00__token_embedding.npy` |
+| Runtime logical name | `embedding.slot_00.token_embedding` |
 
-## Selected target
+The exporter uses `__` in the filename stem because the NPY loader maps `__`
+back to `.`. The mapping is therefore structural and deterministic; it is not a
+substring guess.
 
-The first quantization target is:
+## Why an export is required
 
-- `embedding.slot_00.token_embedding`
+Official Grok-1 checkpoint shards are JAX pickle frames. The real-weight
+`quantize-goz1` path accepts safetensors or a flat NPY directory, not pickle.
+Run [`scripts/export_grok1_embedding_npy.py`](../scripts/export_grok1_embedding_npy.py)
+before packing the official embedding shard. The exporter validates the known
+offset, byte count, dtype, and shape, and writes a stream-compatible `.npy`.
 
-This target already appears as the clearest candidate in [`reports/grok-1-official__ckpt-0/saaq-readiness.md`](../reports/grok-1-official__ckpt-0/saaq-readiness.md).
+This requirement is independent of the metadata-only SAAQ commands. The two
+pipelines have different outputs:
 
-## Why this target
+| Pipeline | Purpose | Weight payloads |
+|---|---|---|
+| `validate-ingest` → `smoke-grok1` → `convert-grok1` → `validate-grok1-artifact` | Validate the `saaq-g1-v0` plan and deterministic structural indexes | Does not quantize or pack weights; `validate-ingest` may hash files named by `checksums.json` |
+| pickle export → `quantize-goz1 --verify` | Export and quantize real tensor values into a GOZ1 container | Reads the 3 GiB f32 embedding payload and writes packed weights |
 
-`embedding.slot_00.token_embedding` is the best first target because it is:
+An `artifact.index.json` from the first pipeline is not a GOZ1 checkpoint.
 
-- a single bounded tensor family rather than a repeated expert family
-- easier to validate than a multi-block rollout
-- not part of the routing-critical path described by the existing artifact reports
-- compatible with the current ternary quantization flow implemented in [`src/core/quantizer.rs`](../src/core/quantizer.rs)
+## Manifest and safety contract
 
-## Expected input artifacts
+Use a manifest that explicitly covers the structural NPY name. Runtime support
+for V2 structural names landed in PR #55: under a V2 manifest, an unmatched
+tensor fails closed instead of falling through to defaults. The in-tree
+[`dissect/grok-1/structural-manifest.json`](../dissect/grok-1/structural-manifest.json)
+is a non-authoritative policy reference; the latest correct xai-dissect run is
+the authoritative planning surface. See
+[`dissect-manifest.md`](./dissect-manifest.md) for resolution precedence.
 
-The first implementation PR should assume the following inputs:
+Routers and norms remain protected. This one-tensor experiment does not test
+full-model inference, routing preservation, or downstream model quality, and it
+does not justify expanding ternary selection to routing-critical tensors.
 
-1. One xai-dissect manifest JSON.
-   - Resolution precedence is already documented in [`docs/dissect-manifest.md`](./dissect-manifest.md).
-   - Runtime resolution is implemented in [`resolve_manifest()`](../src/core/stream.rs:108).
+## Observed first artifact
 
-2. One supported checkpoint source.
-   - Supported input layouts are defined by [`QuantizationInputFormat`](../src/types.rs:40).
-   - The checkpoint source may be safetensors shards or a flat `.npy` directory.
+The historical first pack used the baseline manifest and GOZ1 version 1. It
+produced one verified `201327136`-byte artifact (about 192.00 MiB), compressing
+the 3 GiB f32 payload by about 16×. Its trit distribution at `gif_threshold =
+0.05` was about 4.17% zero, 47.7% positive, and 48.2% negative, so the result was
+dense/sign-like rather than strongly sparse.
 
-3. A concrete mapping from the logical target name to the physical checkpoint tensor name.
-   - This mapping is still a known unknown and must be confirmed during implementation.
+The immutable measurements and exact historical command are in
+[`reports/grok-1-first-embed-goz1/results.md`](../reports/grok-1-first-embed-goz1/results.md).
+New packs use the current GOZ1 version 3 writer, which adds per-tensor
+reconstruction scale and applied-threshold fields; see
+[`goz1-format.md`](./goz1-format.md). Do not compare the old artifact's version
+number with a newly generated file as though they were byte-identical formats.
 
-## Expected output artifact
+## Remaining validation boundaries
 
-The expected output artifact for the first implementation PR is:
+The physical name and source dtype are no longer unknown. The outstanding
+boundaries are deliberately tracked elsewhere:
 
-- one GOZ1 packed checkpoint file
+- GitHub #35 validates the complete local checkpoint inventory and size.
+- GitHub #36 exercises the full 770-tensor / 64-router metadata gate.
+- GitHub #85 and PR #89 contain the later supervised multi-block precision
+  experiment; its INT4 research side tables are not GOZ1 containers.
 
-The format must remain the existing GOZ1 container defined in [`src/core/weight_pack.rs`](../src/core/weight_pack.rs).
+The first embedding result is evidence that one real tensor can be exported,
+packed, and verified. It is not evidence that a complete model is usable or
+that the broader ingest gates are complete.
 
-### Output contract
+## Scope preserved by this contract
 
-- The selected token-embedding tensor must be emitted through the ternary quantization path.
-- Ternary packing must continue to use the existing encoding path in [`pack_trits()`](../src/core/quantizer.rs:62).
-- Source tensors that are still preserve/FP16 must remain on their existing paths.
-- Routing-critical tensors must remain unchanged.
-- For the sprint metadata writer, the selected target is represented in `artifact.index.json` with `candidate_saaq_embedding` policy under the `saaq-g1-v0` custom-format contract. The older GOZ1 streaming path remains separate and unchanged.
-
-## Explicit non-goals for this issue
-
-This issue does **not** do any of the following:
-
-- broaden the first target into multiple quantization targets
-- quantize routing tensors
-- quantize the full expert tensor surface
-- change SAAQ math
-- change router math
-- change dequantization behavior
-- introduce cloud execution
-- mix runtime integration or research narrative work into the same PR
-- change heartbeat behavior, because heartbeat behavior is no longer part of this project
-
-## Assumptions
-
-- The readiness report is currently the best repository-local signal for choosing the first target.
-- GOZ1 is the intended export artifact for quantized weights.
-- Manifest-driven targeting is preferred over legacy substring fallback heuristics.
-
-## Constraints
-
-- The first implementation must stay small enough for one PR.
-- The work must preserve existing GOZ1 writer semantics.
-- The first target must be specific enough for downstream validation work.
-- Routing-critical tensors remain excluded from the first quantized target set.
-
-## Known unknowns
-
-- The exact physical checkpoint tensor name for `embedding.slot_00.token_embedding` is not yet documented.
-- The source dtype for the target tensor still needs confirmation from real checkpoint data.
-- The current fallback manifest in [`dissect/grok-1/baseline.json`](../dissect/grok-1/baseline.json) may need an explicit token-embedding rule if upstream manifest coverage is insufficient.
-- A dedicated downstream validation contract for the one-target GOZ1 case still needs to be written in implementation work.
-
-## Implementation boundary for the first PR
-
-The follow-up implementation PR should be limited to:
-
-1. confirming the physical checkpoint mapping for `embedding.slot_00.token_embedding`
-2. encoding that target as the first manifest-driven ternary quantization target
-3. producing one normal GOZ1 artifact with the token embedding quantized
-4. preserving current handling for routing-critical tensors
-5. adding only the minimum validation needed to prove the target flows through the existing GOZ1 export path
-
-## Recommended branch
-
-- `feat/met-76-first-quant-target-token-embedding`
-
-## Attribution
-
-Planning decision prepared by Roo Code agent openAI/GPT-5.4.
+- Do not quantize routers or norms.
+- Do not change quantization, routing, dequantization, or GOZ1 layout semantics
+  as part of this documentation contract.
+- Do not treat pickle as a direct `quantize-goz1` input.
+- Do not treat SAAQ metadata conversion as real-weight quantization.

--- a/docs/grok1-saaq-artifact-flow.md
+++ b/docs/grok1-saaq-artifact-flow.md
@@ -1,121 +1,62 @@
-# Grok-1 SAAQ artifact flow
+# Grok-1 metadata and first real-weight GOZ1 runbook
 
-This document is the sprint handoff contract for GitHub issues #13, #14,
-#15, #17, #18, and #19.
+SAAQ means **Spiking Adaptive Activity Quantization**, terminology coined by
+this project's creator. This runbook connects its metadata validation path to
+the first verified real Grok-1 embedding pack. The paths are complementary, but
+they produce different artifacts: the SAAQ commands write structural metadata,
+while `quantize-goz1` reads exported tensor values and writes a GOZ1 container.
 
-## Ingest validation
+## 1. Build and choose portable locations
 
-Before conversion, validate the `xai-dissect` manifest and optional checkpoint
-checksum map:
+From the repository root:
 
 ```bash
-cargo run --features cli -- \
-  validate-ingest \
+cargo build --release --features cli
+
+GROK1_CKPT="${GROK1_CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
+GROK1_NPY="${GROK1_NPY:-$HOME/.models/xai-grok-1/export-npy}"
+GROK1_ARTIFACTS="${GROK1_ARTIFACTS:-$HOME/.models/xai-grok-1/artifacts}"
+mkdir -p "$GROK1_NPY" "$GROK1_ARTIFACTS"
+```
+
+`GROK1_CKPT` must point to a local official `ckpt-0` directory. The measured
+checkpoint used for the first experiment contained 770 shards and occupied
+about 297 GiB, but `validate-ingest` does not establish those counts. GitHub
+#35 owns exact local checkpoint inventory validation.
+
+## 2. Validate ingest metadata
+
+```bash
+./target/release/grok-ozempic validate-ingest \
   --manifest dissect/grok-1/baseline.json \
-  --checkpoint /path/to/ckpt-0
+  --checkpoint "$GROK1_CKPT"
 ```
 
-Validation enforces:
+This checks manifest identity and schema, checkpoint-directory presence, and
+the entries in `checksums.json` when that optional file exists. If present,
+those entries cause real shard reads for hashing. It does not independently
+count all checkpoint shards or quantize weights.
 
-- readable JSON manifest
-- supported manifest schema version
-- supported tensor name convention
-- `model.family = grok-1`
-- optional checkpoint directory existence
-- optional `checksums.json` SHA-256 integrity when present in the checkpoint
-  directory
-
-The checksum file is a JSON object whose keys are checkpoint-relative file paths
-and whose values are either raw lowercase SHA-256 hex strings or
-`sha256:<hex>` strings.
-
-## First quantization target
-
-The first bounded target remains:
-
-```text
-embedding.slot_00.token_embedding
-```
-
-In this sprint artifact writer, that target is represented in the deterministic
-artifact index with policy:
-
-```text
-candidate_saaq_embedding
-```
-
-Routers and norms are protected as pass-through f32 metadata, while existing
-int8 expert and dense payloads are wrapped rather than requantized. This keeps
-the first PR concrete and structurally safe without claiming full inference or
-quality benchmarking.
-
-## One-block smoke gate
-
-Run the smoke slice before claiming a full artifact conversion:
+## 3. Run the metadata-only smoke and conversion gates
 
 ```bash
-cargo run --features cli -- \
-  smoke-grok1 \
+./target/release/grok-ozempic smoke-grok1 \
   --manifest dissect/grok-1/baseline.json \
   --block 0 \
   --include-embedding true \
   --include-final-norm true \
   --output-root /tmp/grok1-smoke \
   --dry-run
-```
 
-Expected outputs:
-
-```text
-smoke.summary.md
-smoke.index.json
-smoke.checksums.json
-smoke.warnings.json
-```
-
-The smoke gate validates `block_000` as 12 tensors with one protected f32 router,
-four protected f32 block norms, three expert tensor families, and four wrapped
-unknown dense slots. Unresolved expert projection labels are warnings, not hard
-failures.
-
-## Full conversion metadata writer
-
-Run the full deterministic metadata writer:
-
-```bash
-cargo run --features cli -- \
-  convert-grok1 \
+./target/release/grok-ozempic convert-grok1 \
   --manifest dissect/grok-1/baseline.json \
   --output-root /tmp/grok1-artifact \
   --format saaq-g1-v0 \
   --protect-routers true \
   --protect-norms true \
   --dry-run
-```
 
-Expected outputs:
-
-```text
-manifest.used.json
-conversion.summary.md
-artifact.index.json
-checksums.json
-warnings.json
-```
-
-The writer refuses non-`grok-1` manifests, validates 770 planned tensor entries,
-64 routers, protected f32 routers with shape `(6144, 8)`, protected norms,
-`64 * 8 * 3` logical expert associations, deterministic offsets, and stable JSON
-ordering.
-
-## Final SAAQ-based validation gate
-
-The final sprint gate is scriptable and grounded in the SAAQ/custom-format
-artifact contract:
-
-```bash
-cargo run --features cli -- \
-  validate-grok1-artifact \
+./target/release/grok-ozempic validate-grok1-artifact \
   --manifest dissect/grok-1/baseline.json \
   --artifact-index /tmp/grok1-artifact/artifact.index.json \
   --checksums /tmp/grok1-artifact/checksums.json \
@@ -123,45 +64,90 @@ cargo run --features cli -- \
   --strict-router-protection true
 ```
 
-Expected outputs:
+The smoke output is a block-0 structural slice. The conversion output includes
+`artifact.index.json`, `conversion.summary.md`, `checksums.json`,
+`manifest.used.json`, and `warnings.json`. The final command validates that
+metadata contract, including protected routers and norms. It still does not
+write packed tensor payloads. GitHub #36 owns the complete 770-entry,
+64-router metadata execution gate.
 
-```text
-validation.summary.md
-validation.report.json
-validation.failures.json
-validation.warnings.json
+## 4. Export the real embedding from pickle to NPY
+
+The official shard is a JAX pickle frame, which `quantize-goz1` cannot consume
+directly. The known embedding payload is `tensor00000_000`, offset 151, f32,
+shape `(131072, 6144)`:
+
+```bash
+python3 scripts/export_grok1_embedding_npy.py \
+  --shard "$GROK1_CKPT/tensor00000_000" \
+  --output-dir "$GROK1_NPY"
 ```
 
-Pass criteria:
+The command reads the real approximately 3 GiB payload and writes
+`$GROK1_NPY/embedding__slot_00__token_embedding.npy`. The NPY loader converts
+the stem's `__` separators to the logical name
+`embedding.slot_00.token_embedding`. Safetensors checkpoints can instead be
+passed directly to the real-weight packer with `--input-format safetensors`;
+the official pickle shard cannot.
 
-- source manifest is Grok-1 and schema-valid
-- full artifact has exactly 770 tensor entries
-- every source tensor is represented once in the artifact index
-- exactly 64 routers exist
-- every router is protected/pass-through/f32 with shape `(6144, 8)`
-- block norms and final norm are protected/pass-through/f32
-- every block has 8 experts and 3 expert tensor families
-- unresolved expert projections remain warnings
-- unknown dense slots remain warnings unless count/shape/dtype changes
-- source byte accounting equals artifact byte accounting
-- full raw source byte accounting equals `318114914304`
+## 5. Pack and verify a real GOZ1 artifact
 
-Stable failure categories include:
-
-```text
-missing_tensor
-duplicate_tensor
-shape_mismatch
-dtype_mismatch
-byte_mismatch
-router_count_mismatch
-router_policy_violation
-norm_policy_violation
-expert_family_missing
-manifest_artifact_mismatch
+```bash
+./target/release/grok-ozempic quantize-goz1 \
+  --input-dir "$GROK1_NPY" \
+  --output "$GROK1_ARTIFACTS/grok1-first-embed.goz1" \
+  --manifest dissect/grok-1/structural-manifest.json \
+  --input-format npy \
+  --verify
 ```
+
+This is the first command in the runbook that quantizes and packs weight
+values. Current writes use GOZ1 layout version 3, with per-tensor
+reconstruction scale, GIF threshold, applied absolute threshold, and the row
+sentinel documented in [`goz1-format.md`](./goz1-format.md). The V2 structural
+manifest path fails closed when an input name has no explicit rule, protecting
+against silent router/norm misclassification.
+
+The original measured experiment used the then-current baseline manifest and
+GOZ1 version 1; it produced a verified 192.00 MiB embedding artifact. See the
+canonical [`results.md`](../reports/grok-1-first-embed-goz1/results.md) for its
+immutable command, hashes, compression, and trit histogram. A new v3 pack is a
+reproduction of the workflow, not a promise of byte identity with that v1 file.
+
+## 6. Inspect the result and understand the boundary
+
+`--verify` reopens the container and validates its header, tensor table,
+payload bounds, scale/threshold fields, and row sentinel. For a histogram using
+the repository's independent parser:
+
+```bash
+python3 scripts/goz1_trit_histogram.py \
+  "$GROK1_ARTIFACTS/grok1-first-embed.goz1"
+```
+
+The first embedding experiment proves only export → ternary pack → container
+verification for one tensor. It does not run full inference or establish
+routing or model-quality preservation.
+
+## Advanced multi-block evidence
+
+GitHub #85 and PR #89 extend the research to blocks 0–3 at the locked 8192-token
+Grok-1 context. The canonical entry point is the surviving out-of-process
+[`grok1_multiblock_v4_supervisor.py`](../scripts/grok1_multiblock_v4_supervisor.py),
+not three manually launched experiment commands. It runs one high-memory child
+at a time and fails closed if an arm cannot publish valid evidence. Its
+approximately 64 MiB intra-expert chunks bound side-table construction without
+splitting an expert row.
+
+Read the canonical
+[`results.md`](../reports/grok-1-expert-precision-remedy-v4/results.md) and
+[`metrics.json`](../reports/grok-1-expert-precision-remedy-v4/metrics.json)
+rather than copying their decision values into this runbook. The experiment's
+persisted INT4 code/scale side tables are research caches; they are not the GOZ1
+container format and must not be presented as deployable GOZ1 artifacts.
 
 ## Non-goals
 
-This sprint path does not run full inference, benchmark model quality, quantize
-routers, perform cloud provisioning, or resolve every projection-name ambiguity.
+This runbook does not claim completion of #35 or #36, run full-model inference,
+quantize routers or norms, provision cloud resources, or rerun the multi-hour
+#85 experiment.

--- a/docs/grok1-saaq-artifact-flow.md
+++ b/docs/grok1-saaq-artifact-flow.md
@@ -14,7 +14,7 @@ From the repository root:
 cargo build --release --features cli
 
 GROK1_CKPT="${GROK1_CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
-GROK1_NPY="${GROK1_NPY:-$HOME/.models/xai-grok-1/export-npy}"
+GROK1_NPY="${GROK1_NPY:-$(mktemp -d "${TMPDIR:-/tmp}/grok1-first-embed.XXXXXX")}"
 GROK1_ARTIFACTS="${GROK1_ARTIFACTS:-$HOME/.models/xai-grok-1/artifacts}"
 GROK1_MANIFEST="${GROK1_MANIFEST:-dissect/grok-1/structural-manifest.json}"
 mkdir -p "$GROK1_NPY" "$GROK1_ARTIFACTS"
@@ -88,6 +88,9 @@ shape `(131072, 6144)`:
 python3 scripts/export_grok1_embedding_npy.py \
   --shard "$GROK1_CKPT/tensor00000_000" \
   --output-dir "$GROK1_NPY"
+
+FOUND_NPY="$(find "$GROK1_NPY" -maxdepth 1 -type f -name '*.npy' -printf '%f\n')"
+test "$FOUND_NPY" = "embedding__slot_00__token_embedding.npy"
 ```
 
 The command reads the real approximately 3 GiB payload and writes
@@ -95,7 +98,14 @@ The command reads the real approximately 3 GiB payload and writes
 the stem's `__` separators to the logical name
 `embedding.slot_00.token_embedding`. Safetensors checkpoints can instead be
 passed directly to the real-weight packer with `--input-format safetensors`;
-the official pickle shard cannot.
+the official pickle shard cannot. The default NPY directory is unique per run.
+If `GROK1_NPY` is overridden, the subsequent `test` fails closed unless the
+directory contains exactly the expected embedding NPY and no other NPY tensor.
+
+The exporter prefers independent layout discovery through a working
+`xai-dissect`. When it is unavailable, the exact `tensor00000_000` basename
+uses the measured offset, dtype, and shape shown above and checks payload bounds;
+that fallback does not prove source identity or verify a checkpoint checksum.
 
 ## 5. Pack and verify a real GOZ1 artifact
 
@@ -118,8 +128,11 @@ against silent router/norm misclassification.
 The original measured experiment used the then-current baseline manifest and
 GOZ1 version 1; it produced a verified 192.00 MiB embedding artifact. See the
 canonical [`results.md`](../reports/grok-1-first-embed-goz1/results.md) for its
-immutable command, hashes, compression, and trit histogram. A new v3 pack is a
-reproduction of the workflow, not a promise of byte identity with that v1 file.
+immutable command, file size, and compression result. The exact histogram is
+recorded separately in the canonical
+[`tau-sweep results`](../reports/grok-1-tau-sweep/results.md). No first-pack hash
+is claimed by either report. A new v3 pack is a reproduction of the workflow,
+not a promise of byte identity with that v1 file.
 
 ## 6. Inspect the result and understand the boundary
 

--- a/docs/grok1-saaq-artifact-flow.md
+++ b/docs/grok1-saaq-artifact-flow.md
@@ -16,13 +16,20 @@ cargo build --release --features cli
 GROK1_CKPT="${GROK1_CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
 GROK1_NPY="${GROK1_NPY:-$HOME/.models/xai-grok-1/export-npy}"
 GROK1_ARTIFACTS="${GROK1_ARTIFACTS:-$HOME/.models/xai-grok-1/artifacts}"
+GROK1_MANIFEST="${GROK1_MANIFEST:-dissect/grok-1/structural-manifest.json}"
 mkdir -p "$GROK1_NPY" "$GROK1_ARTIFACTS"
 ```
 
 `GROK1_CKPT` must point to a local official `ckpt-0` directory. The measured
 checkpoint used for the first experiment contained 770 shards and occupied
-about 297 GiB, but `validate-ingest` does not establish those counts. GitHub
-#35 owns exact local checkpoint inventory validation.
+about 297 GiB, but `validate-ingest` does not establish those counts; exact
+local checkpoint inventory validation remains with [GitHub #35](https://github.com/rmems/grok-ozempic/issues/35).
+
+`GROK1_MANIFEST` defaults to the checked-in, loader-compatible policy reference
+so the example is copyable. Override it with an authoritative
+xai-dissect-derived V2 runtime manifest when one is available. The authoritative
+run's `quant-plan.json` is planning input, not itself the
+`xai-dissect.manifest` schema accepted by `quantize-goz1`.
 
 ## 2. Validate ingest metadata
 
@@ -96,7 +103,7 @@ the official pickle shard cannot.
 ./target/release/grok-ozempic quantize-goz1 \
   --input-dir "$GROK1_NPY" \
   --output "$GROK1_ARTIFACTS/grok1-first-embed.goz1" \
-  --manifest dissect/grok-1/structural-manifest.json \
+  --manifest "$GROK1_MANIFEST" \
   --input-format npy \
   --verify
 ```
@@ -148,6 +155,8 @@ container format and must not be presented as deployable GOZ1 artifacts.
 
 ## Non-goals
 
-This runbook does not claim completion of #35 or #36, run full-model inference,
-quantize routers or norms, provision cloud resources, or rerun the multi-hour
-#85 experiment.
+This runbook does not claim completion of [GitHub #35](https://github.com/rmems/grok-ozempic/issues/35)
+or [GitHub #36](https://github.com/rmems/grok-ozempic/issues/36), run full-model
+inference, quantize routers or norms, provision cloud resources, or rerun the
+multi-hour [GitHub #85](https://github.com/rmems/grok-ozempic/issues/85)
+experiment.


### PR DESCRIPTION
**Agent:** Codex: GPT-5.6-Sol (OpenAI)

## Summary

- turn the first-target design note into the measured physical/logical embedding contract
- publish a portable clone-to-metadata-to-export-to-GOZ1 runbook
- distinguish Spiking Adaptive Activity Quantization (SAAQ) metadata from real GOZ1 weight packing
- update the README from stale GOZ1 v2 writer language to the current version 3 layout
- link immutable first-embedding and supervised multi-block evidence without duplicating canonical metrics

## Acceptance matrix

| #41 requirement | Updated section |
|---|---|
| Physical name, dtype, and shape | docs/first-quantization-target.md - Physical-to-logical mapping |
| Portable checkpoint/output convention | README export block and runbook step 1 |
| SAAQ metadata vs real GOZ1 | README pipeline table; first-target export explanation; runbook introduction |
| Pickle vs safetensors/NPY | first-target export contract; runbook step 4 |
| smoke/convert/validate and quantize-goz1 commands | runbook steps 2-5 |
| checkpoint example path | portable GROK1_CKPT default in README and runbook |
| known unknowns resolved | first-target mapping and Remaining validation boundaries |
| current V2 structural bridge and GOZ1 writer | first-target manifest contract; README/runbook v3 descriptions |
| advanced evidence boundary | runbook Advanced multi-block evidence |

## Validation

- just check
- just ci
- exact --help checks for all five documented Rust subcommands and both Python scripts
- copyable metadata flow exercised in a fresh temporary directory: ingest PASS; smoke 14 tensors/1 router; conversion 770 tensors/64 routers; artifact validation PASS
- local Markdown links checked
- git diff --check

No real checkpoint was hashed or rewritten, and the multi-hour #85 experiment was not rerun.

Closes #41
Related to #35
Related to #36

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a verified Grok‑1 first‑experiment runbook and hardens its scope and safety. It replaces the design note with a measured embedding contract, updates docs to GOZ1 v3, and clearly separates SAAQ metadata from real weight packing.

- Physical→logical mapping is explicit: `tensor00000_000` at offset 151, f32 (131072, 6144) → `embedding.slot_00.token_embedding`; exporter writes `embedding__slot_00__token_embedding.npy` and maps `__` back to `.`; pickle is not a `quantize-goz1` input.
- Runbook adds a copyable path: build → validate-ingest → smoke/convert/validate (metadata) → export NPY → `quantize-goz1 --verify` → inspect. GOZ1 v3 writes include per‑tensor reconstruction scale and threshold fields; the NPY step fails closed if the directory has missing/extra tensors.
- README switches to `GROK1_CKPT`, `GROK1_NPY`, `GROK1_ARTIFACTS`, `GROK1_MANIFEST` and documents V2 structural manifests that fail closed on unmatched tensors.
- Scope is explicit: routers/norms stay protected; the runbook proves export → pack → verify for one tensor only; do not expect byte identity with historical v1 artifacts; links canonical results. Connects to Linear RM‑188 by enabling a new reader to dry‑run metadata, then export and pack the embedding with verification.

- Migration: use the new env vars and a V2 `structural-manifest.json`; export the embedding before `quantize-goz1`; treat SAAQ outputs as metadata, not a GOZ1 checkpoint; require `--verify`; ensure the NPY directory contains only the expected embedding file.

<sup>Written for commit 4dfc96405f25f8b0b2183d84b53e0be642112f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

