### PR TITLE
fix: rename output_checksum to honest plan_fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Key CLI entry points are available behind the `cli` feature:
 cargo run --features cli -- validate-ingest --manifest dissect/grok-1/baseline.json
 cargo run --features cli -- smoke-grok1 --manifest dissect/grok-1/baseline.json --output-root /tmp/grok1-smoke --dry-run
 cargo run --features cli -- convert-grok1 --manifest dissect/grok-1/baseline.json --output-root /tmp/grok1-artifact --dry-run
-cargo run --features cli -- validate-grok1-artifact --manifest dissect/grok-1/baseline.json --artifact-index /tmp/grok1-artifact/artifact.index.json --checksums /tmp/grok1-artifact/checksums.json --output-root /tmp/grok1-validation
+cargo run --features cli -- validate-grok1-artifact --manifest dissect/grok-1/baseline.json --artifact-index /tmp/grok1-artifact/artifact.index.json --plan-fingerprints /tmp/grok1-artifact/plan_fingerprints.json --output-root /tmp/grok1-validation
 ```
 
 ### Export Grok-1 embedding for GOZ1 (pickle → `.npy`)

--- a/docs/first-quantization-target.md
+++ b/docs/first-quantization-target.md
@@ -38,7 +38,7 @@ pipelines have different outputs:
 
 | Pipeline | Purpose | Weight payloads |
 |---|---|---|
-| `validate-ingest` → `smoke-grok1` → `convert-grok1` → `validate-grok1-artifact` | Validate the `saaq-g1-v0` plan and deterministic structural indexes | Does not quantize or pack weights; `validate-ingest` may hash files named by `checksums.json` |
+| `validate-ingest` → `smoke-grok1` → `convert-grok1` → `validate-grok1-artifact` | Validate the `saaq-g1-v0` plan and deterministic structural indexes | Does not quantize or pack weights; `validate-ingest` may hash files named by checkpoint `checksums.json`. Convert/validate emit and check `plan_fingerprint` (name/length/policy), which is not a payload sha256 |
 | pickle export → `quantize-goz1 --verify` | Export and quantize real tensor values into a GOZ1 container | Reads the 3 GiB f32 embedding payload and writes packed weights |
 
 An `artifact.index.json` from the first pipeline is not a GOZ1 checkpoint.

--- a/docs/grok1-saaq-artifact-flow.md
+++ b/docs/grok1-saaq-artifact-flow.md
@@ -40,8 +40,10 @@ run's `quant-plan.json` is planning input, not itself the
 ```
 
 This checks manifest identity and schema, checkpoint-directory presence, and
-the entries in `checksums.json` when that optional file exists. If present,
-those entries cause real shard reads for hashing. It does not independently
+the entries in checkpoint `checksums.json` when that optional file exists. If
+present, those entries cause real shard reads for hashing. That ingest file is
+a payload digest of named shard files. It is not the convert-time
+`plan_fingerprint` sidecar (name/length/policy only). It does not independently
 count all checkpoint shards or quantize weights.
 
 ## 3. Run the metadata-only smoke and conversion gates
@@ -66,17 +68,21 @@ count all checkpoint shards or quantize weights.
 ./target/release/grok-ozempic validate-grok1-artifact \
   --manifest dissect/grok-1/baseline.json \
   --artifact-index /tmp/grok1-artifact/artifact.index.json \
-  --checksums /tmp/grok1-artifact/checksums.json \
+  --plan-fingerprints /tmp/grok1-artifact/plan_fingerprints.json \
   --output-root /tmp/grok1-validation \
   --strict-router-protection true
 ```
 
 The smoke output is a block-0 structural slice. The conversion output includes
-`artifact.index.json`, `conversion.summary.md`, `checksums.json`,
-`manifest.used.json`, and `warnings.json`. The final command validates that
-metadata contract, including protected routers and norms. It still does not
-write packed tensor payloads. GitHub #36 owns the complete 770-entry,
-64-router metadata execution gate.
+`artifact.index.json`, `conversion.summary.md`, `plan_fingerprints.json`,
+`manifest.used.json`, and `warnings.json`. Each index entry carries a
+`plan_fingerprint`: a lowercase hex hash of **name, planned byte length, and
+quant policy only**. It is **not** a payload sha256 and is not emitted with a
+`sha256:` prefix. `validate-grok1-artifact` checks that fingerprint against an
+independently rebuilt plan; matching it does not claim content-digest coverage
+of tensor bytes. The final command validates that metadata contract, including
+protected routers and norms. It still does not write packed tensor payloads.
+GitHub #36 owns the complete 770-entry, 64-router metadata execution gate.
 
 ## 4. Export the real embedding from pickle to NPY
 

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -25,6 +25,8 @@ const ATTN_NARROW_BYTES: u64 = 6_291_456;
 const NORM_BYTES: u64 = 24_576;
 const ROUTER_BYTES: u64 = 196_608;
 const CHECKSUMS_FILE: &str = "checksums.json";
+const PLAN_FINGERPRINTS_FILE: &str = "plan_fingerprints.json";
+const SMOKE_PLAN_FINGERPRINTS_FILE: &str = "smoke.plan_fingerprints.json";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArtifactIndex {
@@ -52,7 +54,9 @@ pub struct ArtifactIndexEntry {
     pub shape: Vec<usize>,
     pub byte_len: u64,
     pub source_checksum: Option<String>,
-    pub output_checksum: String,
+    /// Fingerprint of `source_tensor_name`, `byte_len`, and `quant_policy_applied`.
+    /// Lowercase hex with no scheme prefix. This is not a payload sha256.
+    pub plan_fingerprint: String,
     pub quant_policy_applied: String,
     pub artifact_path: String,
     pub artifact_offset: u64,
@@ -84,7 +88,9 @@ pub struct ValidationReport {
     pub protected_norm_violations: usize,
     pub expert_association_count: usize,
     pub unknown_unresolved_warning_count: usize,
-    pub checksum_coverage: String,
+    /// Independently verified plan-fingerprint matches (name/length/policy).
+    /// This is not payload-digest coverage.
+    pub plan_fingerprint_coverage: String,
     pub source_total_bytes: u64,
     pub artifact_total_bytes: u64,
     pub byte_accounting_result: String,
@@ -197,10 +203,14 @@ pub fn smoke_grok1(options: SmokeOptions<'_>) -> Result<ArtifactIndex> {
     Ok(index)
 }
 
+/// Validate a converted `saaq-g1-v0` index.
+///
+/// `plan_fingerprints` is an optional sidecar of name → plan fingerprint
+/// (name/length/policy hex). Matching it is not payload-digest coverage.
 pub fn validate_grok1_artifact(
     manifest: &Path,
     artifact_index: &Path,
-    checksums: Option<&Path>,
+    plan_fingerprints: Option<&Path>,
     output_root: Option<&Path>,
     strict_router_protection: bool,
 ) -> Result<ValidationReport> {
@@ -215,7 +225,7 @@ pub fn validate_grok1_artifact(
         ))
     })?;
 
-    let checksum_map = if let Some(path) = checksums {
+    let plan_fingerprint_map = if let Some(path) = plan_fingerprints {
         Some(load_checksums_file(path)?)
     } else {
         None
@@ -228,7 +238,7 @@ pub fn validate_grok1_artifact(
         strict_router_protection,
         true,
         Some(&expected_entries),
-        checksum_map.as_ref(),
+        plan_fingerprint_map.as_ref(),
     );
     if let Some(dir) = output_root {
         write_validation_outputs(dir, &report)?;
@@ -350,6 +360,40 @@ fn hex_lower(bytes: &[u8]) -> String {
 fn normalize_checksum(value: &str) -> String {
     let lower = value.to_ascii_lowercase();
     lower.strip_prefix("sha256:").unwrap_or(&lower).to_string()
+}
+
+/// True when a value is dressed as a content digest (`sha256:…`).
+/// Plan fingerprints must not use that prefix; stripping it would restore
+/// the self-compare-as-sha256 theater this field was renamed to end.
+fn has_content_digest_prefix(value: &str) -> bool {
+    let lower = value.trim().to_ascii_lowercase();
+    lower.starts_with("sha256:") || lower.starts_with("sha-256:")
+}
+
+fn push_plan_fingerprint_failures(
+    failures: &mut Vec<FailureRecord>,
+    tensor: &str,
+    actual: &str,
+    expected: &str,
+    context: &str,
+) {
+    if has_content_digest_prefix(actual) || has_content_digest_prefix(expected) {
+        failures.push(failure(
+            "plan_fingerprint_kind_mismatch",
+            Some(tensor.to_string()),
+            format!(
+                "{context}: plan_fingerprint is a name/length/policy fingerprint, not a payload digest; refuse sha256: prefix (expected {expected}, got {actual})"
+            ),
+        ));
+        return;
+    }
+    if !actual.eq_ignore_ascii_case(expected) {
+        failures.push(failure(
+            "plan_fingerprint_mismatch",
+            Some(tensor.to_string()),
+            format!("{context}: expected plan fingerprint {expected}, got {actual}"),
+        ));
+    }
 }
 
 fn resolve_checkpoint_checksum_entry_path(checkpoint: &Path, relative: &str) -> Result<PathBuf> {
@@ -603,7 +647,7 @@ impl<'a> TensorPlan<'a> {
 }
 
 fn push_entry(entries: &mut Vec<ArtifactIndexEntry>, offset: &mut u64, plan: TensorPlan<'_>) {
-    let output_checksum = planned_checksum(
+    let plan_fingerprint = plan_fingerprint(
         plan.source_tensor_name,
         plan.byte_len,
         plan.quant_policy_applied,
@@ -618,7 +662,7 @@ fn push_entry(entries: &mut Vec<ArtifactIndexEntry>, offset: &mut u64, plan: Ten
         shape: plan.shape,
         byte_len: plan.byte_len,
         source_checksum: None,
-        output_checksum,
+        plan_fingerprint,
         quant_policy_applied: plan.quant_policy_applied.to_string(),
         artifact_path: "artifact.saaq-g1-v0.meta".to_string(),
         artifact_offset: *offset,
@@ -628,12 +672,13 @@ fn push_entry(entries: &mut Vec<ArtifactIndexEntry>, offset: &mut u64, plan: Ten
     *offset += plan.byte_len;
 }
 
-fn planned_checksum(name: &str, byte_len: u64, policy: &str) -> String {
+/// Hash of name, planned byte length, and quant policy. Not a payload digest.
+fn plan_fingerprint(name: &str, byte_len: u64, policy: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(name.as_bytes());
     hasher.update(byte_len.to_le_bytes());
     hasher.update(policy.as_bytes());
-    format!("sha256:{}", hex_lower(&hasher.finalize()))
+    hex_lower(&hasher.finalize())
 }
 
 fn build_index(
@@ -756,7 +801,7 @@ fn build_validation_report(
     require_router_protection: bool,
     require_norm_protection: bool,
     expected_entries: Option<&BTreeMap<String, ArtifactIndexEntry>>,
-    checksums: Option<&BTreeMap<String, String>>,
+    plan_fingerprints: Option<&BTreeMap<String, String>>,
 ) -> ValidationReport {
     let mut failures = Vec::new();
     let warnings = planned_warnings();
@@ -931,18 +976,13 @@ fn build_validation_report(
                     ),
                 ));
             }
-            if normalize_checksum(&entry.output_checksum)
-                != normalize_checksum(&expected.output_checksum)
-            {
-                failures.push(failure(
-                    "checksum_mismatch",
-                    Some(entry.source_tensor_name.clone()),
-                    format!(
-                        "expected output checksum {}, got {}",
-                        expected.output_checksum, entry.output_checksum
-                    ),
-                ));
-            }
+            push_plan_fingerprint_failures(
+                &mut failures,
+                &entry.source_tensor_name,
+                &entry.plan_fingerprint,
+                &expected.plan_fingerprint,
+                "artifact index",
+            );
         }
     }
 
@@ -1151,50 +1191,62 @@ fn build_validation_report(
         ));
     }
 
-    let checksum_coverage = if let Some(checksums) = checksums {
-        let mut covered = 0usize;
+    let independent_covered = match expected_entries {
+        Some(expected_entries) => index
+            .entries
+            .iter()
+            .filter(|entry| {
+                expected_entries
+                    .get(&entry.source_tensor_name)
+                    .is_some_and(|expected| {
+                        !has_content_digest_prefix(&entry.plan_fingerprint)
+                            && !has_content_digest_prefix(&expected.plan_fingerprint)
+                            && entry
+                                .plan_fingerprint
+                                .eq_ignore_ascii_case(&expected.plan_fingerprint)
+                    })
+            })
+            .count(),
+        None => index
+            .entries
+            .iter()
+            .filter(|entry| {
+                !entry.plan_fingerprint.is_empty()
+                    && !has_content_digest_prefix(&entry.plan_fingerprint)
+            })
+            .count(),
+    };
+    if let Some(sidecar) = plan_fingerprints {
         for entry in &index.entries {
-            match checksums.get(&entry.source_tensor_name) {
+            match sidecar.get(&entry.source_tensor_name) {
                 Some(expected) => {
-                    if normalize_checksum(expected) == normalize_checksum(&entry.output_checksum) {
-                        covered += 1;
-                    } else {
-                        failures.push(failure(
-                            "checksum_mismatch",
-                            Some(entry.source_tensor_name.clone()),
-                            format!(
-                                "checksums file expected {}, got {}",
-                                expected, entry.output_checksum
-                            ),
-                        ));
-                    }
+                    push_plan_fingerprint_failures(
+                        &mut failures,
+                        &entry.source_tensor_name,
+                        &entry.plan_fingerprint,
+                        expected,
+                        "plan_fingerprints sidecar",
+                    );
                 }
                 None => failures.push(failure(
-                    "checksum_missing",
+                    "plan_fingerprint_missing",
                     Some(entry.source_tensor_name.clone()),
-                    "checksums file is missing this tensor entry",
+                    "plan_fingerprints file is missing this tensor entry",
                 )),
             }
         }
-        for unexpected in checksums
-            .keys()
-            .filter(|name| !actual_names.contains(*name))
-        {
+        for unexpected in sidecar.keys().filter(|name| !actual_names.contains(*name)) {
             failures.push(failure(
-                "checksum_mismatch",
+                "plan_fingerprint_mismatch",
                 Some(unexpected.clone()),
-                "checksums file contains a tensor not present in artifact index",
+                "plan_fingerprints file contains a tensor not present in artifact index",
             ));
         }
-        format!("{covered}/{} source tensors", index.entries.len())
-    } else {
-        let covered = index
-            .entries
-            .iter()
-            .filter(|entry| entry.source_checksum.is_some())
-            .count();
-        format!("{covered}/{} source tensors", index.entries.len())
-    };
+    }
+    let plan_fingerprint_coverage = format!(
+        "{independent_covered}/{} plan fingerprints (name/length/policy; not a payload digest)",
+        index.entries.len()
+    );
 
     ValidationReport {
         status: if failures.is_empty() { "PASS" } else { "FAIL" }.to_string(),
@@ -1209,7 +1261,7 @@ fn build_validation_report(
         protected_norm_violations,
         expert_association_count,
         unknown_unresolved_warning_count: warnings.len(),
-        checksum_coverage,
+        plan_fingerprint_coverage,
         source_total_bytes,
         artifact_total_bytes: index.artifact_total_bytes,
         byte_accounting_result: if source_total_bytes == index.artifact_total_bytes {
@@ -1261,7 +1313,10 @@ fn write_conversion_outputs(
     fs::create_dir_all(output_root)?;
     fs::copy(manifest_path, output_root.join("manifest.used.json"))?;
     write_json(output_root.join("artifact.index.json"), index)?;
-    write_json(output_root.join("checksums.json"), &output_checksums(index))?;
+    write_json(
+        output_root.join(PLAN_FINGERPRINTS_FILE),
+        &plan_fingerprint_map(index),
+    )?;
     write_json(output_root.join("warnings.json"), warnings)?;
     if !dry_run {
         fs::write(
@@ -1285,8 +1340,8 @@ fn write_smoke_outputs(
     fs::create_dir_all(output_root)?;
     write_json(output_root.join("smoke.index.json"), index)?;
     write_json(
-        output_root.join("smoke.checksums.json"),
-        &output_checksums(index),
+        output_root.join(SMOKE_PLAN_FINGERPRINTS_FILE),
+        &plan_fingerprint_map(index),
     )?;
     write_json(output_root.join("smoke.warnings.json"), warnings)?;
     if !dry_run {
@@ -1317,14 +1372,14 @@ fn write_validation_outputs(output_root: &Path, report: &ValidationReport) -> Re
     Ok(())
 }
 
-fn output_checksums(index: &ArtifactIndex) -> BTreeMap<String, String> {
+fn plan_fingerprint_map(index: &ArtifactIndex) -> BTreeMap<String, String> {
     index
         .entries
         .iter()
         .map(|entry| {
             (
                 entry.source_tensor_name.clone(),
-                entry.output_checksum.clone(),
+                entry.plan_fingerprint.clone(),
             )
         })
         .collect()
@@ -1428,7 +1483,7 @@ fn smoke_summary(index: &ArtifactIndex) -> String {
 
 fn validation_summary(report: &ValidationReport) -> String {
     format!(
-        "# Grok-1 artifact validation summary\n\n- status: {}\n- source tensor count: {}\n- artifact tensor count: {}\n- router count: {}\n- protected router violations: {}\n- protected norm violations: {}\n- expert association count: {}\n- unknown/unresolved warning count: {}\n- checksum coverage: {}\n- byte accounting result: {}\n- source total bytes: {}\n- artifact total bytes: {}\n- failure count: {}\n",
+        "# Grok-1 artifact validation summary\n\n- status: {}\n- source tensor count: {}\n- artifact tensor count: {}\n- router count: {}\n- protected router violations: {}\n- protected norm violations: {}\n- expert association count: {}\n- unknown/unresolved warning count: {}\n- plan fingerprint coverage: {}\n- byte accounting result: {}\n- source total bytes: {}\n- artifact total bytes: {}\n- failure count: {}\n",
         report.status,
         report.source_tensor_count,
         report.artifact_tensor_count,
@@ -1437,7 +1492,7 @@ fn validation_summary(report: &ValidationReport) -> String {
         report.protected_norm_violations,
         report.expert_association_count,
         report.unknown_unresolved_warning_count,
-        report.checksum_coverage,
+        report.plan_fingerprint_coverage,
         report.byte_accounting_result,
         report.source_total_bytes,
         report.artifact_total_bytes,
@@ -1523,9 +1578,150 @@ mod tests {
         assert_eq!(index.source_total_bytes, GROK1_TENSOR_TOTAL_BYTES);
         assert!(out.join("artifact.index.json").is_file());
         assert!(out.join("conversion.summary.md").is_file());
-        assert!(out.join("checksums.json").is_file());
+        assert!(out.join("plan_fingerprints.json").is_file());
+        assert!(!out.join("checksums.json").exists());
         assert!(out.join("warnings.json").is_file());
         assert!(!out.join("artifact.saaq-g1-v0.meta").exists());
+    }
+
+    #[test]
+    fn plan_fingerprint_is_not_emitted_as_sha256_content_digest() {
+        let dir = temp_dir("plan_fingerprint_emit");
+        let manifest = write_manifest(&dir);
+        let out = dir.join("out");
+        let index = convert_grok1(ConvertOptions {
+            checkpoint: None,
+            manifest: &manifest,
+            output_root: &out,
+            format: GROK1_ARTIFACT_FORMAT,
+            protect_routers: true,
+            protect_norms: true,
+            dry_run: true,
+        })
+        .expect("convert");
+        let entry = index.entries.first().expect("entry");
+        assert!(
+            !entry.plan_fingerprint.starts_with("sha256:"),
+            "plan_fingerprint must not use a sha256: prefix: {}",
+            entry.plan_fingerprint
+        );
+        assert_eq!(
+            entry.plan_fingerprint,
+            plan_fingerprint(
+                &entry.source_tensor_name,
+                entry.byte_len,
+                &entry.quant_policy_applied
+            )
+        );
+
+        let raw = fs::read_to_string(out.join("artifact.index.json")).expect("index json");
+        assert!(
+            raw.contains("\"plan_fingerprint\""),
+            "serialized index must name the field plan_fingerprint: {raw}"
+        );
+        assert!(
+            !raw.contains("\"output_checksum\""),
+            "serialized index must not revive output_checksum: {raw}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("index parse");
+        let fp = parsed["entries"][0]["plan_fingerprint"]
+            .as_str()
+            .expect("plan_fingerprint string");
+        assert!(
+            !fp.to_ascii_lowercase().starts_with("sha256:"),
+            "serialized plan_fingerprint must not be dressed as sha256: {fp}"
+        );
+
+        let sidecar = fs::read_to_string(out.join(PLAN_FINGERPRINTS_FILE)).expect("sidecar");
+        assert!(
+            !sidecar.to_ascii_lowercase().contains("sha256:"),
+            "plan_fingerprints sidecar must not use sha256: prefixes: {sidecar}"
+        );
+    }
+
+    #[test]
+    fn validation_does_not_treat_plan_fingerprint_as_content_hash() {
+        let dir = temp_dir("plan_fingerprint_validate");
+        let manifest = write_manifest(&dir);
+        let out = dir.join("out");
+        let index = convert_grok1(ConvertOptions {
+            checkpoint: None,
+            manifest: &manifest,
+            output_root: &out,
+            format: GROK1_ARTIFACT_FORMAT,
+            protect_routers: true,
+            protect_norms: true,
+            dry_run: true,
+        })
+        .expect("convert");
+        let sidecar = plan_fingerprint_map(&index);
+        let expected_entries = expected_full_entry_map().expect("expected entries");
+        let report = build_validation_report(
+            &index,
+            GROK1_ARTIFACT_FORMAT,
+            true,
+            true,
+            Some(&expected_entries),
+            Some(&sidecar),
+        );
+        assert_eq!(report.status, "PASS");
+        assert!(
+            report
+                .plan_fingerprint_coverage
+                .contains("plan fingerprints (name/length/policy; not a payload digest)"),
+            "coverage must state plan-fingerprint semantics: {}",
+            report.plan_fingerprint_coverage
+        );
+        let report_json = serde_json::to_string(&report).expect("report json");
+        assert!(
+            report_json.contains("\"plan_fingerprint_coverage\""),
+            "validation report must not claim checksum_coverage: {report_json}"
+        );
+        assert!(
+            !report_json.contains("\"checksum_coverage\""),
+            "validation report must not revive checksum_coverage: {report_json}"
+        );
+        assert!(
+            !report_json
+                .to_ascii_lowercase()
+                .contains("payload digest coverage")
+                && !report
+                    .plan_fingerprint_coverage
+                    .to_ascii_lowercase()
+                    .contains("sha256"),
+            "coverage must not describe a content sha256: {}",
+            report.plan_fingerprint_coverage
+        );
+
+        let mut theater = index.clone();
+        if let Some(entry) = theater.entries.first_mut() {
+            entry.plan_fingerprint = format!("sha256:{}", entry.plan_fingerprint);
+        }
+        let theater_report = build_validation_report(
+            &theater,
+            GROK1_ARTIFACT_FORMAT,
+            true,
+            true,
+            Some(&expected_entries),
+            Some(&sidecar),
+        );
+        assert_eq!(theater_report.status, "FAIL");
+        assert!(
+            theater_report.failures.iter().any(|failure| {
+                failure.category == "plan_fingerprint_kind_mismatch"
+                    && failure.message.contains("not a payload digest")
+            }),
+            "sha256: prefix must fail as kind mismatch, not self-compare success: {:?}",
+            theater_report.failures
+        );
+        assert!(
+            !theater_report
+                .failures
+                .iter()
+                .any(|failure| failure.category == "checksum_mismatch"),
+            "validation must not classify plan fingerprints as checksum_mismatch: {:?}",
+            theater_report.failures
+        );
     }
 
     #[test]
@@ -1555,6 +1751,8 @@ mod tests {
         );
         assert!(out.join("smoke.index.json").is_file());
         assert!(out.join("smoke.summary.md").is_file());
+        assert!(out.join("smoke.plan_fingerprints.json").is_file());
+        assert!(!out.join("smoke.checksums.json").exists());
     }
 
     #[test]
@@ -1732,7 +1930,7 @@ mod tests {
             dry_run: true,
         })
         .expect("convert");
-        let checksums = output_checksums(&index);
+        let fingerprints = plan_fingerprint_map(&index);
         index.format = "custom-grok1".to_string();
         index.schema = "foreign.artifact_index".to_string();
         index.schema_version = 9;
@@ -1770,7 +1968,7 @@ mod tests {
             final_norm.source_tensor_name = "final_norm.slot_00.renamed".to_string();
         }
         if let Some(entry) = index.entries.first_mut() {
-            entry.output_checksum = "sha256:deadbeef".to_string();
+            entry.plan_fingerprint = format!("sha256:{}", entry.plan_fingerprint);
         }
         let expected_entries = expected_full_entry_map().expect("expected entries");
         let report = build_validation_report(
@@ -1779,7 +1977,7 @@ mod tests {
             true,
             true,
             Some(&expected_entries),
-            Some(&checksums),
+            Some(&fingerprints),
         );
         for category in [
             "schema_mismatch",
@@ -1790,8 +1988,8 @@ mod tests {
             "missing_tensor",
             "manifest_artifact_mismatch",
             "artifact_location_mismatch",
-            "checksum_mismatch",
-            "checksum_missing",
+            "plan_fingerprint_kind_mismatch",
+            "plan_fingerprint_missing",
             "router_count_mismatch",
         ] {
             assert!(

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -1523,6 +1523,38 @@ mod tests {
         path
     }
 
+    fn dry_convert(name: &str) -> (PathBuf, ArtifactIndex) {
+        let dir = temp_dir(name);
+        let manifest = write_manifest(&dir);
+        let out = dir.join("out");
+        let index = convert_grok1(ConvertOptions {
+            checkpoint: None,
+            manifest: &manifest,
+            output_root: &out,
+            format: GROK1_ARTIFACT_FORMAT,
+            protect_routers: true,
+            protect_norms: true,
+            dry_run: true,
+        })
+        .expect("convert");
+        (out, index)
+    }
+
+    fn full_validation_report(
+        index: &ArtifactIndex,
+        sidecar: Option<&BTreeMap<String, String>>,
+    ) -> ValidationReport {
+        let expected_entries = expected_full_entry_map().expect("expected entries");
+        build_validation_report(
+            index,
+            GROK1_ARTIFACT_FORMAT,
+            true,
+            true,
+            Some(&expected_entries),
+            sidecar,
+        )
+    }
+
     #[test]
     fn hex_lower_matches_known_sha256_vectors() {
         // Guards the sha2 0.10 -> 0.11 migration: `{:x}` on the digest no longer
@@ -1586,19 +1618,7 @@ mod tests {
 
     #[test]
     fn plan_fingerprint_is_not_emitted_as_sha256_content_digest() {
-        let dir = temp_dir("plan_fingerprint_emit");
-        let manifest = write_manifest(&dir);
-        let out = dir.join("out");
-        let index = convert_grok1(ConvertOptions {
-            checkpoint: None,
-            manifest: &manifest,
-            output_root: &out,
-            format: GROK1_ARTIFACT_FORMAT,
-            protect_routers: true,
-            protect_norms: true,
-            dry_run: true,
-        })
-        .expect("convert");
+        let (out, index) = dry_convert("plan_fingerprint_emit");
         let entry = index.entries.first().expect("entry");
         assert!(
             !entry.plan_fingerprint.starts_with("sha256:"),
@@ -1613,114 +1633,58 @@ mod tests {
                 &entry.quant_policy_applied
             )
         );
-
         let raw = fs::read_to_string(out.join("artifact.index.json")).expect("index json");
-        assert!(
-            raw.contains("\"plan_fingerprint\""),
-            "serialized index must name the field plan_fingerprint: {raw}"
-        );
-        assert!(
-            !raw.contains("\"output_checksum\""),
-            "serialized index must not revive output_checksum: {raw}"
-        );
+        assert!(raw.contains("\"plan_fingerprint\""));
+        assert!(!raw.contains("\"output_checksum\""));
         let parsed: serde_json::Value = serde_json::from_str(&raw).expect("index parse");
         let fp = parsed["entries"][0]["plan_fingerprint"]
             .as_str()
             .expect("plan_fingerprint string");
-        assert!(
-            !fp.to_ascii_lowercase().starts_with("sha256:"),
-            "serialized plan_fingerprint must not be dressed as sha256: {fp}"
-        );
-
+        assert!(!fp.to_ascii_lowercase().starts_with("sha256:"));
         let sidecar = fs::read_to_string(out.join(PLAN_FINGERPRINTS_FILE)).expect("sidecar");
-        assert!(
-            !sidecar.to_ascii_lowercase().contains("sha256:"),
-            "plan_fingerprints sidecar must not use sha256: prefixes: {sidecar}"
-        );
+        assert!(!sidecar.to_ascii_lowercase().contains("sha256:"));
     }
 
     #[test]
-    fn validation_does_not_treat_plan_fingerprint_as_content_hash() {
-        let dir = temp_dir("plan_fingerprint_validate");
-        let manifest = write_manifest(&dir);
-        let out = dir.join("out");
-        let index = convert_grok1(ConvertOptions {
-            checkpoint: None,
-            manifest: &manifest,
-            output_root: &out,
-            format: GROK1_ARTIFACT_FORMAT,
-            protect_routers: true,
-            protect_norms: true,
-            dry_run: true,
-        })
-        .expect("convert");
+    fn validation_reports_plan_fingerprint_coverage_not_checksum() {
+        let (_out, index) = dry_convert("plan_fingerprint_coverage");
         let sidecar = plan_fingerprint_map(&index);
-        let expected_entries = expected_full_entry_map().expect("expected entries");
-        let report = build_validation_report(
-            &index,
-            GROK1_ARTIFACT_FORMAT,
-            true,
-            true,
-            Some(&expected_entries),
-            Some(&sidecar),
-        );
+        let report = full_validation_report(&index, Some(&sidecar));
         assert_eq!(report.status, "PASS");
         assert!(
             report
                 .plan_fingerprint_coverage
-                .contains("plan fingerprints (name/length/policy; not a payload digest)"),
-            "coverage must state plan-fingerprint semantics: {}",
-            report.plan_fingerprint_coverage
+                .contains("plan fingerprints (name/length/policy; not a payload digest)")
+        );
+        assert!(
+            !report
+                .plan_fingerprint_coverage
+                .to_ascii_lowercase()
+                .contains("sha256")
         );
         let report_json = serde_json::to_string(&report).expect("report json");
-        assert!(
-            report_json.contains("\"plan_fingerprint_coverage\""),
-            "validation report must not claim checksum_coverage: {report_json}"
-        );
-        assert!(
-            !report_json.contains("\"checksum_coverage\""),
-            "validation report must not revive checksum_coverage: {report_json}"
-        );
-        assert!(
-            !report_json
-                .to_ascii_lowercase()
-                .contains("payload digest coverage")
-                && !report
-                    .plan_fingerprint_coverage
-                    .to_ascii_lowercase()
-                    .contains("sha256"),
-            "coverage must not describe a content sha256: {}",
-            report.plan_fingerprint_coverage
-        );
+        assert!(report_json.contains("\"plan_fingerprint_coverage\""));
+        assert!(!report_json.contains("\"checksum_coverage\""));
+    }
 
-        let mut theater = index.clone();
+    #[test]
+    fn validation_rejects_sha256_prefix_as_kind_mismatch() {
+        let (_out, mut theater) = dry_convert("plan_fingerprint_kind");
+        let sidecar = plan_fingerprint_map(&theater);
         if let Some(entry) = theater.entries.first_mut() {
             entry.plan_fingerprint = format!("sha256:{}", entry.plan_fingerprint);
         }
-        let theater_report = build_validation_report(
-            &theater,
-            GROK1_ARTIFACT_FORMAT,
-            true,
-            true,
-            Some(&expected_entries),
-            Some(&sidecar),
-        );
-        assert_eq!(theater_report.status, "FAIL");
+        let report = full_validation_report(&theater, Some(&sidecar));
+        assert_eq!(report.status, "FAIL");
+        assert!(report.failures.iter().any(|failure| {
+            failure.category == "plan_fingerprint_kind_mismatch"
+                && failure.message.contains("not a payload digest")
+        }));
         assert!(
-            theater_report.failures.iter().any(|failure| {
-                failure.category == "plan_fingerprint_kind_mismatch"
-                    && failure.message.contains("not a payload digest")
-            }),
-            "sha256: prefix must fail as kind mismatch, not self-compare success: {:?}",
-            theater_report.failures
-        );
-        assert!(
-            !theater_report
+            !report
                 .failures
                 .iter()
-                .any(|failure| failure.category == "checksum_mismatch"),
-            "validation must not classify plan fingerprints as checksum_mismatch: {:?}",
-            theater_report.failures
+                .any(|failure| failure.category == "checksum_mismatch")
         );
     }
 

--- a/src/bin/grok-ozempic/main.rs
+++ b/src/bin/grok-ozempic/main.rs
@@ -45,7 +45,7 @@ enum Commands {
         #[arg(long)]
         manifest: PathBuf,
 
-        /// Output directory for manifest.used.json, artifact.index.json, checksums, warnings, summary
+        /// Output directory for manifest.used.json, artifact.index.json, plan_fingerprints, warnings, summary
         #[arg(long)]
         output_root: PathBuf,
 
@@ -87,7 +87,7 @@ enum Commands {
         #[arg(long, action = ArgAction::Set, default_value_t = true)]
         include_final_norm: bool,
 
-        /// Output directory for smoke summary/index/checksum/warnings files
+        /// Output directory for smoke summary/index/plan-fingerprint/warnings files
         #[arg(long)]
         output_root: PathBuf,
 
@@ -105,9 +105,10 @@ enum Commands {
         #[arg(long)]
         artifact_index: PathBuf,
 
-        /// Optional checksums.json emitted by convert-grok1
-        #[arg(long)]
-        checksums: Option<PathBuf>,
+        /// Optional plan-fingerprint map emitted by convert-grok1 (name/length/policy).
+        /// Not a payload sha256. `--checksums` is a compatibility alias for this sidecar.
+        #[arg(long = "plan-fingerprints", visible_alias = "checksums")]
+        plan_fingerprints: Option<PathBuf>,
 
         /// Output directory for validation.summary/report/failures/warnings
         #[arg(long)]
@@ -192,9 +193,9 @@ fn run_cli(command: Commands) -> anyhow::Result<()> {
             checkpoint, manifest, block, include_embedding, include_final_norm, output_root, dry_run,
         ),
         Commands::ValidateGrok1Artifact {
-            manifest, artifact_index, checksums, output_root, strict_router_protection,
+            manifest, artifact_index, plan_fingerprints, output_root, strict_router_protection,
         } => cmd_validate_grok1_artifact(
-            manifest, artifact_index, checksums, output_root, strict_router_protection,
+            manifest, artifact_index, plan_fingerprints, output_root, strict_router_protection,
         ),
         Commands::QuantizeGoz1 {
             input_dir, output, manifest, input_format, gif_threshold, use_embedded_baseline, verify,
@@ -271,14 +272,14 @@ fn cmd_smoke_grok1(
 fn cmd_validate_grok1_artifact(
     manifest: PathBuf,
     artifact_index: PathBuf,
-    checksums: Option<PathBuf>,
+    plan_fingerprints: Option<PathBuf>,
     output_root: Option<PathBuf>,
     strict_router_protection: bool,
 ) -> anyhow::Result<()> {
     let report = artifact::validate_grok1_artifact(
         &manifest,
         &artifact_index,
-        checksums.as_deref(),
+        plan_fingerprints.as_deref(),
         output_root.as_deref(),
         strict_router_protection,
     )


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Agent:** Cursor Grok 4.6 · Ternary Debt Ledger HIGH [21] VERIFIED @ 4464a74

`output_checksum` hashed name/length/policy only, then was emitted as `sha256:…` and “verified” against a sidecar copied from the same index. That is self-compare theater, not a payload digest.

## Change
- Rename the index field to `plan_fingerprint` and emit lowercase hex with **no** `sha256:` prefix.
- Convert/smoke write `plan_fingerprints.json` / `smoke.plan_fingerprints.json` instead of a fake `checksums.json`.
- `validate-grok1-artifact` checks plan fingerprints against an independently rebuilt plan. Coverage is labeled `plan_fingerprint_coverage` and states name/length/policy, not payload digest.
- A `sha256:` prefix is a `plan_fingerprint_kind_mismatch` failure (stripping it would restore the theater).
- CLI flag is `--plan-fingerprints` (`--checksums` remains a compatibility alias).
- Docs updated in `docs/grok1-saaq-artifact-flow.md`, `docs/first-quantization-target.md`, and `README.md`.

Checkpoint ingest `checksums.json` (real shard file hashes under `--checkpoint`) is unchanged.

## Tests
HEAD `4e103cf`. Local `cargo test --all-targets --all-features --locked` and GitHub CI are green, including `Rust / fmt / clippy / test`, Codacy, Qodana, Python scripts, Docker, cargo-audit, and codecov/patch.

Anti-theater guards: field name is `plan_fingerprint`, emitted values have no `sha256:` prefix, and validation refuses that prefix as `plan_fingerprint_kind_mismatch` instead of treating it as a content hash.

## Out of scope
Other HIGH ledger items ([0] RSS, [1] safetensors tests, [22] IR constants, [83] CI branch gate, etc.). No GOZ1 packs, no train, no forward passes.

## Status
**MERGE_READY.** Do not merge from this agent. Assignee `rmems` was requested; the token could not set assignees.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b4efddc-3ef6-456e-8b63-8ae2181a09f9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b4efddc-3ef6-456e-8b63-8ae2181a09f9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the artifact index's `output_checksum` to `plan_fingerprint` because the old field hashed only name/length/policy, was emitted with a `sha256:` prefix, and then was "verified" against a sidecar copied from the same index — self-compare theater, not a payload digest.

- Emits lowercase hex fingerprints with no `sha256:` prefix in `plan_fingerprints.json` and `smoke.plan_fingerprints.json` instead of fake `checksums.json` sidecars.
- Validation labels coverage `plan_fingerprint_coverage` and fails closed on any `sha256:`-prefixed value as a `plan_fingerprint_kind_mismatch`.
- The `validate-grok1-artifact` checks fingerprints against an independently rebuilt plan.
- CLI flag is `--plan-fingerprints`; `--checksums` remains a compatibility alias.
- Checkpoint ingest `checksums.json` (real shard file hashes) is unchanged.
- Docs updated in `README.md`, `docs/grok1-saaq-artifact-flow.md`, and `docs/first-quantization-target.md`.

<sup>Written for commit 4e103cf1b68ea31948d9d51aa83f84611325f0d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Replace misleading checksum labels with explicit plan fingerprints

### What Changed
- Artifact indexes now expose lowercase plan fingerprints for tensor name, planned size, and quantization policy instead of values presented as payload SHA-256 checksums.
- Conversion and smoke runs write `plan_fingerprints.json` and `smoke.plan_fingerprints.json`; checkpoint `checksums.json` handling remains unchanged.
- Artifact validation compares fingerprints against an independently rebuilt plan and rejects `sha256:`-style values instead of treating them as content verification.
- The validation report now clearly labels plan-fingerprint coverage, while `--checksums` remains available as a compatibility alias for `--plan-fingerprints`.

### Impact
`✅ No false payload-hash claims`
`✅ Clearer artifact validation results`
`✅ Existing checksum-based validation commands remain compatible`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
