### PR TITLE
ci: chain the project quality gate back into the beads hooks (#97)

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -22,3 +22,29 @@ if command -v bd >/dev/null 2>&1; then
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.4 ---
+
+# --- BEGIN PROJECT QUALITY GATE (GH #97) ---
+# Deliberately OUTSIDE the beads markers above. `bd hooks install` preserves
+# user content outside its markers across installs and upgrades, so this block
+# survives a beads upgrade. `bd hooks install --force` would destroy it.
+#
+# Why this exists: beads owns core.hooksPath (it points at .beads/hooks), and
+# git consults ONLY that directory -- .git/hooks and .githooks are ignored
+# entirely. Without this block the tracked .githooks/pre-commit never runs, so
+# the `just check` gate documented in REVIEW.md silently never fired.
+#
+# Escape hatch: git commit --no-verify, or BEADS_SKIP_PROJECT_GATE=1 to skip
+# only this block while still running the beads export above.
+_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+_gate="${_root}/.githooks/pre-commit"
+if [ -n "${BEADS_SKIP_PROJECT_GATE:-}" ]; then
+  echo "pre-commit: project gate skipped (BEADS_SKIP_PROJECT_GATE set)" >&2
+elif [ -x "$_gate" ]; then
+  "$_gate" "$@" || exit $?
+elif [ -f "$_gate" ]; then
+  echo "pre-commit: $_gate is not executable; running via sh" >&2
+  sh "$_gate" "$@" || exit $?
+else
+  echo "pre-commit: warning: $_gate not found; project gate skipped" >&2
+fi
+# --- END PROJECT QUALITY GATE (GH #97) ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -22,3 +22,29 @@ if command -v bd >/dev/null 2>&1; then
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.4 ---
+
+# --- BEGIN PROJECT QUALITY GATE (GH #97) ---
+# Deliberately OUTSIDE the beads markers above. `bd hooks install` preserves
+# user content outside its markers across installs and upgrades, so this block
+# survives a beads upgrade. `bd hooks install --force` would destroy it.
+#
+# Why this exists: beads owns core.hooksPath (it points at .beads/hooks), and
+# git consults ONLY that directory -- .git/hooks and .githooks are ignored
+# entirely. Without this block the tracked .githooks/pre-push never runs, so
+# the `just review` gate documented in REVIEW.md silently never fired.
+#
+# Escape hatch: git push --no-verify, or BEADS_SKIP_PROJECT_GATE=1 to skip
+# only this block while still running the beads sync above.
+_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+_gate="${_root}/.githooks/pre-push"
+if [ -n "${BEADS_SKIP_PROJECT_GATE:-}" ]; then
+  echo "pre-push: project gate skipped (BEADS_SKIP_PROJECT_GATE set)" >&2
+elif [ -x "$_gate" ]; then
+  "$_gate" "$@" || exit $?
+elif [ -f "$_gate" ]; then
+  echo "pre-push: $_gate is not executable; running via sh" >&2
+  sh "$_gate" "$@" || exit $?
+else
+  echo "pre-push: warning: $_gate not found; project gate skipped" >&2
+fi
+# --- END PROJECT QUALITY GATE (GH #97) ---

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -59,24 +59,43 @@ Hooks live in **`.githooks/`** (tracked).
 
 ⚠ **`core.hooksPath` is owned by beads, not by `.githooks`.** Beads installs its
 own hooks and points `core.hooksPath` at `.beads/hooks`. Git consults **only**
-that directory — `.git/hooks` and `.githooks` are then ignored entirely — and the
-beads `pre-push` runs `bd hooks run pre-push` **without chaining to
-`.githooks/pre-push`**. So `git config core.hooksPath .githooks` (what this file
-used to say) would silently disable beads sync, and leaving it as beads set it
-silently disables `just review`. Neither is what you want.
+that directory — `.git/hooks` and `.githooks` are then ignored entirely. So
+`git config core.hooksPath .githooks` (what this file used to say) would
+silently disable beads sync, while leaving it as beads set it silently disabled
+`just review`. Neither is what you want, which is why the two are **chained**.
 
-```console
-$ git config --get core.hooksPath
-/home/raulmc/rmems/grok-ozempic/.beads/hooks
+Since GH #97, each tracked `.beads/hooks/{pre-commit,pre-push}` runs the beads
+block first and then invokes the matching `.githooks/` script:
+
+```
+.beads/hooks/pre-push
+  ├── BEADS INTEGRATION block   → bd hooks run pre-push   (sync)
+  └── PROJECT QUALITY GATE block → .githooks/pre-push → just review
 ```
 
-Restoring the chain is tracked as **GH #97**. Until it lands, `just review` does
-**not** run automatically on push — run it yourself.
+The gate block sits **outside** the beads markers on purpose: `bd hooks install`
+preserves user content outside its markers across installs and upgrades. The one
+command that would destroy it is `bd hooks install --force`; if you ever run
+that, re-apply the block and check with `just doctor`.
 
-| Hook | Intended to run | Skip |
-|------|-----------------|------|
-| `.githooks/pre-push` | `just review` | `git push --no-verify` (escape hatch only) |
-| `.githooks/pre-commit` | `just check` | `git commit --no-verify` |
+| Hook | Runs | Skip |
+|------|------|------|
+| `.beads/hooks/pre-push` | beads sync, then `just review` | `git push --no-verify` |
+| `.beads/hooks/pre-commit` | beads export, then `just check` | `git commit --no-verify` |
+
+`BEADS_SKIP_PROJECT_GATE=1` skips only the `just` half while still running the
+beads sync — use it when you need the export but not a 2–4 minute gate.
+
+### Bootstrap (once per clone)
+
+`core.hooksPath` lives in `.git/config`, which is **not** shared by git, and
+beads writes it as an **absolute** path — so it does not survive a fresh clone
+and is wrong inside a worktree. Set it explicitly:
+
+```bash
+git config core.hooksPath "$(git rev-parse --show-toplevel)/.beads/hooks"
+just doctor    # confirms the path AND that the project gate is chained
+```
 
 Requirements on `PATH`: `just`, `cargo`, `python3`, and for Python tests `numpy`
 (`python3 -m pip install --user 'numpy>=1.26,<3'`).
@@ -84,9 +103,9 @@ Requirements on `PATH`: `just`, `cargo`, `python3`, and for Python tests `numpy`
 Verify:
 
 ```bash
-git config --get core.hooksPath   # today: .../.beads/hooks (see #97)
+git config --get core.hooksPath   # expect: <repo>/.beads/hooks
+just doctor                       # expect: "project gate chained into both hooks"
 bd github status                  # should not say "Not configured"
-just review                       # the gate itself — run it manually until #97 lands
 ```
 
 Agents: if `core.hooksPath` is unset, still run `just review` before any push.

--- a/justfile
+++ b/justfile
@@ -349,6 +349,30 @@ doctor:
       status missing "jq not on PATH (required for just ci coauthor hook tests)"
     fi
 
+    echo "=== git hooks (GH #97) ==="
+    # Nothing used to detect a broken pre-push gate. beads owns core.hooksPath,
+    # and git consults only that directory, so .githooks runs only if the beads
+    # hooks chain to it. Verify the chain, not just the path.
+    hp="$(git config --get core.hooksPath 2>/dev/null || true)"
+    if [[ -z "${hp}" ]]; then
+      status warn "core.hooksPath unset — no hook runs; see REVIEW.md bootstrap"
+    else
+      status ok "core.hooksPath=${hp}"
+      chained=0
+      for h in pre-commit pre-push; do
+        if [[ -f "${hp}/${h}" ]] && grep -q 'PROJECT QUALITY GATE' "${hp}/${h}" 2>/dev/null; then
+          chained=$((chained + 1))
+        fi
+      done
+      if [[ "${chained}" -eq 2 ]]; then
+        status ok "project gate chained into both hooks (just check / just review)"
+      elif [[ "${chained}" -eq 1 ]]; then
+        status warn "project gate chained into only 1 of 2 hooks — re-apply GH #97 block"
+      else
+        status missing "project gate NOT chained: .githooks never runs, so 'just review' does not gate pushes (GH #97)"
+      fi
+    fi
+
     echo "=== crate / CLI ==="
     if [[ -f Cargo.toml ]]; then
       status ok "Cargo.toml present"


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #97 · Ternary Debt Ledger [85] VERIFIED @ `4464a74`

Closes #97.

## Why

`REVIEW.md` and `.githooks/pre-push` documented a pre-push gate running `just review`. **It had never run.** beads owns `core.hooksPath` — it points at `.beads/hooks` — and git consults *only* that directory, so `.git/hooks` and `.githooks` are ignored entirely. The beads `pre-push` ran `bd hooks run pre-push` and stopped there.

Both halves are wanted, so this chains them rather than choosing:

```
.beads/hooks/pre-push
  ├── BEADS INTEGRATION block    → bd hooks run pre-push   (sync)
  └── PROJECT QUALITY GATE block → .githooks/pre-push → just review
```

The gate block sits deliberately **outside** the beads markers. `bd hooks install --help` documents that user content outside its markers is preserved across installs and upgrades, so this survives a beads upgrade. Only `bd hooks install --force` destroys it, and `REVIEW.md` now says so.

I considered `bd hooks install --beads --chain`, but `--chain` wires in hooks present *at install time* — `.beads/hooks/` currently holds only beads content, so it would have chained nothing.

## Proof it works

Not asserted — observed. **This PR pushed through its own gate:**

```console
$ git push -u origin ci/gh-97-restore-pre-push-gate
pre-push: just review (see REVIEW.md)
+ cargo fmt --all -- --check
+ cargo clippy --all-targets --all-features --locked -- -D warnings
+ cargo test --all-targets --all-features --locked
+ cargo build --all-targets --all-features --locked
+ cargo doc --no-deps --all-features --locked
+ actionlint
+ shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh
+ python3 -m py_compile (31 scripts)
  unittest modules invoked: 13
push exit=0
```

The commit itself was gated too — `pre-commit` ran `just check` (fmt + clippy) before it was allowed.

Behaviour verified directly by stubbing `.githooks/pre-push`:

| Case | Result |
|---|---|
| args pass through | `STUB RAN with args: origin git@github.com:x/y.git` |
| `BEADS_SKIP_PROJECT_GATE=1` | gate skipped, beads sync still runs |
| gate exits 7 | hook exits **7** — failure propagates, not swallowed |
| `sh -n` + `shellcheck -s sh` | clean on both hooks |

## `just doctor` can now see this class of breakage

Nothing detected it before, which is exactly why it went unnoticed for so long. The new section checks that the gate is **actually chained**, not merely that a path is set:

```console
$ just doctor
=== git hooks (GH #97) ===
ok: core.hooksPath=/home/raulmc/rmems/grok-ozempic/.beads/hooks
ok: project gate chained into both hooks (just check / just review)
```

It degrades honestly: `warn` if chained into only one hook, `missing` if neither.

## Bootstrap, documented

`core.hooksPath` lives in `.git/config`, which git does **not** share, and beads writes it as an *absolute* path — so it does not survive a fresh clone and is wrong inside a worktree. `REVIEW.md` now carries a one-liner that sets it relative to the repo root, plus the `BEADS_SKIP_PROJECT_GATE=1` escape hatch for when you want the export but not a 2–4 minute gate.

## Scope

Hook wiring, the doctor check, and the REVIEW.md text. **`just review` itself is unchanged** — what it runs was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the project quality gate so `just review` and `just check` actually run on push and commit, instead of silently never firing.

**Changes**
- Beads hooks now chain to the tracked `.githooks` scripts: beads sync first, then the corresponding gate.
- Set `BEADS_SKIP_PROJECT_GATE=1` to skip the gate while keeping beads sync; `--no-verify` still bypasses everything.
- `just doctor` now verifies the gate is chained into both hooks, not just that `core.hooksPath` is set.
- `REVIEW.md` documents the chain and the per‑clone bootstrap, since `core.hooksPath` uses an absolute path that doesn’t survive a fresh clone.

<sup>Written for commit dfde33953ad1f0a85e2ba65955bf82287992772b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Restore project quality checks for commits and pushes

### What Changed
- Commits and pushes now run the project’s `just check` and `just review` gates after the beads hooks
- Gate failures now block the commit or push instead of being silently skipped
- `just doctor` reports whether hooks are configured and both quality gates are connected
- Developers can skip only the project gate with `BEADS_SKIP_PROJECT_GATE=1` while retaining beads synchronization

### Impact
`✅ Quality checks run automatically before commits and pushes`
`✅ Fewer pushes that bypass required review checks`
`✅ Clearer hook setup and configuration errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
