### PR TITLE
fix(reports): name the spec builder honestly and document the tautology (#105)

### DIFF
--- a/src/bin/grok-ozempic/artifacts.rs
+++ b/src/bin/grok-ozempic/artifacts.rs
@@ -118,11 +118,11 @@ fn load_manifest_ir(
     )
     .map_err(|e| anyhow::anyhow!("Failed to parse manifest: {}", e))?;
 
-    reports::detector::build_ir_from_manifest(&dissect_manifest, actual_checkpoint, actual_shards)
+    reports::detector::build_grok1_spec_ir(&dissect_manifest, actual_checkpoint, actual_shards)
         .map_err(|e| anyhow::anyhow!("Failed to build IR: {}", e))
 }
 
-/// Returns `(checkpoint_override, shard_count)` for [`reports::detector::build_ir_from_manifest`].
+/// Returns `(checkpoint_override, shard_count)` for [`reports::detector::build_grok1_spec_ir`].
 fn resolve_checkpoint_and_shards(
     weights_dir: Option<&Path>,
     checkpoint: Option<String>,

--- a/src/reports/detector.rs
+++ b/src/reports/detector.rs
@@ -24,6 +24,16 @@ const GROK1_MOE_DOWN_BYTES: u64 = 103_079_215_104;
 const GROK1_MOE_UNRESOLVED_BYTES: u64 = 206_158_430_208;
 const GROK1_ROUTER_BYTES: u64 = 12_582_912;
 
+/// Reject a manifest this builder cannot honour.
+///
+/// This is the **only** place a manifest can change the outcome. It checks four
+/// things: the model family, that every declared block index is in range, that
+/// no index repeats, and that a declared expert count matches Grok-1's. Anything
+/// else in the manifest — `preserve`, `ternary_candidates`, `defaults`,
+/// `schema_version`, and the *number* of blocks — is ignored by design, because
+/// [`build_grok1_spec_ir`] emits the full Grok-1 spec regardless. Partial and
+/// unordered block metadata is explicitly supported; see
+/// `test_manifest_block_metadata_can_be_partial_and_unordered`.
 fn validate_supported_manifest(manifest: &DissectManifest) -> Result<(), GrokOzempicError> {
     if manifest.model.family != GROK1_FAMILY {
         return Err(GrokOzempicError::InvalidConfig(format!(
@@ -59,7 +69,30 @@ fn validate_supported_manifest(manifest: &DissectManifest) -> Result<(), GrokOze
     Ok(())
 }
 
-pub fn build_ir_from_manifest(
+/// Build the Grok-1 **specification** IR.
+///
+/// The name matters, because the old one (`build_ir_from_manifest`) implied a
+/// detector reading structure out of the manifest. It does not, and cannot: a
+/// [`ManifestBlock`](crate::core::manifest::ManifestBlock) carries only `index`,
+/// `experts` and `role` — no shapes, no dtypes, no byte counts — so there is
+/// nothing to derive from. Every structural figure below comes from the
+/// `GROK1_*` constants; the manifest contributes `model.source` (only when
+/// `checkpoint` is `None`) and is otherwise used to *reject* incompatible input
+/// via [`validate_supported_manifest`].
+///
+/// Consequences worth knowing before trusting the output:
+///
+/// - The IR describes the Grok-1 architecture as this crate understands it, not
+///   the checkpoint on disk. `actual_shards` is the one observed quantity, and
+///   it is passed in by the caller rather than read here.
+/// - [`super::validator::validate_ir`] asserts the same constants this function
+///   writes, so it is a schema/self-consistency check, not verification. It can
+///   only fail on an IR that something else has mutated — which is exactly what
+///   `src/reports/tests.rs` does.
+///
+/// Deriving real totals from a checkpoint scan needs a manifest schema that
+/// carries them; tracked separately rather than faked here.
+pub fn build_grok1_spec_ir(
     manifest: &DissectManifest,
     checkpoint: Option<&str>,
     actual_shards: Option<usize>,
@@ -74,7 +107,10 @@ pub fn build_ir_from_manifest(
 
     let totals = TensorTotals {
         total: GROK1_TENSOR_TOTAL,
-        f32_tensors: GROK1_TENSOR_F32, // TODO: derive from actual scan in phase 2
+        // Spec constants, not a scan. Deriving these from the checkpoint needs a
+        // manifest schema that carries per-tensor dtype/bytes; see this
+        // function's doc comment.
+        f32_tensors: GROK1_TENSOR_F32,
         int8_tensors: GROK1_TENSOR_INT8,
         quant_tensors: GROK1_TENSOR_QUANT,
         total_elements: GROK1_TENSOR_TOTAL_ELEMENTS,

--- a/src/reports/tests.rs
+++ b/src/reports/tests.rs
@@ -8,7 +8,7 @@ use crate::reports::validator;
 fn create_valid_ir() -> ArtifactIR {
     // We can use the detector to build a valid IR from the embedded baseline
     let manifest = embedded_grok1_baseline().expect("Failed to get baseline manifest");
-    detector::build_ir_from_manifest(manifest, None, None).expect("Failed to build valid IR")
+    detector::build_grok1_spec_ir(manifest, None, None).expect("Failed to build valid IR")
 }
 
 #[test]
@@ -48,7 +48,7 @@ fn test_inventory_uses_resolved_attention_labels() {
 #[test]
 fn test_scan_shard_count_does_not_override_tensor_totals() {
     let manifest = embedded_grok1_baseline().expect("Failed to get baseline manifest");
-    let ir = detector::build_ir_from_manifest(manifest, None, Some(42))
+    let ir = detector::build_grok1_spec_ir(manifest, None, Some(42))
         .expect("Failed to build IR with scan-derived shard count");
 
     assert_eq!(ir.manifest.shards, 42);
@@ -74,9 +74,25 @@ fn test_manifest_block_metadata_can_be_partial_and_unordered() {
         },
     ];
 
-    let ir = detector::build_ir_from_manifest(&manifest, None, None)
+    let ir = detector::build_grok1_spec_ir(&manifest, None, None)
         .expect("partial unordered advisory blocks should be accepted");
     assert!(validator::validate_ir(&ir).is_ok());
+
+    // The consequence worth pinning: a manifest declaring TWO blocks still
+    // yields the full 64-block spec IR. Block metadata is advisory -- the
+    // builder emits the Grok-1 spec regardless -- so the block *count* is
+    // ignored rather than rejected. Anyone reading the IR as a description of
+    // the manifest, rather than of the architecture, would be wrong.
+    assert_eq!(manifest.blocks.len(), 2, "fixture declares two blocks");
+    assert_eq!(
+        ir.hyperparameters.n_blocks, 64,
+        "block count comes from the spec constant, not the manifest"
+    );
+    assert_eq!(
+        ir.routers.len(),
+        64,
+        "one router per spec block, not per manifest block"
+    );
 }
 
 #[test]

--- a/src/reports/validator.rs
+++ b/src/reports/validator.rs
@@ -8,6 +8,24 @@ use crate::types::{
 use std::collections::HashSet;
 const CRITICAL_ROUTER_RISK_THRESHOLD: f64 = 0.5;
 
+/// Check an [`ArtifactIR`] against the Grok-1 spec constants.
+///
+/// **This is a schema/self-consistency check, not verification of a checkpoint.**
+/// [`super::detector::build_grok1_spec_ir`] writes these same `GROK1_*`
+/// constants, so on any IR that function produces every assertion below holds by
+/// construction — it is a tautology on the happy path. It earns its keep in two
+/// narrower ways:
+///
+/// 1. It catches an IR that something *else* mutated — deserialised from a
+///    hand-edited report, or altered in a test. `src/reports/tests.rs` relies on
+///    exactly that.
+/// 2. It pins the invariants themselves, so a future change to one constant
+///    without the other trips a test rather than silently shipping a skewed
+///    report.
+///
+/// What it does **not** do is tell you the checkpoint on disk matches. Nothing in
+/// this module reads tensor data. Do not cite a green `validate_ir` as evidence
+/// about real weights.
 pub fn validate_ir(ir: &ArtifactIR) -> Result<(), GrokOzempicError> {
     if ir.hyperparameters.d_model != GROK1_HIDDEN_DIM {
         return Err(GrokOzempicError::ArtifactValidation(format!(


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #105 · Ternary Debt Ledger [22] VERIFIED @ `4464a74`

Closes #105.

## Why

`build_ir_from_manifest` took a `&DissectManifest` and derived almost nothing from it. Totals, hyperparameters, routers, expert blocks, inventory blocks — all `GROK1_*` constants. The manifest contributed `model.source`, and only when `checkpoint` was `None`; `model.family` had already been forced to `"grok-1"` by `validate_supported_manifest`, so it was a constant in disguise. `validate_ir` then asserted those same constants back, making it a **tautology** on any IR the builder produces — it can only fail on an IR something else mutated, which is exactly what `src/reports/tests.rs` does.

## Why (a) and not (b)

This is not laziness that trying harder here would fix. The schema has nothing to derive from:

```console
$ sed -n '172,177p' src/core/manifest.rs
pub struct ManifestBlock {
    pub index: u32,
    pub experts: Option<u32>,
    pub role: Option<String>,
}
```

No shapes, no dtypes, no byte counts. So the real choice is between faking a scan and saying plainly what the function does. This PR does the second and files the first as **#113**, which is blocked on a `xai-dissect` schema change — `.claude/rules/manifests.md` is explicit that this crate never writes manifests and must not invent schema fields.

## Changes

- **Renamed** `build_ir_from_manifest` → `build_grok1_spec_ir`. It builds the Grok-1 *spec* IR; the old name implied a detector reading structure out of the manifest.
- **Documented** what the manifest can and cannot change, and that `validate_supported_manifest` is the only place it changes anything at all (family, block index range, duplicate index, expert count — everything else ignored by design).
- **Documented `validate_ir`** as a schema/self-consistency check, explicitly *not* verification, with the two narrow ways it still earns its keep: catching an externally mutated IR, and pinning the constants against each other so a one-sided change trips a test. Added the warning not to cite a green `validate_ir` as evidence about real weights, since nothing in the module reads tensor data.
- **Replaced the stale TODO** (`// TODO: derive from actual scan in phase 2`) with a note pointing at the schema prerequisite. It had already outlived its phase; a tracked issue beats a comment.

## One assertion added

`test_manifest_block_metadata_can_be_partial_and_unordered` accepted a 2-block manifest but never asserted the surprising part. Now it does:

```rust
assert_eq!(manifest.blocks.len(), 2, "fixture declares two blocks");
assert_eq!(ir.hyperparameters.n_blocks, 64, "block count comes from the spec constant, not the manifest");
assert_eq!(ir.routers.len(), 64, "one router per spec block, not per manifest block");
```

That behaviour is deliberate — block metadata is advisory — but it was unpinned, so nothing stopped a future change from making the IR track the manifest and silently shrinking every report.

## Scope

Naming and documentation. **No behavioural change.** The inventory table in this file is untouched — that is #106, which is blocked on this PR precisely because both edit `detector.rs`.

## Verification

`cargo test reports::` 7/7 · full matrix 150 + 6 tests · `cargo fmt --check`, `clippy --all-targets --all-features --locked -D warnings`, and `cargo doc` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa


___

## **CodeAnt-AI Description**
Clarify that report generation describes the Grok-1 specification, not checkpoint contents

### What Changed
- Renamed the report builder to reflect that it produces a fixed Grok-1 specification rather than deriving architecture details from the manifest
- Partial or unordered block metadata is accepted while the generated report consistently contains the complete 64-block Grok-1 specification
- Documented that validation checks report consistency and supported manifest details, but does not verify tensor data on disk
- Added coverage confirming that manifest block counts do not change the generated specification

### Impact
`✅ Clearer report meaning`
`✅ Consistent 64-block Grok-1 reports`
`✅ Reduced risk of mistaking validation for checkpoint verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `build_ir_from_manifest` to `build_grok1_spec_ir` because the IR is built from Grok-1 spec constants, not derived from the manifest. Also documents `validate_ir` as a schema/self-consistency check that asserts those same constants, so a green result on builder output is a tautology; nothing in the module reads tensor data.

No behavioral change. The manifest's `ManifestBlock` schema only carries `index`, `experts`, and `role` — no shapes, dtypes, or byte counts — so there's nothing to scan; the manifest only contributes `model.source` (when `checkpoint` is `None`) and otherwise rejects incompatible input via `validate_supported_manifest`.

**Tests**
- Strengthens `test_manifest_block_metadata_can_be_partial_and_unordered` to assert a 2-block manifest still yields a 64-block IR with 64 routers, pinning the deliberate behavior that block metadata is advisory.

<sup>Written for commit 4e76be1fdbdf7ff0556637eddd8fb2bd8a559300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

