### PR TITLE
test: cover the safetensors input path, which had none (#103)

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -818,6 +818,80 @@ mod tests {
     }
 
     /// Per-test unique scratch dir.
+    /// Minimal `*.safetensors` shard writer — the safetensors twin of
+    /// [`write_npy_f32`] / [`write_npy_i8`].
+    ///
+    /// Built with `safetensors::serialize` rather than hand-rolled bytes on
+    /// purpose. `bytemuck_cast_f32` / `bytemuck_cast_f16` reinterpret
+    /// `view.data()` as `&[f32]` / `&[f16]` with no alignment check, and the
+    /// safetensors format does not guarantee the data section is 4- or 2-byte
+    /// aligned. Letting the library lay the file out keeps these fixtures on
+    /// the aligned happy path; a hand-built shard could be UB rather than a
+    /// test failure. Do not replace this with a byte literal.
+    ///
+    /// Unlike `.npy` (one tensor per file), a shard holds many tensors and the
+    /// names live inside the file — the filename only has to end in
+    /// `.safetensors` so `collect_safetensor_shards` picks it up.
+    fn write_safetensors_raw(
+        path: &std::path::Path,
+        tensors: &[(&str, safetensors::Dtype, &[usize], &[u8])],
+    ) {
+        use safetensors::tensor::TensorView;
+        let views: Vec<(&str, TensorView<'_>)> = tensors
+            .iter()
+            .map(|&(name, dtype, shape, data)| {
+                let view = TensorView::new(dtype, shape.to_vec(), data)
+                    .expect("safetensors fixture: data length must match dtype x shape");
+                (name, view)
+            })
+            .collect();
+        let bytes = safetensors::serialize(views, None).expect("serialize safetensors fixture");
+        std::fs::write(path, bytes).expect("write safetensors fixture");
+    }
+
+    /// F32 shard: `&[(tensor_name, shape, data)]`.
+    fn write_safetensors_f32(path: &std::path::Path, tensors: &[(&str, &[usize], &[f32])]) {
+        let payloads: Vec<Vec<u8>> = tensors
+            .iter()
+            .map(|(_, shape, data)| {
+                let expected: usize = shape.iter().product();
+                assert_eq!(expected, data.len(), "data length must match shape");
+                data.iter().flat_map(|v| v.to_le_bytes()).collect()
+            })
+            .collect();
+        let rows: Vec<(&str, safetensors::Dtype, &[usize], &[u8])> = tensors
+            .iter()
+            .zip(&payloads)
+            .map(|((name, shape, _), bytes)| {
+                (*name, safetensors::Dtype::F32, *shape, bytes.as_slice())
+            })
+            .collect();
+        write_safetensors_raw(path, &rows);
+    }
+
+    /// I8 shard — `parse_safetensors_dtype` maps I8 to [`SourceDtype::Other`],
+    /// which is the branch that exercises the V2 pre-skip classification at
+    /// `build_manifest_safetensors`. The safetensors counterpart of
+    /// [`write_npy_i8`].
+    fn write_safetensors_i8(path: &std::path::Path, tensors: &[(&str, &[usize], &[i8])]) {
+        let payloads: Vec<Vec<u8>> = tensors
+            .iter()
+            .map(|(_, shape, data)| {
+                let expected: usize = shape.iter().product();
+                assert_eq!(expected, data.len(), "data length must match shape");
+                data.iter().map(|v| *v as u8).collect()
+            })
+            .collect();
+        let rows: Vec<(&str, safetensors::Dtype, &[usize], &[u8])> = tensors
+            .iter()
+            .zip(&payloads)
+            .map(|((name, shape, _), bytes)| {
+                (*name, safetensors::Dtype::I8, *shape, bytes.as_slice())
+            })
+            .collect();
+        write_safetensors_raw(path, &rows);
+    }
+
     fn scratch_dir(tag: &str) -> std::path::PathBuf {
         let pid = std::process::id();
         let nanos = std::time::SystemTime::now()
@@ -1366,6 +1440,180 @@ mod tests {
                 assert_eq!(name, "blk.0.moe_gate.weight");
             }
             other => panic!("expected ManifestV2UnmatchedTensor, got {other:?}"),
+        }
+    }
+
+    // ---------- safetensors input path (GH #103) ----------
+    //
+    // Until #103 the safetensors half of `quantize-goz1` had zero coverage,
+    // although it is one of the two documented production input formats. The
+    // V2 fail-closed *raise* is shared with npy (`classify_and_decide`), but
+    // the pre-skip call that applies it to unsupported dtypes before the
+    // intentional `continue` is duplicated per format, and only the npy copy
+    // was exercised.
+    //
+    // ORDER-AGNOSTIC BY CONSTRUCTION. `SafeTensors::tensors()` iterates a
+    // randomly-seeded `std::collections::HashMap`, so tensor order inside a
+    // shard — and therefore the GOZ1 tensor table and data layout — varies run
+    // to run (GH #115). Nothing below asserts position, or byte-compares two
+    // packs; the npy byte-identity idiom (`parity_legacy_vs_baseline_...`)
+    // must not be copied onto a multi-tensor safetensors fixture, where it
+    // would pass repeatedly and then fail. The fail-closed fixtures carry
+    // exactly ONE unmatched tensor so the reported name is deterministic.
+
+    fn safetensors_config(dir: &std::path::Path, out: &std::path::Path) -> QuantizationConfig {
+        let mut config = base_config(dir, out);
+        config.input_format = QuantizationInputFormat::Safetensors;
+        config
+    }
+
+    /// End-to-end twin of [`v2_structural_manifest_end_to_end_npy`]. One shard
+    /// holds all four structural tensors, so unlike the npy fixture (one file
+    /// per tensor) there is a single `ShardStats` carrying aggregate counts —
+    /// which is order-independent, and the right shape of assertion here.
+    #[test]
+    fn v2_structural_manifest_end_to_end_safetensors() {
+        let dir = scratch_dir("v2-st-e2e-input");
+        write_safetensors_f32(
+            &dir.join("shard.safetensors"),
+            &[
+                (
+                    "block_000.slot_00.moe_expert.gate",
+                    &[2, 2],
+                    &[0.1f32, -0.2, 0.3, -0.4],
+                ),
+                (
+                    "block_000.slot_07.block_norm",
+                    &[2, 2],
+                    &[1.0f32, -1.0, 0.5, -0.5],
+                ),
+                (
+                    "block_000.slot_11.router",
+                    &[2, 2],
+                    &[0.05f32, 0.9, -0.05, -0.9],
+                ),
+                (
+                    "embedding.slot_00.token_embedding",
+                    &[2, 2],
+                    &[0.3f32, -0.3, 0.01, -0.01],
+                ),
+            ],
+        );
+        let out = scratch_dir("v2-st-e2e-out").join("v2st.goz1");
+
+        let mut config = safetensors_config(&dir, &out);
+        config.manifest_path = Some(in_tree_structural_manifest());
+        let stats = run_quantization(&config)
+            .expect("V2 structural manifest must be accepted for safetensors");
+
+        assert_eq!(stats.len(), 1, "one ShardStats per safetensors shard");
+        // router + block_norm preserve (fp16-at-rest); gate + embedding ternary.
+        assert_eq!(
+            (stats[0].tensors_fp16, stats[0].tensors_ternary),
+            (2, 2),
+            "routers/norms preserved and candidates ternary, counted per shard"
+        );
+        assert!(out.exists(), "pack must be written");
+    }
+
+    /// Fail-closed on a supported dtype through the safetensors builder. Twin
+    /// of [`v2_manifest_fails_closed_on_unmatched_name`].
+    #[test]
+    fn v2_manifest_fails_closed_on_unmatched_name_safetensors() {
+        let dir = scratch_dir("v2-st-fail-closed-input");
+        write_safetensors_f32(
+            &dir.join("shard.safetensors"),
+            &[("blk.0.moe_gate.weight", &[2, 2], &[0.1f32, -0.2, 0.3, -0.4])],
+        );
+        let out = scratch_dir("v2-st-fail-closed-out").join("bad.goz1");
+
+        let mut config = safetensors_config(&dir, &out);
+        config.manifest_path = Some(in_tree_structural_manifest());
+        let err = run_quantization(&config)
+            .expect_err("V1-named safetensors input under a V2 manifest must fail closed");
+        match err {
+            GrokOzempicError::ManifestV2UnmatchedTensor { ref name } => {
+                assert_eq!(name, "blk.0.moe_gate.weight");
+            }
+            other => panic!("expected ManifestV2UnmatchedTensor, got {other:?}"),
+        }
+    }
+
+    /// The test this issue exists for: the Other-dtype pre-skip block in
+    /// `build_manifest_safetensors` is the code that had no coverage. An I8
+    /// tensor is skipped by the float stream, but under V2 its name must still
+    /// be classified first, so a legacy stem cannot vanish past fail-closed.
+    ///
+    /// Deleting the `is_structural_v2()` pre-check in the safetensors builder
+    /// makes this test fail and leaves every other test green.
+    #[test]
+    fn v2_manifest_fails_closed_on_unmatched_other_dtype_safetensors() {
+        let dir = scratch_dir("v2-st-fail-closed-other-input");
+        write_safetensors_i8(
+            &dir.join("shard.safetensors"),
+            &[("blk.0.moe_gate.weight", &[4], &[1i8, -1, 0, 2])],
+        );
+        let out = scratch_dir("v2-st-fail-closed-other-out").join("bad.goz1");
+
+        let mut config = safetensors_config(&dir, &out);
+        config.manifest_path = Some(in_tree_structural_manifest());
+        let err = run_quantization(&config)
+            .expect_err("unmatched Other-dtype safetensors name under V2 must fail closed");
+        match err {
+            GrokOzempicError::ManifestV2UnmatchedTensor { ref name } => {
+                assert_eq!(name, "blk.0.moe_gate.weight");
+            }
+            other => panic!("expected ManifestV2UnmatchedTensor, got {other:?}"),
+        }
+    }
+
+    /// Counterpart to the fail-closed pair: with **no** manifest there is no
+    /// V2 rule to violate, so an unsupported dtype is silently dropped from the
+    /// pack. This is deliberate (`.claude/rules/goz1-pipeline.md`: "V2
+    /// fail-closed does not detect under-packing"), and pinning it keeps the
+    /// two behaviours from being conflated — the guard is about
+    /// *misclassification*, never about *absence*.
+    #[test]
+    fn safetensors_other_dtype_is_skipped_when_no_manifest_applies() {
+        let dir = scratch_dir("st-other-skip-input");
+        write_safetensors_i8(
+            &dir.join("only-i8.safetensors"),
+            &[("blk.0.moe_gate.weight", &[4], &[1i8, -1, 0, 2])],
+        );
+        let out = scratch_dir("st-other-skip-out").join("empty.goz1");
+
+        let config = safetensors_config(&dir, &out);
+        // Every tensor was skipped, so nothing is quantizable and the run
+        // errors rather than emitting an empty pack. Match the variant only:
+        // the message says "all skipped as unsupported dtype?", which is right
+        // here but is a guess the code cannot actually make.
+        let err = run_quantization(&config)
+            .expect_err("a shard of only unsupported dtypes leaves nothing to pack");
+        assert!(
+            matches!(err, GrokOzempicError::InvalidConfig(_)),
+            "expected InvalidConfig for an all-skipped shard, got {err:?}"
+        );
+    }
+
+    /// `collect_safetensor_shards` filters on the extension only, so a
+    /// directory containing no `*.safetensors` short-circuits before the
+    /// builder runs. Mirrors the npy branch.
+    #[test]
+    fn safetensors_dir_without_shards_is_rejected() {
+        let dir = scratch_dir("st-no-shards-input");
+        write_npy_f32(&dir.join("stray.npy"), &[2], &[1.0f32, 2.0]);
+        let out = scratch_dir("st-no-shards-out").join("none.goz1");
+
+        let err = run_quantization(&safetensors_config(&dir, &out))
+            .expect_err("a directory with no .safetensors must be rejected");
+        match err {
+            GrokOzempicError::InvalidConfig(ref msg) => {
+                assert!(
+                    msg.contains("no .safetensors files found"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected InvalidConfig, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #103 · Ternary Debt Ledger [1] VERIFIED @ `4464a74`

Closes #103.

## Why

safetensors is one of two documented production input formats for `quantize-goz1`, with its own recipe in `.claude/rules/goz1-pipeline.md`. It had **zero** test references — `build_manifest_safetensors` and `quantize_safetensors_entry` were reached by nothing.

**Correction to how I originally described this** (caught in review on #109): the fail-closed *raise* is **shared**, not copy-pasted. `classify_and_decide` returns `ManifestV2UnmatchedTensor` from a single site, and both builders call it. What is duplicated per format is the **pre-skip call** that applies fail-closed to unsupported dtypes *before* the intentional `continue` — and only the npy copy was exercised.

## Two mutation runs prove exactly that shape

Not asserted — measured. A green test that detects nothing is worse than no test, so I verified these fail when the code they guard is removed:

| Mutation | Tests that fail |
|---|---|
| delete the **safetensors** pre-skip guard (`stream.rs:628-630`) | **1** — the new Other-dtype test. All 154 others, including every npy test, stay green |
| delete the **shared** raise (`classify_and_decide`) | **4** — 2 npy + 2 safetensors |

The first row *is* the gap #103 exists to close: before this PR, that mutation was invisible.

## Tests

```
v2_structural_manifest_end_to_end_safetensors
v2_manifest_fails_closed_on_unmatched_name_safetensors
v2_manifest_fails_closed_on_unmatched_other_dtype_safetensors   ← the gap
safetensors_other_dtype_is_skipped_when_no_manifest_applies
safetensors_dir_without_shards_is_rejected
```

## Two design constraints, both load-bearing

**1. Order-agnostic.** `SafeTensors::tensors()` iterates a randomly-seeded `std::collections::HashMap`, so tensor order inside a shard — and therefore the GOZ1 tensor table and data layout — varies run to run. Filed separately as **#115**. Nothing here asserts position or byte-compares two packs. Copying the npy byte-identity idiom (`parity_legacy_vs_baseline_is_byte_identical`) onto a multi-tensor safetensors fixture would produce a test that passes hundreds of times and then fails. The fail-closed fixtures carry **exactly one** unmatched tensor so the reported name is deterministic.

**2. Fixtures built with `safetensors::serialize`, never hand-rolled bytes.** `bytemuck_cast_f32`/`_f16` reinterpret `view.data()` as `&[f32]`/`&[f16]` with no alignment check, and the format does not guarantee the data section is aligned. Letting the library lay out the file keeps these fixtures on the aligned happy path — a hand-built shard could be **UB** rather than a test failure. The helper carries that warning so the next person doesn't "simplify" it.

## Shape difference worth knowing

safetensors is one shard holding many tensors, so there is a single `ShardStats` with aggregate counts — unlike the npy fixture's one-file-per-tensor classification oracle. Aggregate counts are order-independent, which is the correct assertion here anyway.

The fourth test pins that an unsupported dtype with **no** applicable manifest is silently dropped. That is deliberate per the rules doc, and worth pinning precisely so it stays distinct from the guard: fail-closed is about *misclassification*, never about *absence*.

## Scope

**Tests only. No production code touched.** #115 (determinism) and the alignment concern are filed, not fixed here.

## Verification

155 Rust tests (up from 150) + 6. Pushed through the `just review` pre-push gate restored in #97 — full cargo matrix, 13 Python modules, actionlint, shellcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa


___

## **CodeAnt-AI Description**
Add coverage for safetensors quantization and V2 manifest safeguards

### What Changed
- Safetensors inputs now have end-to-end coverage for structural V2 manifests, including preservation and ternary tensor counts
- Tests verify unmatched supported and unsupported tensor names fail with a clear manifest error instead of being silently skipped
- Tests verify unsupported dtypes are skipped without a manifest and that directories without safetensors shards are rejected

### Impact
`✅ Safetensors V2 quantization behavior verified`
`✅ Fewer silently omitted tensors under V2 manifests`
`✅ Clearer errors for invalid safetensors inputs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds test coverage for the safetensors input path in `quantize-goz1`, which previously had none despite being one of two documented production formats. Five tests now exercise the V2 fail-closed guard for unsupported dtypes — previously only covered on the npy path — with no production code touched.

**Design notes**
- Tests are order-agnostic: `SafeTensors::tensors()` iterates a randomly-seeded `HashMap`, so no test asserts tensor position or byte-compares packs.
- Fixtures use `safetensors::serialize` rather than hand-rolled bytes, since the format doesn't guarantee data-section alignment and `bytemuck_cast_*` reinterprets without checking.
- Mutation runs confirm coverage: deleting the safetensors pre-skip guard fails only the new Other-dtype test; deleting the shared raise fails all four fail-closed tests.

<sup>Written for commit 7142ab8da3021b2d72441812c74778bc3588eab9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

