### PR TITLE
ci: add ruff as a blocking gate over 24k lines of unlinted Python (#101)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,26 @@ jobs:
       - name: ShellCheck
         run: shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh
 
+  python:
+    name: ruff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      # Version-pinned deliberately: an unpinned linter turns unrelated PRs red
+      # on release day. Installed via pip rather than a third-party action so
+      # the only thing to trust is the pinned package version.
+      - name: Install ruff
+        run: python3 -m pip install --user 'ruff==0.15.14'
+
+      - name: ruff
+        run: |
+          ruff --version
+          ruff check --output-format=github scripts/
+
   workflows:
     name: actionlint
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -122,7 +122,7 @@ _optional-linters:
     #!/usr/bin/env bash
     # Fail-fast when an installed optional linter finds issues (just ci must not greenwash).
     #
-    # Optional *locally only*. Since GH #98 both run unconditionally in
+    # Optional *locally only*. Since GH #98/#101 all three run unconditionally in
     # .github/workflows/lint.yml, so a `skip:` here means "not checked on this
     # machine", not "not checked at all" — CI will still fail the PR.
     # Local coverage is narrower than CI's: CI also lints .githooks/* and
@@ -133,6 +133,12 @@ _optional-linters:
       actionlint
     else
       echo "skip: actionlint not installed (lint.yml enforces it in CI)"
+    fi
+    if command -v ruff >/dev/null 2>&1; then
+      echo "+ ruff check scripts/"
+      ruff check scripts/
+    else
+      echo "skip: ruff not installed (lint.yml enforces it in CI; pip install 'ruff==0.15.14')"
     fi
     if command -v shellcheck >/dev/null 2>&1; then
       shopt -s nullglob
@@ -342,6 +348,11 @@ doctor:
       status ok "shellcheck present"
     else
       status warn "shellcheck not installed (optional for just ci)"
+    fi
+    if command -v ruff >/dev/null 2>&1; then
+      status ok "ruff $(ruff --version 2>/dev/null | head -1)"
+    else
+      status warn "ruff not installed (blocking in CI since #101; pip install 'ruff==0.15.14')"
     fi
     if command -v jq >/dev/null 2>&1; then
       status ok "jq $(jq --version 2>/dev/null | head -1)"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,44 @@
+# Python lint gate for scripts/ (GH #101).
+#
+# Before this, ~24k lines of Python across 34 scripts had no linter, type
+# checker or formatter of any kind: `just ci` ran `py_compile` (syntax only),
+# Qodana is `linter: qodana-rust`, and Codacy's pylint ruleset is gitignored and
+# therefore unversioned. Rust had `clippy -D warnings`; Python had nothing.
+#
+# Blocking from day one, so the rule set is chosen to be worth blocking on.
+
+target-version = "py311"          # matches .codacy/codacy.yaml runtime
+line-length = 100                 # documentation only; E501 is not enabled -- see below
+
+[lint]
+# High-signal only. Every rule here catches something that can be wrong at
+# runtime or is a latent bug, not a matter of taste.
+#
+#   F   pyflakes            undefined names, unused imports, f-string bugs
+#   B   flake8-bugbear      mutable defaults, loop-variable capture, bare zip()
+#   E4  imports             module-import-not-at-top, shadowed builtins
+#   E7  statements          comparison/lambda/type errors
+#   E9  syntax/IO           E9 is the "this will not run" class
+#   C4  comprehensions      correctness-adjacent simplifications
+#   UP  pyupgrade           deprecated stdlib imports and forms
+select = ["F", "B", "E4", "E7", "E9", "C4", "UP"]
+
+# DELIBERATELY NOT ENABLED
+#
+# E501 (line-too-long) accounts for 374 of the 376 violations a full `E,W` run
+# reports on this tree. These are research and experiment scripts carrying long
+# tensor names, structural paths and tabular literals; reflowing them would be a
+# ~374-line diff with no correctness value, and it would bury the seven findings
+# that actually matter. Enable it in a dedicated PR if you also want a formatter.
+#
+# SIM / RET are omitted for the same reason at smaller scale: they are style
+# opinions, and a blocking gate should not fail a PR over taste.
+
+[lint.per-file-ignores]
+# Test modules legitimately build closures inside a loop and consume them within
+# the same iteration (mock.patch side_effect, immediate invocation), which B023
+# cannot distinguish from a closure that escapes. Verified by hand for
+# test_grok1_multiblock_v4_supervisor.py: the loop is
+# `for signum in (SIGINT, SIGTERM)` and every closure is passed straight into
+# mock.patch.object / self._run within that iteration.
+"scripts/test_*.py" = ["B023"]

--- a/scripts/grok1_block_weights.py
+++ b/scripts/grok1_block_weights.py
@@ -31,9 +31,9 @@ import shutil
 import subprocess  # nosec B404
 import sys
 from collections.abc import Iterable
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Protocol
+from typing import Protocol
+from collections.abc import Callable
 
 import numpy as np
 

--- a/scripts/grok1_multiblock_lib.py
+++ b/scripts/grok1_multiblock_lib.py
@@ -1703,12 +1703,12 @@ def _build_rationale(
     baseline = BASELINE_64["expert_only"]["block_output_cosine"]
     topk_key = _topk_label(top_k)
     return [
-        f"block_output_cosine sequence={['%.6f' % c for c in m['cos']]}",
-        f"residual_in_drift sequence={['%.6f' % d for d in m['resid_in']]}",
-        f"block_output_drift sequence={['%.6f' % d for d in m['out_drift']]}",
-        f"router_top1 sequence={['%.6f' % t for t in m['top1']]}",
-        f"{topk_key} sequence={['%.6f' % t for t in m['topk']]}",
-        f"expert_load_js_bits sequence={['%.6f' % j for j in m['js']]}",
+        f"block_output_cosine sequence={[f'{c:.6f}' for c in m['cos']]}",
+        f"residual_in_drift sequence={[f'{d:.6f}' for d in m['resid_in']]}",
+        f"block_output_drift sequence={[f'{d:.6f}' for d in m['out_drift']]}",
+        f"router_top1 sequence={[f'{t:.6f}' for t in m['top1']]}",
+        f"{topk_key} sequence={[f'{t:.6f}' for t in m['topk']]}",
+        f"expert_load_js_bits sequence={[f'{j:.6f}' for j in m['js']]}",
         f"compounding_heuristic={compounding}",
         f"end_block_output_cosine={end_cos:.6f}",
         f"last_block_residual_in_drift={last_resid_in}",

--- a/scripts/grok1_multiblock_v4_supervisor.py
+++ b/scripts/grok1_multiblock_v4_supervisor.py
@@ -33,7 +33,7 @@ import subprocess  # nosec B404
 import sys
 import tempfile
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
@@ -186,7 +186,7 @@ _LABEL_BY_ALIAS = {
 
 
 def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _output_lock_path(out: Path) -> Path:

--- a/scripts/route_preservation_measure.py
+++ b/scripts/route_preservation_measure.py
@@ -339,7 +339,16 @@ def routing_metrics(
     o_ref = np.argsort(-l_ref, axis=1)[:, :2]
     o_q = np.argsort(-l_q, axis=1)[:, :2]
     top2 = float(
-        np.mean([len(set(a.tolist()) & set(b.tolist())) == 2 for a, b in zip(o_ref, o_q)])
+        # strict=True: o_ref and o_q are same-shaped by construction, but a bare
+        # zip() would silently truncate to the shorter one if that ever stopped
+        # holding, publishing a top-k agreement computed over fewer rows than
+        # claimed. Fail loudly instead -- this figure ends up in reports.
+        np.mean(
+            [
+                len(set(a.tolist()) & set(b.tolist())) == 2
+                for a, b in zip(o_ref, o_q, strict=True)
+            ]
+        )
     )
 
     load_ref = np.bincount(top1_ref, minlength=experts).astype(np.float64) / len(top1_ref)

--- a/scripts/test_export_grok1_embedding_npy.py
+++ b/scripts/test_export_grok1_embedding_npy.py
@@ -87,13 +87,13 @@ class WriteNpyTests(unittest.TestCase):
 
 class LayoutPolicyTests(unittest.TestCase):
     def _ns(self, **kw):
-        defaults = dict(
-            offset=None,
-            shape=None,
-            dtype=None,
-            no_dissect=True,
-            xai_dissect=None,
-        )
+        defaults = {
+            "offset": None,
+            "shape": None,
+            "dtype": None,
+            "no_dissect": True,
+            "xai_dissect": None,
+        }
         defaults.update(kw)
         return argparse_ns(**defaults)
 

--- a/scripts/test_export_grok1_int8_npy.py
+++ b/scripts/test_export_grok1_int8_npy.py
@@ -24,7 +24,7 @@ _write_shard = _sf.write_shard
 _write_quantized = _sf.write_quantized
 
 
-def _array_spec(shape: tuple[int, ...], descr: str) -> "exp.ArraySpec":
+def _array_spec(shape: tuple[int, ...], descr: str) -> exp.ArraySpec:
     """An ArraySpec with a self-consistent nbytes for `shape`/`descr`.
 
     Shared by the classes below. Argument order matches ArraySpec's own fields;

--- a/scripts/test_grok1_multiblock_v4_supervisor.py
+++ b/scripts/test_grok1_multiblock_v4_supervisor.py
@@ -51,7 +51,7 @@ def _expert_scale_sources(block: int, source: str) -> dict[str, str]:
 _ARM_FIXTURES = {
     "baseline": {
         "schedule": ("int4", [], [0, 1, 2, 3], []),
-        "sources": {block: "research_int4_side" for block in (0, 1, 2, 3)},
+        "sources": dict.fromkeys((0, 1, 2, 3), "research_int4_side"),
     },
     "p1": {
         "schedule": ("int4_channel_alpha", [1, 2, 3], [0], [0]),
@@ -69,9 +69,7 @@ _ARM_FIXTURES = {
             [0, 1, 2, 3],
             [0, 1, 2, 3],
         ),
-        "sources": {
-            block: "research_int4_channel_alpha_side" for block in (0, 1, 2, 3)
-        },
+        "sources": dict.fromkeys((0, 1, 2, 3), "research_int4_channel_alpha_side"),
     },
 }
 


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #101 · Ternary Debt Ledger [89] VERIFIED @ `4464a74`

Closes #101.

## Why

Python is the larger half of this codebase — **13,954 non-test + 9,923 test LOC vs 11,037 Rust** — and had no linter, type checker or formatter of any kind. `just ci` ran `py_compile` (syntax only), `qodana.yaml` is `linter: qodana-rust`, and Codacy's pylint ruleset is gitignored and therefore unversioned. Rust had `clippy -D warnings`. Python had nothing.

Blocking from day one, as you asked — which made the **rule set** the real decision.

## Measured before choosing

| rule set | violations |
|---|---:|
| `E,W,F` (full) | 376 |
| — of which **`E501` line-too-long** | **374** |
| `F,B,E4,E7,E9` (semantic) | 7 |
| **selected: `F,B,E4,E7,E9,C4,UP`** | **14** |

`E501` is deliberately **not** enabled, and `ruff.toml` says why: these are research scripts carrying long tensor names, structural paths and tabular literals. Reflowing 374 lines is a diff with no correctness value that would bury the seven findings that matter. Enable it in a dedicated PR if a formatter comes with it. `SIM`/`RET` omitted on the same reasoning — a blocking gate shouldn't fail a PR over taste.

## All 14 fixed

- **7 auto-fixed** (`--fix`, safe fixes only): unused import, deprecated `collections.abc` import, `datetime.UTC` alias, quoted annotation, 2× dict-comprehension-for-iterable.
- **6 × UP031** percent-format → f-string specifiers in `grok1_multiblock_lib.py`. Mechanical and **output-identical**: `'%.6f' % c` and `f'{c:.6f}'` render the same string, and these feed a list repr in a report line.
- **1 × C408** `dict()` → literal in a test helper.

## One intentional behaviour change, flagged

The scope contract says mechanical fixes only, so this is called out rather than buried:

```python
# route_preservation_measure.py:342
for a, b in zip(o_ref, o_q, strict=True)
```

`o_ref`/`o_q` are same-shaped by construction, but a bare `zip()` **silently truncates** to the shorter one if that ever stops holding — publishing a top-k agreement computed over fewer rows than claimed, from a function whose output goes into reports. Now fails loudly instead.

## Five B023 ignored, not fixed — and why that's correct

`B023` (closure captures loop variable) fires 5× in `test_grok1_multiblock_v4_supervisor.py`. These are **false positives**, verified by hand rather than assumed:

```console
$ # the enclosing loop
for signum in (signal.SIGINT, signal.SIGTERM):
$ # how the closures are consumed
side_effect=interrupt_after_success,
result, run = self._run(args, child)
```

Every closure is passed straight into `mock.patch.object(...)` or `self._run(...)` **within the same iteration** — none escapes. B023 cannot distinguish that from a closure that outlives the loop. Scoped to `scripts/test_*.py` via `per-file-ignores`, with the reasoning in the config so nobody has to re-derive it.

## Wiring

A `ruff` job in `lint.yml` (the workflow #98 created), plus `_optional-linters` and a `just doctor` row. Installed via **pinned pip** rather than a third-party action, so the only thing to trust is the version — and pinned to `0.15.14`, because an unpinned linter turns unrelated PRs red on release day.

## Verification

`ruff check scripts/` → **All checks passed**. The four touched test modules pass (`test_export_grok1_embedding_npy` 22/22, plus 3 modules OK). `actionlint` clean, `lint.yml` parses. Pushed through the `just review` pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa


___

## **CodeAnt-AI Description**
Add blocking Python lint checks and prevent incomplete route metrics

### What Changed
- Pull requests now fail CI when Python scripts contain high-confidence lint errors
- Local checks and environment diagnostics report whether Ruff is installed and run it when available
- Route-preservation top-k agreement now fails instead of silently calculating results from fewer rows if the compared data lengths differ
- Existing code and tests were updated to satisfy the new checks without changing report output

### Impact
`✅ Python lint failures caught before merge`
`✅ Consistent lint checks in CI and local development`
`✅ No silently truncated route-agreement reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ruff` as a blocking lint gate over the ~24k lines of Python in `scripts/`, which previously had no linter, and fixes all 14 violations the chosen rule set found. Closes #101.

**Rule set**
- `ruff.toml` selects runtime-correctness rules (F, B, E4, E7, E9, C4, UP); E501 and SIM/RET are excluded, with the rationale in the config.
- 13 of 14 fixes are mechanical — 6 are output-identical `%.6f` → f-string conversions in `grok1_multiblock_lib.py`, the rest are auto-fixes.
- 5 B023 findings in `scripts/test_*.py` are per-file-ignored as verified false positives: closures are consumed within the same loop iteration.

**Behavior change**
- `route_preservation_measure.py` now zips with `strict=True`, failing loudly instead of silently truncating a top-k agreement that feeds reports.

<sup>Written for commit 1dbef9289b4d4a135d916f9e291ae7f265457769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

