### PR TITLE
fix: accept both GROK_OZEMPIC_DISSECT_RUN shapes and fail loud when set (#102)

### DIFF
--- a/.claude/rules/goz1-pipeline.md
+++ b/.claude/rules/goz1-pipeline.md
@@ -92,6 +92,19 @@ cargo run --release --features cli --locked -- quantize-goz1 \
 
 Since #40 / RM-191, **runtime** packs prefer the V2 `structural-manifest.json` whenever tensor names are structural (`block_{NNN}.slot_{SS}.{kind}`, export-script stems). V2 is fail-closed: an unmatched name hard-errors instead of defaulting to ternary. For legacy `blk.*`-named inputs use V1 `baseline.json` (defaults fallthrough allowed). Prefer `--verify`. Authoritative structural names / planning surface: `~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0/` (tests honor `GROK_OZEMPIC_DISSECT_RUN`).
 
+**`GROK_OZEMPIC_DISSECT_RUN` accepts either shape** (GH #102): the run root
+(`.../LATEST_CORRECT_GROK1_RUN`, what `block_pilot_goz1.sh` and this doc export)
+or the already-resolved run3 dir (`.../manifests/xai-grok-1-ckpt-0`). The Rust
+oracle probes direct-then-nested, matching the justfile.
+
+⚠ Before #102 the Rust side accepted **only** the resolved dir, so exporting the
+documented run root made `run3_conversion_manifest_names_fully_classified` fail
+its `is_file()` probe and **skip while reporting green** — the misclassification
+oracle silently disabled itself for anyone following these instructions. It now
+**panics** when the variable is set but unresolvable. A skip means "not
+configured"; it never means "configured and ignored". If you see `skip:` from
+that test, believe the skip, not the green.
+
 **Evidence sources:**
 
 | Metric | Where |

--- a/scripts/block_pilot_goz1.sh
+++ b/scripts/block_pilot_goz1.sh
@@ -60,7 +60,7 @@ fi
 for required in conversion-manifest.json quant-plan.json pilot-selection-plan.json; do
   [ -f "$RUN3/$required" ] || {
     echo "error: run3 $required not found under $RUN3" >&2
-    echo "       set GROK_OZEMPIC_DISSECT_RUN to the xai-dissect run root" >&2
+    echo "       set GROK_OZEMPIC_DISSECT_RUN to the xai-dissect run root (or the resolved .../manifests/xai-grok-1-ckpt-0 dir; both are accepted -- GH #102)" >&2
     exit 1
   }
 done

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -1633,36 +1633,142 @@ mod tests {
         assert_structural_fixture_stats(&stats);
     }
 
+    /// The two shapes `GROK_OZEMPIC_DISSECT_RUN` is written as in this repo.
+    ///
+    /// `scripts/block_pilot_goz1.sh:41`, `.claude/rules/goz1-pipeline.md` and
+    /// `reports/grok-1-block-pilot/results.md:481` all export the **run root**
+    /// (`.../LATEST_CORRECT_GROK1_RUN`), while this test historically joined
+    /// `conversion-manifest.json` directly and therefore required the
+    /// **resolved run3 dir** (`.../manifests/xai-grok-1-ckpt-0`). The justfile
+    /// already probed both (`justfile:261-278`), which is how the ambiguity
+    /// stayed invisible. Probe both here too, in the same order.
+    fn resolve_run3_conversion_manifest(base: &std::path::Path) -> Option<std::path::PathBuf> {
+        const RUN3_SUBDIR: &str = "manifests/xai-grok-1-ckpt-0";
+        let direct = base.join("conversion-manifest.json");
+        if direct.is_file() {
+            return Some(direct);
+        }
+        let nested = base.join(RUN3_SUBDIR).join("conversion-manifest.json");
+        if nested.is_file() {
+            return Some(nested);
+        }
+        None
+    }
+
+    /// Both documented shapes of `GROK_OZEMPIC_DISSECT_RUN` resolve, and a
+    /// path that is neither resolves to `None` (which the oracle turns into a
+    /// loud panic rather than a silent skip). Runs everywhere -- no mounted
+    /// xai-dissect run required, which is the point: the resolution contract
+    /// is testable even where the data is not.
+    #[test]
+    fn dissect_run_env_accepts_run_root_and_resolved_run3_dir() {
+        let root = scratch_dir("dissect-run-shapes");
+
+        // (a) already-resolved run3 dir: conversion-manifest.json sits directly
+        //     under the given path. This is the shape stream.rs required before
+        //     GH #102 -- the only one it accepted.
+        let resolved = root.join("resolved");
+        std::fs::create_dir_all(&resolved).unwrap();
+        std::fs::write(resolved.join("conversion-manifest.json"), b"{}").unwrap();
+        assert_eq!(
+            resolve_run3_conversion_manifest(&resolved),
+            Some(resolved.join("conversion-manifest.json")),
+            "resolved run3 dir must be accepted"
+        );
+
+        // (b) run root: the manifest is nested under manifests/xai-grok-1-ckpt-0.
+        //     This is the shape block_pilot_goz1.sh and the docs export, and the
+        //     one that used to make the oracle skip while passing.
+        let run_root = root.join("LATEST_CORRECT_GROK1_RUN");
+        let nested = run_root.join("manifests/xai-grok-1-ckpt-0");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("conversion-manifest.json"), b"{}").unwrap();
+        assert_eq!(
+            resolve_run3_conversion_manifest(&run_root),
+            Some(nested.join("conversion-manifest.json")),
+            "run root must be accepted (the documented value)"
+        );
+
+        // (c) neither shape -> None, so the caller can fail loudly.
+        let empty = root.join("empty");
+        std::fs::create_dir_all(&empty).unwrap();
+        assert_eq!(
+            resolve_run3_conversion_manifest(&empty),
+            None,
+            "a directory with neither layout must not resolve"
+        );
+
+        // (d) direct hit wins over nested when both exist -- deterministic order.
+        let both = root.join("both");
+        let both_nested = both.join("manifests/xai-grok-1-ckpt-0");
+        std::fs::create_dir_all(&both_nested).unwrap();
+        std::fs::write(both.join("conversion-manifest.json"), b"{}").unwrap();
+        std::fs::write(both_nested.join("conversion-manifest.json"), b"{}").unwrap();
+        assert_eq!(
+            resolve_run3_conversion_manifest(&both),
+            Some(both.join("conversion-manifest.json")),
+            "direct hit must win, matching the justfile probe order"
+        );
+    }
+
     /// Path-gated oracle against the latest authoritative xai-dissect run:
     /// every `structural_name` in run3's `conversion-manifest.json` must
     /// classify to an explicit rule of the in-tree structural manifest
     /// (routers/norms preserve, everything else ternary, zero Default).
     ///
-    /// Skips (passes trivially) when the run directory is absent, e.g. CI.
-    /// Override the location with `GROK_OZEMPIC_DISSECT_RUN`.
+    /// `GROK_OZEMPIC_DISSECT_RUN` may be either the run root or the resolved
+    /// run3 directory; both are accepted (GH #102).
+    ///
+    /// Skip policy, and the reason it is not uniform:
+    ///
+    /// - env **unset** and no usable default → skip. The run is multi-GiB and
+    ///   not mounted in CI; that is the expected case, not a failure.
+    /// - env **set but unresolvable** → **panic**. Before #102 this skipped,
+    ///   so exporting the documented value (the run root) made this oracle
+    ///   silently disable itself and report green. "You configured this and I
+    ///   ignored you" must not look like "not configured".
     #[test]
     fn run3_conversion_manifest_names_fully_classified() {
-        let run_dir = std::env::var("GROK_OZEMPIC_DISSECT_RUN")
-            .map(std::path::PathBuf::from)
-            .ok()
-            .or_else(|| {
-                std::env::var("HOME").ok().map(|h| {
-                    std::path::PathBuf::from(h).join(
-                        "rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN/manifests/xai-grok-1-ckpt-0",
+        const RUN3_SUBDIR: &str = "manifests/xai-grok-1-ckpt-0";
+        let conversion = match std::env::var("GROK_OZEMPIC_DISSECT_RUN") {
+            Ok(raw) if !raw.trim().is_empty() => {
+                let base = std::path::PathBuf::from(raw.trim());
+                resolve_run3_conversion_manifest(&base).unwrap_or_else(|| {
+                    panic!(
+                        "GROK_OZEMPIC_DISSECT_RUN={} does not resolve to a run3 \
+                         conversion-manifest.json.\n  probed: {}\n  probed: {}\n\
+                         Set it to either the xai-dissect run root or the \
+                         {RUN3_SUBDIR} directory. Unset it to skip this oracle.",
+                        base.display(),
+                        base.join("conversion-manifest.json").display(),
+                        base.join(RUN3_SUBDIR)
+                            .join("conversion-manifest.json")
+                            .display(),
                     )
                 })
-            });
-        let Some(conversion) = run_dir.map(|d| d.join("conversion-manifest.json")) else {
-            eprintln!("skip: no GROK_OZEMPIC_DISSECT_RUN and no HOME");
-            return;
+            }
+            // Unset, empty, or non-UTF-8: fall back to the conventional
+            // location under HOME and skip quietly if it is not mounted.
+            _ => {
+                let Some(home) = std::env::var("HOME").ok() else {
+                    eprintln!("skip: no GROK_OZEMPIC_DISSECT_RUN and no HOME");
+                    return;
+                };
+                let base = std::path::PathBuf::from(home)
+                    .join("rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN");
+                match resolve_run3_conversion_manifest(&base) {
+                    Some(p) => p,
+                    None => {
+                        eprintln!(
+                            "skip: no conversion-manifest.json under {} (xai-dissect run not mounted)",
+                            base.display()
+                        );
+                        return;
+                    }
+                }
+            }
         };
-        if !conversion.is_file() {
-            eprintln!(
-                "skip: {} not present (xai-dissect run not mounted)",
-                conversion.display()
-            );
-            return;
-        }
+        eprintln!("run3 oracle: using {}", conversion.display());
 
         let bytes = std::fs::read(&conversion).expect("read conversion manifest");
         let doc: serde_json::Value =


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #102 · Ternary Debt Ledger [74] VERIFIED @ `4464a74`

Closes #102.

## Why

One environment variable, two incompatible meanings. `stream.rs` joined `conversion-manifest.json` directly, so it required the **resolved run3 dir**; `block_pilot_goz1.sh:41`, `.claude/rules/goz1-pipeline.md` and `reports/grok-1-block-pilot/results.md:481` all export the **run root**. The justfile documented and probed *both* (`justfile:261-278`) — which is how the ambiguity stayed invisible: every surface worked except the one nobody re-checked.

The consequence was worse than inconvenience. Exporting the **documented** value made `run3_conversion_manifest_names_fully_classified` fail its `is_file()` probe, print `skip:`, and **pass**. That test is the oracle proving every run3 structural name classifies to an explicit rule — the guard against exactly the misclassification #40 exists to prevent. Following the documentation turned it off, silently, green.

## Verified against the real mounted run

This is the layout that triggered it — not a constructed example:

```console
$ RUN=~/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN
$ [ -f "$RUN/conversion-manifest.json" ] && echo yes || echo no
no                                    # ← what the old code probed
$ [ -f "$RUN/manifests/xai-grok-1-ckpt-0/conversion-manifest.json" ] && echo yes || echo no
yes                                   # ← where it actually lives
```

So the documented export hit the missing path and skipped. After this PR:

```console
$ GROK_OZEMPIC_DISSECT_RUN="$RUN" cargo test --features cli --locked run3_conversion -- --nocapture
run3 oracle: using .../manifests/xai-grok-1-ckpt-0/conversion-manifest.json
test result: ok. 1 passed
```

The oracle now actually runs against real data on the documented setup.

## Behaviour matrix

| `GROK_OZEMPIC_DISSECT_RUN` | before | after |
|---|---|---|
| unset, run not mounted | skip | skip |
| **run root** (documented) | **skip, green** | **runs** |
| resolved run3 dir | runs | runs |
| set to a bogus path | **skip, green** | **panics**, naming both probed paths |

The asymmetry is deliberate. Unset still skips — the run is multi-GiB and absent in CI, which is expected, not a failure. Set-but-unresolvable now fails: *"you configured this and I ignored you"* must not look like *"not configured"*.

## Testable without the data

`dissect_run_env_accepts_run_root_and_resolved_run3_dir` pins all four cases — resolved dir, run root, neither, and both-present (direct wins, matching justfile probe order) — using scratch dirs. That matters: the resolution contract was previously only exercised on machines where the data happened to exist, which is precisely why the divergence survived.

The oracle also now prints which manifest it used, so a passing run says what it actually checked.

## Scope

One environment contract. **Classification logic untouched** — this is about whether the existing oracle runs, not what it decides.

## Verification

156 Rust tests (up from 155) + 6. `bash -n` and `shellcheck` clean on the edited script. Pushed through the `just review` pre-push gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa


___

## **CodeAnt-AI Description**
Accept both run path formats and fail clearly on invalid configuration

### What Changed
- `GROK_OZEMPIC_DISSECT_RUN` now accepts either the full run root or the resolved run3 directory.
- Configured paths that cannot find the conversion manifest now fail loudly instead of silently skipping the classification check.
- Unconfigured or unavailable default runs still skip as expected, while tests cover both supported layouts and direct-path precedence.
- Scripts and pipeline guidance now document both accepted path formats and the updated skip behavior.

### Impact
`✅ Fewer silently skipped validation checks`
`✅ Clearer errors for invalid run paths`
`✅ Reliable run3 validation with documented path formats`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GH #102 so the run3 classification oracle actually runs on the documented setup: `GROK_OZEMPIC_DISSECT_RUN` now accepts both the run root and the resolved run3 dir, and a set-but-unresolvable value fails loudly instead of skipping green.

- Before, exporting the documented run root made `run3_conversion_manifest_names_fully_classified` fail its `is_file()` probe, print `skip:`, and pass — silencing the guard against the misclassification from #40.
- Now, an unresolvable configured value panics, naming both paths probed; unset still skips, since the multi-GiB run is absent in CI.
- A new test pins all four resolution cases (resolved dir, run root, neither, both-present with direct winning) using scratch dirs, so the contract is testable without the mounted data.
- The oracle now prints which manifest it used, and the docs and error message in `block_pilot_goz1.sh` state that both shapes are accepted.

<sup>Written for commit b81a05b7bf72d0ec9dd86e3ed1a11454b45dea33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

