### PR TITLE
fix(stream): sort safetensors tensors so GOZ1 packs are reproducible (#115)

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -618,7 +618,23 @@ fn build_manifest_safetensors(
                 .map_err(GrokOzempicError::Io)?
         };
         let tensors = SafeTensors::deserialize(&mmap).map_err(GrokOzempicError::Safetensors)?;
-        for (name, view) in tensors.tensors() {
+        // Sort by tensor name before building entries (GH #115).
+        //
+        // `SafeTensors::tensors()` walks `Metadata::index_map`, a
+        // `std::collections::HashMap<String, usize>` whose `RandomState` is
+        // seeded per instance — so iteration order differs between processes
+        // and even between two `deserialize` calls in one process. That order
+        // becomes the manifest order, which becomes the GOZ1 tensor table and
+        // the data-section layout, so two runs over the same shard produced
+        // byte-different packs.
+        //
+        // The npy path has always been deterministic (`paths.sort()` in
+        // `collect_npy_files`); sorting here makes the two documented input
+        // formats agree, and makes pack bytes and `file_size` usable as the
+        // evidence `.claude/rules/goz1-pipeline.md` treats them as.
+        let mut named = tensors.tensors();
+        named.sort_by(|(a, _), (b, _)| a.cmp(b));
+        for (name, view) in named {
             let dtype = parse_safetensors_dtype(view.dtype());
             if dtype == SourceDtype::Other {
                 // i8/Other covered for alignment via structural manifest (see grok1_inventory NOTE);
@@ -1514,6 +1530,57 @@ mod tests {
             "routers/norms preserved and candidates ternary, counted per shard"
         );
         assert!(out.exists(), "pack must be written");
+    }
+
+    /// Two runs over the same shard must produce byte-identical packs (GH #115).
+    ///
+    /// `SafeTensors::tensors()` iterates a randomly-seeded `HashMap`, so before
+    /// the sort in `build_manifest_safetensors` this failed — tensor order, and
+    /// therefore the GOZ1 tensor table and data layout, varied per run. The npy
+    /// path has always been deterministic via `paths.sort()`.
+    ///
+    /// Enough tensors that a random permutation is overwhelmingly unlikely to
+    /// coincide: 8! = 40320 orderings, so a regression is caught ~99.998% of
+    /// the time per run rather than being a coin flip.
+    #[test]
+    fn safetensors_packs_are_byte_reproducible() {
+        let dir = scratch_dir("st-repro-input");
+        let names = [
+            "block_000.slot_00.moe_expert.gate",
+            "block_000.slot_01.moe_expert.down",
+            "block_000.slot_02.moe_expert.up",
+            "block_000.slot_07.block_norm",
+            "block_000.slot_08.block_norm",
+            "block_000.slot_11.router",
+            "embedding.slot_00.token_embedding",
+            "final_norm.slot_00.final_norm",
+        ];
+        let payload = [0.1f32, -0.2, 0.3, -0.4];
+        let rows: Vec<(&str, &[usize], &[f32])> = names
+            .iter()
+            .map(|n| (*n, &[2usize, 2][..], &payload[..]))
+            .collect();
+        write_safetensors_f32(&dir.join("shard.safetensors"), &rows);
+
+        let out_a = scratch_dir("st-repro-a").join("a.goz1");
+        let out_b = scratch_dir("st-repro-b").join("b.goz1");
+
+        let mut cfg_a = safetensors_config(&dir, &out_a);
+        cfg_a.manifest_path = Some(in_tree_structural_manifest());
+        run_quantization(&cfg_a).expect("first pack");
+
+        // Fresh config and a fresh deserialize -- a new HashMap instance, so a
+        // new random seed. This is what makes the test meaningful.
+        let mut cfg_b = safetensors_config(&dir, &out_b);
+        cfg_b.manifest_path = Some(in_tree_structural_manifest());
+        run_quantization(&cfg_b).expect("second pack");
+
+        assert_eq!(
+            goz1_bytes(&out_a),
+            goz1_bytes(&out_b),
+            "two runs over the same safetensors shard must produce identical packs; \
+             tensor order must not depend on HashMap iteration order (GH #115)"
+        );
     }
 
     /// Fail-closed on a supported dtype through the safetensors builder. Twin

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -630,8 +630,11 @@ fn build_manifest_safetensors(
         //
         // The npy path has always been deterministic (`paths.sort()` in
         // `collect_npy_files`); sorting here makes the two documented input
-        // formats agree, and makes pack bytes and `file_size` usable as the
-        // evidence `.claude/rules/goz1-pipeline.md` treats them as.
+        // formats agree, and makes pack *bytes* reproducible so a hash or a
+        // diff of a pack means something. Note `file_size` specifically was
+        // already order-invariant — permuting tensors rearranges the container
+        // without changing its length — so it is the byte-level evidence this
+        // fixes, not the size figure.
         let mut named = tensors.tensors();
         named.sort_by(|(a, _), (b, _)| a.cmp(b));
         for (name, view) in named {
@@ -1468,14 +1471,24 @@ mod tests {
     // intentional `continue` is duplicated per format, and only the npy copy
     // was exercised.
     //
-    // ORDER-AGNOSTIC BY CONSTRUCTION. `SafeTensors::tensors()` iterates a
-    // randomly-seeded `std::collections::HashMap`, so tensor order inside a
-    // shard — and therefore the GOZ1 tensor table and data layout — varies run
-    // to run (GH #115). Nothing below asserts position, or byte-compares two
-    // packs; the npy byte-identity idiom (`parity_legacy_vs_baseline_...`)
-    // must not be copied onto a multi-tensor safetensors fixture, where it
-    // would pass repeatedly and then fail. The fail-closed fixtures carry
-    // exactly ONE unmatched tensor so the reported name is deterministic.
+    // ORDERING. `SafeTensors::tensors()` iterates a randomly-seeded
+    // `std::collections::HashMap`, so the order it hands back still varies run
+    // to run. `build_manifest_safetensors` now sorts by tensor name before
+    // building entries (GH #115), so the resulting manifest — and therefore the
+    // GOZ1 tensor table and data layout — is deterministic, and
+    // `safetensors_packs_are_byte_reproducible` below asserts exactly that.
+    //
+    // These tests were originally written order-agnostically, before that sort
+    // existed. Two habits from then are still worth keeping:
+    //
+    // - Assert on aggregate counts or named lookups rather than on position.
+    //   Nothing here depends on *which* index a tensor lands at, only that the
+    //   whole pack is stable, so the tests stay honest if the ordering rule
+    //   ever changes from name to offset.
+    // - The fail-closed fixtures carry exactly ONE unmatched tensor. Under V2 a
+    //   shard with several unmatched names would still report an arbitrary one,
+    //   because the error is raised on the first match failure during the sorted
+    //   walk and the fixture's intent is to pin *which* name is named.
 
     fn safetensors_config(dir: &std::path::Path, out: &std::path::Path) -> QuantizationConfig {
         let mut config = base_config(dir, out);


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #115

Closes #115.

## Why

Two runs of `quantize-goz1` over the **same** safetensors directory produced **byte-different** GOZ1 packs. The npy path did not.

`SafeTensors::tensors()` walks `Metadata::index_map`, a `std::collections::HashMap<String, usize>` whose `RandomState` is seeded per instance — so iteration order differs between processes *and* between two `deserialize` calls in one process:

```console
$ grep -n 'index_map' ~/.cargo/registry/src/*/safetensors-0.8.0/src/tensor.rs | head -3
455:    pub fn tensors(&self) -> Vec<(String, TensorView<'data>)> {
457:        for (name, &index) in &self.metadata.index_map {
535:    index_map: HashMap<String, usize>,
```

That order became the manifest order → the GOZ1 tensor table → the data-section layout. Tensor table, every per-tensor offset, and the whole file's bytes shifted run to run.

The npy path has always sorted (`collect_npy_files` → `paths.sort()`), so the two documented production input formats disagreed on a property this repo enshrines in tests for one of them — `parity_legacy_vs_baseline_is_byte_identical` and `preserve_and_fp16_tiers_emit_identical_goz1_bytes` both assert byte identity, and both are npy-only.

## Why it matters beyond tidiness

- `.claude/rules/goz1-pipeline.md` treats pack bytes and `file_size` as **evidence**. A figure that changes between two identical runs is not evidence.
- Any hash-keyed cache over a safetensors-built pack misses every time.
- With >1 unmatched tensor under a V2 manifest, `ManifestV2UnmatchedTensor` named an **arbitrary** one — the same broken input blamed a different tensor each run.

## Fix

Sort by tensor name after `deserialize`, mirroring the npy path rather than introducing a second ordering convention.

## Verified by mutation, not assertion

`safetensors_packs_are_byte_reproducible` packs the same 8-tensor shard twice and asserts byte equality. Eight is deliberate: 8! = 40,320 orderings, so a regression is caught ~99.998% of the time per run instead of being a coin flip.

```console
=== reproducibility test, 6 runs against a build with the sort removed ===
  run 1: FAIL   run 2: FAIL   run 3: FAIL
  run 4: FAIL   run 5: FAIL   run 6: FAIL
  -> caught the regression in 6/6 runs
```

With the sort restored: 157 Rust tests pass (up from 156).

## Provenance

Found while designing #103's test set — 31 agents traced this path, and 11 of 27 suspicions survived an adversarial pass, this one among them. #103's tests were deliberately written **order-agnostically** so they characterise the fail-closed guard without encoding this bug; this PR removes the bug itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts safetensors tensors by name after deserialization so two runs over the same shard produce byte-identical GOZ1 packs, matching the npy path's deterministic behavior. Previously, `SafeTensors::tensors()` walked a HashMap with a randomly-seeded per-instance iterator, so tensor order—and therefore the tensor table, offsets, and file bytes—varied between runs. This made pack bytes unreliable as evidence and caused hash-keyed caches to miss.

Adds a regression test that packs an 8-tensor shard twice and asserts byte equality; the 8 tensors give ~99.998% detection per run. Closes #115.

<sup>Written for commit cc338148f8e817299d0e418dde10d88daa5dab4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Make safetensors-based GOZ1 packs produce identical bytes for identical input

### What Changed
- Safetensors tensors are processed in name order instead of unpredictable discovery order
- Repeated quantization of the same safetensors shard now produces byte-identical packs
- Added coverage that verifies reproducibility across separate quantization runs

### Impact
`✅ Reproducible GOZ1 pack bytes`
`✅ Reliable pack hashes and diffs`
`✅ Stable tensor layout and error selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
