### PR TITLE
fix: close seven review findings against this session's merged work

### DIFF
--- a/.claude/commands/pr-ready.md
+++ b/.claude/commands/pr-ready.md
@@ -44,7 +44,13 @@ just test
 cargo fmt --all -- --check
 cargo clippy --all-targets --features cli --locked -- -D warnings
 cargo test --features cli --locked
-# `just test` also runs all thirteen Python modules -- see the loop above.
+
+# `just test` also runs every Python module. A comment pointing at the loop
+# above does not run it, so the loop is repeated here -- this block is only a
+# mirror of `just check` + `just test` if it actually executes both halves.
+python3 -c 'import numpy; print(numpy.__version__)'
+sed -n '/^    mods=(/,/^    )/p' justfile | grep -oE 'scripts\.[a-z0-9_]+' \
+  | while read -r m; do python3 -m unittest "$m" -v || exit 1; done
 ```
 
 Path-scoped extras (only when those paths change; not part of `just ci`):

--- a/.claude/commands/pr-ready.md
+++ b/.claude/commands/pr-ready.md
@@ -8,8 +8,10 @@ Prefer the root `justfile` (#62 / RM-250):
 just ci
 ```
 
-Canonical matrix fallback if `just` is unavailable (`--locked` is intentional and
-stricter than GHA; include Python + `bash -n` so the fallback matches `just ci`):
+Fallback if `just` is unavailable (`--locked` is intentional and stricter than
+GHA). **This is not a hand-maintained copy of the module list** -- that is what
+went stale before: this file listed five Python modules while `just ci` ran
+thirteen, and named no linters at all, while claiming parity.
 
 ```bash
 cargo fmt --all -- --check
@@ -17,13 +19,20 @@ cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --all-targets --all-features --locked
 cargo build --all-targets --all-features --locked
 cargo doc --no-deps --all-features --locked
+
+# Python modules: read the list from the justfile rather than retyping it.
 python3 -c 'import numpy; print(numpy.__version__)'
-python3 -m unittest scripts.test_export_grok1_embedding_npy -v
-python3 -m unittest scripts.test_export_grok1_int8_npy -v
-python3 -m unittest scripts.test_export_grok1_int8_select -v
-python3 -m unittest scripts.test_route_preservation_surface -v
-python3 -m unittest scripts.test_route_preservation_io -v
+sed -n '/^    mods=(/,/^    )/p' justfile | grep -oE 'scripts\.[a-z0-9_]+' \
+  | while read -r m; do python3 -m unittest "$m" -v || exit 1; done
+
 for f in scripts/*.sh; do bash -n "$f"; done
+
+# Linters -- blocking in CI via .github/workflows/lint.yml (GH #98 / #101).
+# Omitting these is the most common way a "green" local run disagrees with CI.
+ruff check scripts/                      # pip install 'ruff==0.15.14'
+shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push \
+           .codex/hooks/*.sh .beads/hooks/pre-commit .beads/hooks/pre-push
+actionlint
 ```
 
 Fast smoke while iterating on CLI-only edits (not sufficient alone before merge):
@@ -35,12 +44,7 @@ just test
 cargo fmt --all -- --check
 cargo clippy --all-targets --features cli --locked -- -D warnings
 cargo test --features cli --locked
-python3 -c 'import numpy; print(numpy.__version__)'
-python3 -m unittest scripts.test_export_grok1_embedding_npy -v
-python3 -m unittest scripts.test_export_grok1_int8_npy -v
-python3 -m unittest scripts.test_export_grok1_int8_select -v
-python3 -m unittest scripts.test_route_preservation_surface -v
-python3 -m unittest scripts.test_route_preservation_io -v
+# `just test` also runs all thirteen Python modules -- see the loop above.
 ```
 
 Path-scoped extras (only when those paths change; not part of `just ci`):

--- a/.claude/commands/smoke.md
+++ b/.claude/commands/smoke.md
@@ -9,12 +9,20 @@ just check
 just test
 ```
 
-Equivalent fallback if `just` is unavailable:
+Fallback if `just` is unavailable. Note `just test` also runs **thirteen**
+Python unittest modules, which the Rust commands alone do not -- so this is not
+equivalent unless you include the Python loop:
 
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets --features cli --locked -- -D warnings
 cargo test --features cli --locked
+
+# The Python half of `just test`. Read the list from the justfile rather than
+# retyping it -- a hand-copied list is what drifted to five modules before.
+python3 -c 'import numpy; print(numpy.__version__)'
+sed -n '/^    mods=(/,/^    )/p' justfile | grep -oE 'scripts\.[a-z0-9_]+' \
+  | while read -r m; do python3 -m unittest "$m" -v || exit 1; done
 ```
 
 Optional broader check (slower) — or use `just ci`:

--- a/.claude/commands/v2-bridge.md
+++ b/.claude/commands/v2-bridge.md
@@ -37,19 +37,20 @@ cargo test --features cli --locked v2_structural_manifest_end_to_end
 cargo test --features cli --locked run3_conversion_manifest_names_fully_classified
 ```
 
-⚠ Two known gaps, both tracked:
+⚠ Both gaps this section used to list are now **closed**:
 
-- The **safetensors input path has zero test coverage** (**GH #103**). The raise
-  itself is shared, not duplicated: `ManifestV2UnmatchedTensor` is returned from
-  exactly one place, `classify_and_decide` (`src/core/stream.rs:601`), which both
-  builders call. What *is* duplicated per format is the pre-skip invocation that
-  makes fail-closed apply to unsupported dtypes before the intentional `continue`
-  (`stream.rs:628-631` safetensors vs `:666-669` npy) — and only the npy copy of
-  that block is exercised, by `v2_manifest_fails_closed_on_unmatched_other_dtype`
-  (`:1351`) via the `write_npy_i8` fixture.
-- `GROK_OZEMPIC_DISSECT_RUN` has two incompatible meanings, and the documented
-  value makes the run3 oracle **silently skip while passing** (**GH #102**). If
-  that test reports `skip:`, believe the skip, not the green.
+- **#103** added the missing safetensors coverage, including the Other-dtype
+  pre-skip path that had none. Verified by mutation: deleting the safetensors
+  guard fails exactly one test.
+- **#102** made `GROK_OZEMPIC_DISSECT_RUN` accept the run root as well as the
+  resolved run3 dir, and made it **panic** when set but unresolvable instead of
+  skipping. A `skip:` from that test now means "not configured", never
+  "configured and ignored".
+- **#115** additionally made safetensors packs byte-reproducible; tensor order
+  no longer depends on HashMap iteration order.
+
+If that test still reports `skip:`, the run simply is not mounted -- which is
+the expected case in CI.
 
 ## Related
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Fast pre-commit gate — see REVIEW.md
-# Enable: git config core.hooksPath .githooks
+# NOT enabled by pointing core.hooksPath here. beads owns that setting
+# (it points at .beads/hooks), and `git config core.hooksPath .githooks`
+# would silently disable the beads sync. Since GH #97 the tracked
+# .beads/hooks/pre-commit chains to this script instead. See REVIEW.md.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # Pre-push quality gate — see REVIEW.md
-# Enable: git config core.hooksPath .githooks
+# NOT enabled by pointing core.hooksPath here. beads owns that setting
+# (it points at .beads/hooks), and `git config core.hooksPath .githooks`
+# would silently disable the beads sync. Since GH #97 the tracked
+# .beads/hooks/pre-push chains to this script instead. See REVIEW.md.
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel)"

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - "releases/*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
       # Covers scripts/*.sh, the tracked git hooks, and the Codex hook scripts.
       # The hooks have no .sh suffix, so they are listed explicitly.
       - name: ShellCheck
-        run: shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh
+        run: shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh .beads/hooks/pre-commit .beads/hooks/pre-push
 
   python:
     name: ruff

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,8 @@ cargo doc --no-deps --all-features --locked
 # + the thirteen python3 -m unittest lines above
 for f in scripts/*.sh; do bash -n "$f"; done
 # GH #98 also made these blocking in CI (.github/workflows/lint.yml):
-shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh
+shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh \
+           .beads/hooks/pre-commit .beads/hooks/pre-push
 actionlint
 
 # CLI smoke

--- a/justfile
+++ b/justfile
@@ -125,8 +125,9 @@ _optional-linters:
     # Optional *locally only*. Since GH #98/#101 all three run unconditionally in
     # .github/workflows/lint.yml, so a `skip:` here means "not checked on this
     # machine", not "not checked at all" — CI will still fail the PR.
-    # Local coverage is narrower than CI's: CI also lints .githooks/* and
-    # .codex/hooks/*.sh. Install both to reproduce CI exactly.
+    # The shellcheck file list below is identical to lint.yml's, so an installed
+    # local shellcheck reproduces CI's shell coverage exactly. Install all three
+    # binaries (actionlint, ruff, shellcheck) for the full local gate.
     set -euo pipefail
     if command -v actionlint >/dev/null 2>&1; then
       echo "+ actionlint"
@@ -142,7 +143,8 @@ _optional-linters:
     fi
     if command -v shellcheck >/dev/null 2>&1; then
       shopt -s nullglob
-      scripts=(scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh)
+      scripts=(scripts/*.sh .githooks/pre-commit .githooks/pre-push \
+               .codex/hooks/*.sh .beads/hooks/pre-commit .beads/hooks/pre-push)
       if [[ ${#scripts[@]} -gt 0 ]]; then
         echo "+ shellcheck ${scripts[*]}"
         shellcheck "${scripts[@]}"

--- a/scripts/block_pilot_goz1.sh
+++ b/scripts/block_pilot_goz1.sh
@@ -39,7 +39,17 @@ CKPT="${CKPT:-$HOME/.models/xai-grok-1/ckpt-0}"
 # Token embedding shard: block 0's real attention input (see EMBED_ARGS below).
 EMBED_SHARD="${EMBED_SHARD:-tensor00000_000}"
 DISSECT_RUN="${GROK_OZEMPIC_DISSECT_RUN:-$HOME/rmems/grok-result/xai-dissect/LATEST_CORRECT_GROK1_RUN}"
-RUN3="$DISSECT_RUN/manifests/xai-grok-1-ckpt-0"
+# GROK_OZEMPIC_DISSECT_RUN accepts either the run root or the already-resolved
+# run3 dir (GH #102). Probe direct-then-nested, matching justfile:261-278 and
+# resolve_run3_conversion_manifest() in src/core/stream.rs. Before this, the
+# error message at the bottom of this block promised both shapes while the code
+# only ever appended the subdir -- so passing the resolved dir double-appended
+# and failed with a path that did not exist.
+if [[ -f "$DISSECT_RUN/conversion-manifest.json" ]]; then
+  RUN3="$DISSECT_RUN"
+else
+  RUN3="$DISSECT_RUN/manifests/xai-grok-1-ckpt-0"
+fi
 ART="${ART:-$HOME/.models/xai-grok-1/artifacts}/block-pilot"
 BIN="$REPO/target/release/grok-ozempic"
 BLOCK_LABEL="$(printf 'block_%03d' "$BLOCK")"


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic)

A four-lens adversarial review of this session's merged PRs confirmed **12 of 13** findings. Two were on open PR #119 and fixed there. These seven are on work already on `main` — most of them mine.

## 1. A real bug, not a doc issue

`scripts/block_pilot_goz1.sh`. #118 updated the error message to promise that `GROK_OZEMPIC_DISSECT_RUN` accepts either shape, but left the resolution hardcoded:

```bash
RUN3="$DISSECT_RUN/manifests/xai-grok-1-ckpt-0"
```

Passing the **resolved** dir — the shape my own message says is accepted — double-appended the subdir and failed on a path that does not exist. Now probes direct-then-nested, matching `justfile:261-278` and `resolve_run3_conversion_manifest()` in `stream.rs`.

## 2. A copy-pasteable footgun in the files the fix was about

`.githooks/pre-commit` and `pre-push` still said:

```
# Enable: git config core.hooksPath .githooks
```

Since #97 that is **exactly** the command `REVIEW.md` documents as silently disabling the beads sync. Replaced with what actually enables them.

## 3. The gate lived in the two files nothing linted

#97 put the quality gate into `.beads/hooks/{pre-commit,pre-push}` — hand-edited shell. #98 had just established a shellcheck set that did not include them. Now in both `lint.yml` and the justfile; **shellcheck coverage goes 8 → 10 files**, all clean.

## 4. A comment contradicting the line three below it

`justfile _optional-linters` claimed *"Local coverage is narrower than CI's"* directly above the array that made it identical — both written in the same commit. My earlier `sed` to fix the adjacent "Install both" had silently no-op'd because the pattern was mid-line.

## 5–6. Fallbacks claiming parity they did not have

`/pr-ready` called its fallback a `just ci` match while listing **5 of 13** Python modules and naming **none** of the three linters now blocking in CI. `/smoke` called its Rust-only block an "equivalent fallback" for `just check` + `just test`, when `just test` also runs 13 Python modules.

Omitting the linters is the most common way a green local run disagrees with CI.

**The fix is to stop duplicating the list.** Both now extract module names from the justfile:

```bash
sed -n '/^    mods=(/,/^    )/p' justfile | grep -oE 'scripts\.[a-z0-9_]+' \
  | while read -r m; do python3 -m unittest "$m" -v || exit 1; done
```

One source of truth instead of a fourth copy to drift. Verified the extraction yields exactly 13.

## 7. Stale command doc

`/v2-bridge` advertised #103 and #102 as open gaps; both are closed. Replaced with their outcomes, plus #115.

**Also:** `cargo-audit.yml` was the only push-triggered workflow still missing `"releases/*"`, left out of #111's normalization.

## Verification

`shellcheck` clean across all **ten** shell files (up from eight), `actionlint` clean, `ruff` clean, `bash -n` and the Codex hook contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ezmu4PicsLGXPJoeyaEtpa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven review findings against this session's merged work, including a real bug, misleading docs, and lint coverage gaps.

**Bug Fixes**
- `scripts/block_pilot_goz1.sh` now probes both the run root and nested run3 path for `GROK_OZEMPIC_DISSECT_RUN`, fixing a double-append failure.
- `.githooks/pre-commit` and `pre-push` no longer advise `git config core.hooksPath .githooks`, which would silently disable the beads sync.
- `.github/workflows/cargo-audit.yml` now triggers on `releases/*` like the other push workflows.

**Refactors**
- The Python module list for `pr-ready` and `smoke` fallbacks is now extracted from the justfile instead of hardcoded, and `pr-ready`'s fast-smoke block now runs that extraction instead of only pointing at the other block.
- Shellcheck now covers `.beads/hooks/pre-commit` and `pre-push` in lint.yml, the justfile, and the CLAUDE.md fallback, so all three check the same ten files.
- The `v2-bridge` command now documents the closed gaps (#102, #103, #115); merging `main` brings in the safetensors sort that backs the reproducibility claim.

<sup>Written for commit f97a0ce1395b389cc4eb2ecc300150e66f43a211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Align run resolution and quality checks with their documented behavior

### What Changed
- Accepts either the run root or resolved run directory for pilot execution, avoiding invalid doubled paths.
- Local fallback checks now cover all Python tests and linters used by CI instead of a stale subset.
- Adds the beads hook scripts to ShellCheck coverage and clarifies the correct hook setup so commits retain beads synchronization.
- Keeps release branches covered by the cargo audit workflow.
- Updates v2 bridge guidance to reflect closed coverage, failure-handling, and reproducibility gaps.

### Impact
`✅ Fewer pilot runs failing from invalid run paths`
`✅ Fewer discrepancies between local checks and CI`
`✅ Preserved beads synchronization during commits and pushes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
