### PR TITLE
refactor: collapse the duplicated per-format paths in stream.rs (#104)

### DIFF
--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -15,7 +15,7 @@ use std::{
     collections::BTreeMap,
     fs::{self, File},
     io::{BufWriter, Write},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use half::f16;
@@ -472,38 +472,7 @@ fn quantize_safetensors_entry(
         )));
     }
 
-    if entry.emits_fp16_bytes() {
-        let fp16_bytes = encode_fp16_bytes(dtype, view.data())?;
-        Ok(QuantizedPayload {
-            bytes: fp16_bytes,
-            ternary_sparsity: None,
-            stats: TensorRowStats::fp16(),
-        })
-    } else {
-        let qt = match dtype {
-            SourceDtype::F32 => {
-                let f32_slice = bytemuck_cast_f32(view.data());
-                quantize_f32(f32_slice, entry.gif_threshold)
-            }
-            SourceDtype::F16 => {
-                let f16_slice: &[f16] = bytemuck_cast_f16(view.data());
-                quantize_f16(f16_slice, entry.gif_threshold)
-            }
-            SourceDtype::BF16 => {
-                let f32_vals = bf16_bytes_to_f32(view.data());
-                quantize_f32(&f32_vals, entry.gif_threshold)
-            }
-            SourceDtype::Other => unreachable!(),
-        };
-        Ok(QuantizedPayload {
-            bytes: qt.packed,
-            ternary_sparsity: Some(qt.sparsity),
-            // The applied multiplier comes back from the quantizer rather than
-            // being re-read from `entry`, so the row records what the gate
-            // actually used.
-            stats: TensorRowStats::ternary(qt.scale, qt.gif_threshold, qt.threshold),
-        })
-    }
+    quantize_raw(dtype, view.data(), entry)
 }
 
 fn quantize_npy_entry(
@@ -518,40 +487,55 @@ fn quantize_npy_entry(
             entry.source_path.display()
         )));
     }
-    let raw = npy.data();
+    quantize_raw(dtype, npy.data(), entry)
+}
+
+/// Turn one tensor's raw source bytes into its GOZ1 payload.
+///
+/// Format-independent by construction: everything past "give me the bytes and
+/// their dtype" was byte-identical between the safetensors and npy paths, and
+/// keeping two copies is how the GH #40 fail-closed guard ended up tested on
+/// only one of them (GH #103). The callers keep exactly what genuinely differs
+/// — how the source is opened, how its dtype is read, and their distinct
+/// unsupported-dtype messages, which are user-visible and not interchangeable.
+///
+/// `dtype` must not be [`SourceDtype::Other`]; callers reject that first so
+/// they can name the offending file in the format's own vocabulary.
+fn quantize_raw(dtype: SourceDtype, raw: &[u8], entry: &ManifestEntry) -> Result<QuantizedPayload> {
+    debug_assert_ne!(
+        dtype,
+        SourceDtype::Other,
+        "callers must reject Other before calling quantize_raw"
+    );
 
     if entry.emits_fp16_bytes() {
-        let fp16_bytes = encode_fp16_bytes(dtype, raw)?;
-        Ok(QuantizedPayload {
-            bytes: fp16_bytes,
+        return Ok(QuantizedPayload {
+            bytes: encode_fp16_bytes(dtype, raw)?,
             ternary_sparsity: None,
             stats: TensorRowStats::fp16(),
-        })
-    } else {
-        let qt = match dtype {
-            SourceDtype::F32 => {
-                let f32_slice = bytemuck_cast_f32(raw);
-                quantize_f32(f32_slice, entry.gif_threshold)
-            }
-            SourceDtype::F16 => {
-                let f16_slice: &[f16] = bytemuck_cast_f16(raw);
-                quantize_f16(f16_slice, entry.gif_threshold)
-            }
-            SourceDtype::BF16 => {
-                let f32_vals = bf16_bytes_to_f32(raw);
-                quantize_f32(&f32_vals, entry.gif_threshold)
-            }
-            SourceDtype::Other => unreachable!(),
-        };
-        Ok(QuantizedPayload {
-            bytes: qt.packed,
-            ternary_sparsity: Some(qt.sparsity),
-            // The applied multiplier comes back from the quantizer rather than
-            // being re-read from `entry`, so the row records what the gate
-            // actually used.
-            stats: TensorRowStats::ternary(qt.scale, qt.gif_threshold, qt.threshold),
-        })
+        });
     }
+
+    let qt = match dtype {
+        SourceDtype::F32 => quantize_f32(bytemuck_cast_f32(raw), entry.gif_threshold),
+        SourceDtype::F16 => {
+            let f16_slice: &[f16] = bytemuck_cast_f16(raw);
+            quantize_f16(f16_slice, entry.gif_threshold)
+        }
+        SourceDtype::BF16 => {
+            let f32_vals = bf16_bytes_to_f32(raw);
+            quantize_f32(&f32_vals, entry.gif_threshold)
+        }
+        SourceDtype::Other => unreachable!("rejected by the caller"),
+    };
+    Ok(QuantizedPayload {
+        bytes: qt.packed,
+        ternary_sparsity: Some(qt.sparsity),
+        // The applied multiplier comes back from the quantizer rather than
+        // being re-read from `entry`, so the row records what the gate
+        // actually used.
+        stats: TensorRowStats::ternary(qt.scale, qt.gif_threshold, qt.threshold),
+    })
 }
 
 /// Encode raw source bytes as FP16 for tensors that emit through the
@@ -639,26 +623,8 @@ fn build_manifest_safetensors(
         named.sort_by(|(a, _), (b, _)| a.cmp(b));
         for (name, view) in named {
             let dtype = parse_safetensors_dtype(view.dtype());
-            if dtype == SourceDtype::Other {
-                // i8/Other covered for alignment via structural manifest (see grok1_inventory NOTE);
-                // skipped in float stream; int8 via artifact wraps. Kilo agent xAI/Grok Build 0.1 (Codex P1 PR#26).
-                // Under V2 still classify the name so fail-closed applies to *all* present tensors
-                // (including unsupported dtypes) before the intentional skip — GH #40 / RM-191.
-                if dissect_manifest.is_some_and(|m| m.is_structural_v2()) {
-                    let _ = classify_and_decide(&name, dissect_manifest, config)?;
-                }
-                continue;
-            }
-            let (_class, precision, gif_threshold) =
-                classify_and_decide(&name, dissect_manifest, config)?;
             let shape: Vec<u64> = view.shape().iter().map(|&d| d as u64).collect();
-            v.push(ManifestEntry {
-                source_path: shard.clone(),
-                tensor_name: name,
-                shape,
-                precision,
-                gif_threshold,
-            });
+            push_classified_entry(&mut v, shard, name, dtype, shape, dissect_manifest, config)?;
         }
     }
     Ok(v)
@@ -677,28 +643,64 @@ fn build_manifest_npy(
             GrokOzempicError::InvalidConfig(format!("bad npy filename: {}", path.display()))
         })?;
         let tensor_name = npy_stem_to_tensor_name(stem);
-        if dtype == SourceDtype::Other {
-            // i8/Other from xai-dissect inventory covered in structural manifest for alignment only
-            // (grok1_inventory.rs NOTE + structural _i8_streaming_note). Skipped here; enter via artifact wraps.
-            // Kilo agent xAI/Grok Build 0.1 (Codex P1 on PR #26).
-            // Under V2 still classify the name so fail-closed applies before the skip (GH #40 / RM-191).
-            if dissect_manifest.is_some_and(|m| m.is_structural_v2()) {
-                let _ = classify_and_decide(&tensor_name, dissect_manifest, config)?;
-            }
-            continue;
-        }
-        let (_class, precision, gif_threshold) =
-            classify_and_decide(&tensor_name, dissect_manifest, config)?;
         let shape: Vec<u64> = npy.shape().iter().map(|&d| d as u64).collect();
-        v.push(ManifestEntry {
-            source_path: path.clone(),
+        push_classified_entry(
+            &mut v,
+            path,
             tensor_name,
+            dtype,
             shape,
-            precision,
-            gif_threshold,
-        });
+            dissect_manifest,
+            config,
+        )?;
     }
     Ok(v)
+}
+
+/// Classify one source tensor and append its [`ManifestEntry`], or skip it.
+///
+/// This is the single place the GH #40 / RM-191 fail-closed rule is applied to
+/// a discovered tensor. It used to be copy-pasted once per input format, which
+/// is exactly how the safetensors copy ended up exercised by nothing until
+/// GH #103 — the raise in `classify_and_decide` was shared, but the call that
+/// reaches it for unsupported dtypes was not.
+///
+/// Unsupported (`SourceDtype::Other`) tensors are skipped by the float stream:
+/// i8/Other from the xai-dissect inventory are covered by the structural
+/// manifest for alignment only (see `grok1_inventory.rs` NOTE and
+/// `structural-manifest.json` `_i8_streaming_note`) and enter through the
+/// artifact wrapping path, not here. Under a V2 manifest their names are still
+/// classified **before** that skip, so a legacy or misspelled stem cannot
+/// silently disappear past fail-closed.
+///
+/// Note this rejects on *misclassification*, never on *absence*: a tensor that
+/// is simply missing from the input produces no name to match. Completeness is
+/// enforced separately — see `.claude/rules/goz1-pipeline.md`.
+fn push_classified_entry(
+    out: &mut Vec<ManifestEntry>,
+    source_path: &Path,
+    tensor_name: String,
+    dtype: SourceDtype,
+    shape: Vec<u64>,
+    dissect_manifest: Option<&DissectManifest>,
+    config: &QuantizationConfig,
+) -> Result<()> {
+    if dtype == SourceDtype::Other {
+        if dissect_manifest.is_some_and(|m| m.is_structural_v2()) {
+            let _ = classify_and_decide(&tensor_name, dissect_manifest, config)?;
+        }
+        return Ok(());
+    }
+    let (_class, precision, gif_threshold) =
+        classify_and_decide(&tensor_name, dissect_manifest, config)?;
+    out.push(ManifestEntry {
+        source_path: source_path.to_path_buf(),
+        tensor_name,
+        shape,
+        precision,
+        gif_threshold,
+    });
+    Ok(())
 }
 
 fn collect_safetensor_shards(dir: &str) -> Result<Vec<PathBuf>> {


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #104

Closes #104.

## Why

Two pairs of near-identical functions, one per input format. The duplication is **why** the GH #40 fail-closed guard ended up exercised on only one of the two documented production input formats until #103 added the missing tests.

- `quantize_safetensors_entry` / `quantize_npy_entry` were ~90% identical — everything from `if entry.emits_fp16_bytes()` down was byte-for-byte the same. Extracted `quantize_raw(dtype, raw, entry)`.
- Both manifest builders shared the whole classify tail (Other-dtype skip, V2 pre-skip guard, `classify_and_decide`, shape widening, push). Extracted `push_classified_entry()`, now the single place fail-closed is applied to a discovered tensor.

The callers keep exactly what genuinely differs, including their two distinct messages (`"has unsupported dtype"` vs `"has unsupported descr"`) — those name the offending file in each format's own vocabulary and are user-visible, so they are **not** interchangeable.

## Mutation-verified — this is the actual deliverable

| | deleting the guard breaks |
|---|---|
| before (two copies) | **1** test |
| after (one copy) | **2** tests, one per format |

```console
$ # with the single guard removed:
test v2_manifest_fails_closed_on_unmatched_other_dtype ... FAILED
test v2_manifest_fails_closed_on_unmatched_other_dtype_safetensors ... FAILED
```

The two formats can no longer drift apart in coverage: any future change to fail-closed behaviour is caught on both paths or neither.

## One deliberate detail

**No `#[allow]` shipped.** I added `#[allow(clippy::too_many_arguments)]` for the 7-argument helper, then checked whether clippy actually needed it. It does not, so it is not in the diff — stray allows were flagged as debt earlier in this epic.

The helper's doc comment also repeats the distinction that keeps getting lost: it rejects on **misclassification**, never on **absence**. A tensor simply missing from the input produces no name to match, so completeness stays a separate gate.

## Verification

157 Rust tests pass, `clippy --all-targets --all-features --locked -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MQY2Roz94s2zwtAWAodEQ


___

## **CodeAnt-AI Description**
Apply tensor validation consistently across supported input formats

### What Changed
- Unsupported tensors in both Safetensors and NPY inputs are checked against structural manifests before being skipped
- Misnamed or incorrectly classified tensors now fail closed consistently regardless of input format
- Float and FP16 tensor conversion continues to produce the same payloads and statistics for supported tensors

### Impact
`✅ Consistent validation for Safetensors and NPY inputs`
`✅ Fewer silently skipped misclassified tensors`
`✅ Unchanged quantization results for supported tensors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #104. Previously the fail-closed guard existed in two near-identical copies and was tested only for safetensors. This collapses those duplicated paths so the same behavior is exercised for both safetensors and npy inputs.

**Behavior**
- Extracts shared quantization and manifest-classification logic into two helpers.
- Keeps format-specific opening, dtype parsing, and user-visible unsupported-dtype messages in the callers.
- Removing the guard now fails two tests (one per format) instead of only one.

**Verification**
- 157 Rust tests pass; `clippy --all-targets --all-features --locked -D warnings` is clean.

<sup>Written for commit e411d52127d722f43196c46352b892d4b0b8e7ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

