### PR TITLE
test: cover the documented under-packing guard, which had none (#107)

### DIFF
--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Unit tests (GOZ1 pack readback)
         run: python3 -m unittest scripts.test_route_preservation_io -v
 
+      # The documented under-packing guard (GH #107). Fail-closed cannot see an
+      # absent tensor, so this is the check that stands between a short pack and
+      # a published "certified" result.
+      - name: Unit tests (pack completeness gate)
+        run: python3 -m unittest scripts.test_route_preservation_completeness -v
+
       - name: Unit tests (multi-block remedy decisions)
         run: python3 -m unittest scripts.test_grok1_multiblock_experiment -v
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ cargo fmt --all -- --check
 cargo clippy --all-targets --features cli --locked -- -D warnings
 
 # just test (numpy required for several scripts/test_* modules)
-# These thirteen modules are `_python-tests` in the justfile and the thirteen
+# These fourteen modules are `_python-tests` in the justfile and the fourteen
 # unittest steps in .github/workflows/python-scripts.yml. Keep all three lists
 # in sync: a module omitted here is one an agent will silently skip.
 # (GH #98 added the final two and folded away `_python-tests-extra`; before it
@@ -193,6 +193,7 @@ python3 -m unittest scripts.test_export_grok1_int8_npy -v
 python3 -m unittest scripts.test_export_grok1_int8_select -v
 python3 -m unittest scripts.test_route_preservation_surface -v
 python3 -m unittest scripts.test_route_preservation_io -v
+python3 -m unittest scripts.test_route_preservation_completeness -v
 python3 -m unittest scripts.test_grok1_multiblock_experiment -v
 python3 -m unittest scripts.test_grok1_multiblock_progress -v
 python3 -m unittest scripts.test_grok1_multiblock_v4_decision -v
@@ -208,7 +209,7 @@ cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --all-targets --all-features --locked
 cargo build --all-targets --all-features --locked
 cargo doc --no-deps --all-features --locked
-# + the thirteen python3 -m unittest lines above
+# + the fourteen python3 -m unittest lines above
 for f in scripts/*.sh; do bash -n "$f"; done
 # GH #98 also made these blocking in CI (.github/workflows/lint.yml):
 shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -23,7 +23,7 @@ just review
 
 This is the default **pre-push** recipe. It runs, in order:
 
-1. **`just ci`** — GHA parity for Rust + the **thirteen** CI Python unittests +
+1. **`just ci`** — GHA parity for Rust + the **fourteen** CI Python unittests +
    `bash -n` on `scripts/*.sh` + `actionlint` / `shellcheck` (blocking in CI via
    `.github/workflows/lint.yml` since GH #98; still skipped locally when not installed)
 2. **`cargo audit`** — if `cargo-audit` is on `PATH` (matches
@@ -186,7 +186,7 @@ GHA `rust.yml` omits `--locked`; local `just` is **stricter** (intentional).
 ### Python
 
 `just test`, `just ci`, `just review` and `python-scripts.yml` all run the same
-**thirteen** modules. Until GH #98 the last two (79 tests) lived in a separate
+**fourteen** modules. Until GH #98 the last two (79 tests) lived in a separate
 `_python-tests-extra` recipe reachable only through `just review`, and were
 gated by nothing in CI; that recipe is gone and there is now one list.
 
@@ -200,6 +200,7 @@ python3 -m unittest scripts.test_export_grok1_int8_npy -v
 python3 -m unittest scripts.test_export_grok1_int8_select -v
 python3 -m unittest scripts.test_route_preservation_surface -v
 python3 -m unittest scripts.test_route_preservation_io -v
+python3 -m unittest scripts.test_route_preservation_completeness -v
 python3 -m unittest scripts.test_grok1_multiblock_experiment -v
 python3 -m unittest scripts.test_grok1_multiblock_progress -v
 python3 -m unittest scripts.test_grok1_multiblock_v4_decision -v

--- a/justfile
+++ b/justfile
@@ -34,6 +34,7 @@ _python-tests:
       scripts.test_export_grok1_int8_select
       scripts.test_route_preservation_surface
       scripts.test_route_preservation_io
+      scripts.test_route_preservation_completeness
       scripts.test_grok1_multiblock_experiment
       scripts.test_grok1_multiblock_progress
       scripts.test_grok1_multiblock_v4_decision

--- a/scripts/test_route_preservation_completeness.py
+++ b/scripts/test_route_preservation_completeness.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Unit tests for the pack completeness gate (GH #107).
+
+`.claude/rules/goz1-pipeline.md` is explicit that V2 fail-closed **cannot**
+detect under-packing:
+
+    ⚠ V2 fail-closed does not detect under-packing. It rejects an *input name
+    that matches no rule* -- a misclassification guard. A tensor that is simply
+    **absent** from the npy directory produces no name to match, so V2 is
+    silent about it and the pack comes out short.
+
+The compensating check is `_validate_ternary_inventory` /
+`_validate_preserve_inventory` here: they compare pack contents against the
+xai-dissect conversion manifest. Until GH #107 neither was called by any test,
+so the guard standing between a short pack and a published "certified" result
+was itself unguarded.
+
+These tests need no pack and no mounted xai-dissect run: the validators take
+plain dicts, so the contract is testable everywhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import route_preservation_metrics as rpm  # noqa: E402
+from route_preservation_measure import GATE_FAILURE_EXIT  # noqa: E402
+
+BLOCK = 0
+MODE = "attention_plus_expert"
+
+# Kind -> tier, mirroring EXPORT_MODES/PRESERVE_KINDS. Ternary kinds for
+# attention_plus_expert are the mode's kinds minus the preserve set.
+TERNARY_KINDS = (
+    "attn_proj_i8.model_width",
+    "attn_proj_i8.narrow",
+    "moe_expert.down",
+    "moe_expert.gate",
+    "moe_expert.up",
+)
+PRESERVE_KINDS_USED = ("block_norm", "router")
+
+
+def _name(kind: str, slot: int, block: int = BLOCK) -> str:
+    return f"block_{block:03d}.slot_{slot:02d}.{kind}"
+
+
+def _manifest_tensor(kind: str, slot: int, block: int = BLOCK) -> dict:
+    return {"structural_name": _name(kind, slot, block), "block": block, "kind": kind}
+
+
+def _index_entry(tensor_type: int) -> dict:
+    return {"tensor_type": tensor_type}
+
+
+def _args(block: int = BLOCK, mode: str = MODE) -> argparse.Namespace:
+    return argparse.Namespace(block=block, mode=mode)
+
+
+def _full_fixture() -> tuple[list[dict], dict[str, dict]]:
+    """A conversion manifest and a matching pack index (nothing missing)."""
+    manifest: list[dict] = []
+    index: dict[str, dict] = {}
+    for slot, kind in enumerate(TERNARY_KINDS):
+        manifest.append(_manifest_tensor(kind, slot))
+        index[_name(kind, slot)] = _index_entry(rpm.TENSOR_TERNARY)
+    for offset, kind in enumerate(PRESERVE_KINDS_USED):
+        slot = 7 + offset
+        manifest.append(_manifest_tensor(kind, slot))
+        index[_name(kind, slot)] = _index_entry(rpm.TENSOR_F16)
+    return manifest, index
+
+
+class TernaryInventoryTests(unittest.TestCase):
+    def test_matching_inventory_passes(self) -> None:
+        manifest, index = _full_fixture()
+        ternary, _ = rpm._split_tiers(index)
+        rpm._validate_ternary_inventory(_args(), ternary, manifest)
+
+    def test_missing_ternary_tensor_is_rejected(self) -> None:
+        """The under-packing case fail-closed cannot see."""
+        manifest, index = _full_fixture()
+        dropped = _name(TERNARY_KINDS[0], 0)
+        del index[dropped]
+
+        ternary, _ = rpm._split_tiers(index)
+        with self.assertRaises(rpm.MetricsError) as ctx:
+            rpm._validate_ternary_inventory(_args(), ternary, manifest)
+        msg = str(ctx.exception)
+        self.assertIn("missing=", msg)
+        self.assertIn(dropped, msg)
+
+    def test_extra_ternary_tensor_is_rejected(self) -> None:
+        manifest, index = _full_fixture()
+        surprise = _name("attn_proj_i8.narrow", 42)
+        index[surprise] = _index_entry(rpm.TENSOR_TERNARY)
+
+        ternary, _ = rpm._split_tiers(index)
+        with self.assertRaises(rpm.MetricsError) as ctx:
+            rpm._validate_ternary_inventory(_args(), ternary, manifest)
+        self.assertIn("extra=", str(ctx.exception))
+        self.assertIn(surprise, str(ctx.exception))
+
+    def test_tensor_demoted_to_preserve_counts_as_missing(self) -> None:
+        """A ternary candidate that got preserved is under-packing too.
+
+        The tensor is still in the pack, so a count of rows would not notice.
+        Only the per-tier inventory catches it.
+        """
+        manifest, index = _full_fixture()
+        demoted = _name(TERNARY_KINDS[1], 1)
+        index[demoted] = _index_entry(rpm.TENSOR_F16)
+
+        ternary, _ = rpm._split_tiers(index)
+        with self.assertRaises(rpm.MetricsError) as ctx:
+            rpm._validate_ternary_inventory(_args(), ternary, manifest)
+        self.assertIn(demoted, str(ctx.exception))
+
+
+class PreserveInventoryTests(unittest.TestCase):
+    def test_matching_inventory_passes(self) -> None:
+        manifest, index = _full_fixture()
+        rpm._validate_preserve_inventory(_args(), index, manifest)
+
+    def test_missing_preserve_tensor_is_rejected(self) -> None:
+        """A dropped router or norm is the most dangerous omission."""
+        manifest, index = _full_fixture()
+        dropped = _name("router", 8)
+        del index[dropped]
+
+        with self.assertRaises(rpm.MetricsError) as ctx:
+            rpm._validate_preserve_inventory(_args(), index, manifest)
+        self.assertIn("missing=", str(ctx.exception))
+        self.assertIn(dropped, str(ctx.exception))
+
+    def test_preserve_tensor_ternarised_counts_as_missing(self) -> None:
+        """A router that fell into the ternary tier is the #40 disaster.
+
+        Fail-closed catches this when the *name* matches no rule; it cannot
+        catch it when the name matched but the tier came out wrong.
+        """
+        manifest, index = _full_fixture()
+        router = _name("router", 8)
+        index[router] = _index_entry(rpm.TENSOR_TERNARY)
+
+        with self.assertRaises(rpm.MetricsError) as ctx:
+            rpm._validate_preserve_inventory(_args(), index, manifest)
+        self.assertIn(router, str(ctx.exception))
+
+
+class ValidatePilotArgsDispatchTests(unittest.TestCase):
+    """Which check runs depends on whether a conversion manifest was supplied."""
+
+    def test_with_manifest_uses_inventory_and_catches_absence(self) -> None:
+        manifest, index = _full_fixture()
+        del index[_name(TERNARY_KINDS[0], 0)]
+        with self.assertRaises(rpm.MetricsError):
+            rpm._validate_pilot_args(_args(), index, manifest)
+
+    def test_without_manifest_a_short_pack_is_NOT_caught(self) -> None:
+        """The gap the rules doc warns about, pinned.
+
+        Kinds-only fallback compares the *set of kinds present*. Drop one of two
+        tensors sharing a kind and the set is unchanged, so the check passes on
+        a pack that is genuinely short. This is why a run without
+        `--conversion-manifest` is diagnostic-only and must not be read as
+        certification.
+        """
+        manifest, index = _full_fixture()
+        # Two tensors of the same kind; removing one leaves the kind present.
+        second = _name(TERNARY_KINDS[0], 90)
+        index[second] = _index_entry(rpm.TENSOR_TERNARY)
+        manifest.append(_manifest_tensor(TERNARY_KINDS[0], 90))
+        del index[second]
+
+        # Kinds-only: passes, because every expected kind still appears.
+        rpm._validate_pilot_args(_args(), index, None)
+        # Inventory-aware: rejects, because a named tensor is absent.
+        with self.assertRaises(rpm.MetricsError):
+            rpm._validate_pilot_args(_args(), index, manifest)
+
+
+class CertificationExitTests(unittest.TestCase):
+    """A diagnostic run must not look like a passing one."""
+
+    @staticmethod
+    def _all_passing_summary() -> list[dict]:
+        return [
+            {"name": "router_top1_agreement", "observed": 1.0, "threshold": ">= 99.0%", "status": "pass"},
+            {"name": "block_output_cosine", "observed": 1.0, "threshold": ">= 0.995", "status": "pass"},
+        ]
+
+    def test_certified_run_with_all_gates_passing_exits_zero(self) -> None:
+        with redirect_stdout(io.StringIO()):
+            code = rpm.report_gates(self._all_passing_summary(), certified=True)
+        self.assertEqual(code, 0)
+
+    def test_uncertified_run_exits_nonzero_even_when_gates_pass(self) -> None:
+        """Without a conversion manifest, passing gates are not a pass."""
+        with redirect_stdout(io.StringIO()):
+            code = rpm.report_gates(self._all_passing_summary(), certified=False)
+        self.assertNotEqual(
+            code,
+            0,
+            "an uncertified run must not exit 0 -- otherwise a diagnostic run "
+            "is indistinguishable from a certified one",
+        )
+        self.assertEqual(code, GATE_FAILURE_EXIT)
+
+    def test_uncertified_run_says_so_in_its_output(self) -> None:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rpm.report_gates(self._all_passing_summary(), certified=False)
+        text = buf.getvalue().lower()
+        self.assertTrue(
+            "diagnostic" in text or "not certified" in text or "uncertified" in text,
+            f"uncertified output should say so; got: {buf.getvalue()!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #107

Closes #107.

## Why

`.claude/rules/goz1-pipeline.md` is explicit that V2 fail-closed **cannot** detect under-packing — it rejects an input name matching no rule, and a tensor that is simply *absent* produces no name to match. The compensating check it names is `_validate_ternary_inventory` / `_validate_preserve_inventory`.

**Neither was called by any test.** The guard standing between a short pack and a published "certified" result was itself unguarded.

## Twelve tests, four areas

- **Ternary inventory** — matching passes; a missing tensor is rejected *by name*; an extra tensor is rejected; and a ternary candidate **demoted to preserve** counts as missing. That last one matters: the tensor is still in the pack, so a row count would not notice — only the per-tier inventory catches it.
- **Preserve inventory** — a dropped router or norm is rejected, and a preserve tensor that fell into the **ternary** tier is rejected. That is the #40 disaster from the other side: fail-closed catches it when the *name* matches no rule, never when the name matched but the tier came out wrong.
- **Dispatch**, including the gap the rules doc only *described*, now pinned:

  > with two tensors of one kind, removing one leaves the kind set unchanged, so the kinds-only fallback **passes on a genuinely short pack** while the inventory check rejects it

  That is precisely why a run without `--conversion-manifest` is diagnostic-only.
- **Certification exit** — an uncertified run must exit non-zero even when every gate passes, and must say so in its output. Otherwise a diagnostic run is indistinguishable from a certified one.

## Mutation-verified

```
neutering _validate_ternary_inventory   -> 5 tests fail
making report_gates ignore `certified`  -> 2 tests fail
```

## Testable everywhere

No pack and no mounted xai-dissect run required — the validators take plain dicts. That matters: this contract was previously only exercisable where the multi-GiB data happened to exist, which is a large part of why it went untested.

Wired into `justfile _python-tests` and `python-scripts.yml` **in the same commit**, so this does not repeat the #98 problem of a test module gated by nothing. All four surfaces enumerate the same list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MQY2Roz94s2zwtAWAodEQ


___

## **CodeAnt-AI Description**
Add coverage for pack completeness and certification safeguards

### What Changed
- Verifies that missing, extra, or incorrectly tiered tensors are rejected during pack validation
- Confirms conversion-manifest validation catches absent tensors that the kinds-only check can miss
- Confirms uncertified diagnostic runs return a failure status and clearly identify themselves, while certified runs with passing gates still succeed
- Runs the new completeness tests in CI and standard local test commands

### Impact
`✅ Fewer incomplete packs marked as certified`
`✅ Clearer distinction between diagnostic and certified runs`
`✅ Pack completeness checks run automatically in CI`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
