### PR TITLE
chore: one canonical JSON form, and regenerate the 20 divergent artifacts (#108)

### DIFF
--- a/.codex/hooks/test-coauthor-hooks.sh
+++ b/.codex/hooks/test-coauthor-hooks.sh
@@ -9,6 +9,24 @@ for required in git jq; do
 done
 
 repo_root=$(git rev-parse --show-toplevel)
+
+# Resolve repo_root above from the ambient environment, then drop every git
+# environment variable before touching the throwaway repo created below.
+#
+# This is load-bearing, not hygiene. A pre-push hook exports GIT_DIR (and
+# friends), and GIT_DIR takes precedence over `git -C <path>` when git locates a
+# repository -- so `git init "$repo"`, `git -C "$repo" commit` and everything
+# after it operate on the REAL repository instead of the temp one.
+#
+# That is not hypothetical. Running `just review` from the pre-push hook
+# committed this script's own fixtures -- tracked.txt, staged.txt, partial.txt,
+# compound.txt -- onto the project's main as "Tester <tester@example.com>",
+# carrying this file's commit messages (initial, staged, partial, compound), and
+# left core.bare=true behind from the redirected `git init`, which breaks every
+# subsequent worktree command in the real checkout.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_NAMESPACE
+
 pre_hook="$repo_root/.codex/hooks/coauthor-record-head.sh"
 post_hook="$repo_root/.codex/hooks/coauthor-commit.sh"
 muse_pre_hook="$repo_root/.muse/hooks/coauthor-record-head.sh"

--- a/.github/workflows/python-scripts.yml
+++ b/.github/workflows/python-scripts.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Unit tests (GOZ1 pack readback)
         run: python3 -m unittest scripts.test_route_preservation_io -v
 
+      # Committed artifacts must stay in canonical form (GH #108) -- the guard
+      # that stops three writers disagreeing on sort_keys again.
+      - name: Unit tests (canonical JSON + committed artifacts)
+        run: python3 -m unittest scripts.test_json_canonical -v
+
       - name: Unit tests (multi-block remedy decisions)
         run: python3 -m unittest scripts.test_grok1_multiblock_experiment -v
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ cargo fmt --all -- --check
 cargo clippy --all-targets --features cli --locked -- -D warnings
 
 # just test (numpy required for several scripts/test_* modules)
-# These thirteen modules are `_python-tests` in the justfile and the thirteen
+# These fourteen modules are `_python-tests` in the justfile and the fourteen
 # unittest steps in .github/workflows/python-scripts.yml. Keep all three lists
 # in sync: a module omitted here is one an agent will silently skip.
 # (GH #98 added the final two and folded away `_python-tests-extra`; before it
@@ -193,6 +193,7 @@ python3 -m unittest scripts.test_export_grok1_int8_npy -v
 python3 -m unittest scripts.test_export_grok1_int8_select -v
 python3 -m unittest scripts.test_route_preservation_surface -v
 python3 -m unittest scripts.test_route_preservation_io -v
+python3 -m unittest scripts.test_json_canonical -v
 python3 -m unittest scripts.test_grok1_multiblock_experiment -v
 python3 -m unittest scripts.test_grok1_multiblock_progress -v
 python3 -m unittest scripts.test_grok1_multiblock_v4_decision -v
@@ -208,7 +209,7 @@ cargo clippy --all-targets --all-features --locked -- -D warnings
 cargo test --all-targets --all-features --locked
 cargo build --all-targets --all-features --locked
 cargo doc --no-deps --all-features --locked
-# + the thirteen python3 -m unittest lines above
+# + the fourteen python3 -m unittest lines above
 for f in scripts/*.sh; do bash -n "$f"; done
 # GH #98 also made these blocking in CI (.github/workflows/lint.yml):
 shellcheck scripts/*.sh .githooks/pre-commit .githooks/pre-push .codex/hooks/*.sh

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -23,7 +23,7 @@ just review
 
 This is the default **pre-push** recipe. It runs, in order:
 
-1. **`just ci`** — GHA parity for Rust + the **thirteen** CI Python unittests +
+1. **`just ci`** — GHA parity for Rust + the **fourteen** CI Python unittests +
    `bash -n` on `scripts/*.sh` + `actionlint` / `shellcheck` (blocking in CI via
    `.github/workflows/lint.yml` since GH #98; still skipped locally when not installed)
 2. **`cargo audit`** — if `cargo-audit` is on `PATH` (matches
@@ -186,7 +186,7 @@ GHA `rust.yml` omits `--locked`; local `just` is **stricter** (intentional).
 ### Python
 
 `just test`, `just ci`, `just review` and `python-scripts.yml` all run the same
-**thirteen** modules. Until GH #98 the last two (79 tests) lived in a separate
+**fourteen** modules. Until GH #98 the last two (79 tests) lived in a separate
 `_python-tests-extra` recipe reachable only through `just review`, and were
 gated by nothing in CI; that recipe is gone and there is now one list.
 
@@ -200,6 +200,7 @@ python3 -m unittest scripts.test_export_grok1_int8_npy -v
 python3 -m unittest scripts.test_export_grok1_int8_select -v
 python3 -m unittest scripts.test_route_preservation_surface -v
 python3 -m unittest scripts.test_route_preservation_io -v
+python3 -m unittest scripts.test_json_canonical -v
 python3 -m unittest scripts.test_grok1_multiblock_experiment -v
 python3 -m unittest scripts.test_grok1_multiblock_progress -v
 python3 -m unittest scripts.test_grok1_multiblock_v4_decision -v

--- a/justfile
+++ b/justfile
@@ -34,6 +34,7 @@ _python-tests:
       scripts.test_export_grok1_int8_select
       scripts.test_route_preservation_surface
       scripts.test_route_preservation_io
+      scripts.test_json_canonical
       scripts.test_grok1_multiblock_experiment
       scripts.test_grok1_multiblock_progress
       scripts.test_grok1_multiblock_v4_decision

--- a/reports/grok-1-block-pilot/artifacts/block_000-attention_only-histogram.json
+++ b/reports/grok-1-block-pilot/artifacts/block_000-attention_only-histogram.json
@@ -1,6 +1,6 @@
 {
+  "file_basename": "block_000-attention_only.goz1",
   "file_size": 22168640,
-  "version": 1,
   "metadata": {
     "grok1.architecture": "grok-1",
     "grok1.attention.head_count": 48,
@@ -11,120 +11,120 @@
     "grok1.expert_count": 8,
     "grok1.feed_forward_length": 32768,
     "oz.gif_threshold": "0.05",
+    "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05",
     "oz.name": "grok-ozempic",
-    "oz.quantization_version": 1,
-    "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05"
+    "oz.quantization_version": 1
   },
   "tensors": [
     {
-      "name": "block_000.slot_03.attn_proj_i8.narrow",
-      "shape": [
-        6144,
-        1024
-      ],
-      "num_elements": 6291456,
-      "type": "ternary",
+      "effective_tau": 0.4,
       "histogram": {
-        "zeros": 2117334,
-        "pos": 2085009,
+        "invalid": 0,
         "neg": 2089113,
-        "invalid": 0
+        "pos": 2085009,
+        "zeros": 2117334
       },
-      "sparsity": 0.33654117584228516,
-      "effective_tau": 0.4
-    },
-    {
-      "name": "block_000.slot_04.attn_proj_i8.model_width",
-      "shape": [
-        6144,
-        6144
-      ],
-      "num_elements": 37748736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 12596418,
-        "pos": 12576958,
-        "neg": 12575360,
-        "invalid": 0
-      },
-      "sparsity": 0.3336911201477051,
-      "effective_tau": 0.4
-    },
-    {
-      "name": "block_000.slot_05.attn_proj_i8.model_width",
-      "shape": [
-        6144,
-        6144
-      ],
-      "num_elements": 37748736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 12161834,
-        "pos": 12792574,
-        "neg": 12794328,
-        "invalid": 0
-      },
-      "sparsity": 0.3221785757276747,
-      "effective_tau": 0.4
-    },
-    {
-      "name": "block_000.slot_06.attn_proj_i8.narrow",
+      "name": "block_000.slot_03.attn_proj_i8.narrow",
+      "num_elements": 6291456,
       "shape": [
         6144,
         1024
       ],
-      "num_elements": 6291456,
-      "type": "ternary",
+      "sparsity": 0.33654117584228516,
+      "type": "ternary"
+    },
+    {
+      "effective_tau": 0.4,
       "histogram": {
-        "zeros": 2047031,
-        "pos": 2122564,
-        "neg": 2121861,
-        "invalid": 0
+        "invalid": 0,
+        "neg": 12575360,
+        "pos": 12576958,
+        "zeros": 12596418
       },
+      "name": "block_000.slot_04.attn_proj_i8.model_width",
+      "num_elements": 37748736,
+      "shape": [
+        6144,
+        6144
+      ],
+      "sparsity": 0.3336911201477051,
+      "type": "ternary"
+    },
+    {
+      "effective_tau": 0.4,
+      "histogram": {
+        "invalid": 0,
+        "neg": 12794328,
+        "pos": 12792574,
+        "zeros": 12161834
+      },
+      "name": "block_000.slot_05.attn_proj_i8.model_width",
+      "num_elements": 37748736,
+      "shape": [
+        6144,
+        6144
+      ],
+      "sparsity": 0.3221785757276747,
+      "type": "ternary"
+    },
+    {
+      "effective_tau": 0.4,
+      "histogram": {
+        "invalid": 0,
+        "neg": 2121861,
+        "pos": 2122564,
+        "zeros": 2047031
+      },
+      "name": "block_000.slot_06.attn_proj_i8.narrow",
+      "num_elements": 6291456,
+      "shape": [
+        6144,
+        1024
+      ],
       "sparsity": 0.3253668149312337,
-      "effective_tau": 0.4
+      "type": "ternary"
     },
     {
       "name": "block_000.slot_07.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_08.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_09.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_10.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_11.router",
+      "num_elements": 49152,
       "shape": [
         6144,
         8
       ],
-      "num_elements": 49152,
       "type": "f16"
     }
   ],
-  "file_basename": "block_000-attention_only.goz1"
+  "version": 1
 }

--- a/reports/grok-1-block-pilot/artifacts/block_000-attention_only-route-preservation.json
+++ b/reports/grok-1-block-pilot/artifacts/block_000-attention_only-route-preservation.json
@@ -1,291 +1,78 @@
 {
-  "model_family": "grok-1",
-  "produced_by": "grok-ozempic scripts/route_preservation_metrics.py (GH #53 / RM-222)",
   "certification": {
-    "certified": true,
     "basis": "pack inventory verified against the xai-dissect conversion manifest",
+    "certified": true,
     "conversion_manifest_basename": "conversion-manifest.json"
   },
+  "model_family": "grok-1",
   "pilot": {
-    "block": 0,
-    "mode": "attention_only",
-    "tokens": 4096,
-    "seed": 20260805,
-    "ternary_tensors": 4,
-    "preserve_tensors": 5,
-    "pack_metadata": {
-      "oz.gif_threshold": "0.05",
-      "oz.name": "grok-ozempic",
-      "oz.quantization_version": 1,
-      "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05"
-    },
-    "ternary_scale": "least-squares optimal alpha = sum(|w| fired)/count(fired); GOZ1 v1 stores no scale",
     "activations": "real token-embedding rows through the block's RMSNorm gain",
+    "block": 0,
     "effective_tau_policy": {
       "attn_proj_i8.*": 0.4,
       "moe_expert.*": 0.9
     },
-    "pack_basename": "block_000-attention_only.goz1",
+    "mode": "attention_only",
     "npy_dir_basename": "npy",
-    "paths_note": "Host-local absolute paths removed for publication; regenerate with BLOCK=<n> MODE=<mode> scripts/block_pilot_goz1.sh (the npy stage is a per-run mktemp directory deleted on exit)."
-  },
-  "summary": [
-    {
-      "name": "router_top1_agreement",
-      "scope": "router_behavior",
-      "status": "fail",
-      "threshold": ">= 99.0%",
-      "observed": 0.6396484375,
-      "detail": "Worst case over evaluated d_model x d_model projections; router read from the pack (fp16 preserve tier)."
+    "pack_basename": "block_000-attention_only.goz1",
+    "pack_metadata": {
+      "oz.gif_threshold": "0.05",
+      "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05",
+      "oz.name": "grok-ozempic",
+      "oz.quantization_version": 1
     },
-    {
-      "name": "router_top2_set_agreement",
-      "scope": "router_behavior",
-      "status": "fail",
-      "threshold": ">= 99.5%",
-      "observed": 0.421142578125,
-      "detail": "Fraction of tokens whose unordered top-2 expert set is unchanged."
-    },
-    {
-      "name": "expert_load_distribution_delta",
-      "scope": "router_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.24853515625,
-      "detail": "Max per-expert share change in the top-1 load histogram."
-    },
-    {
-      "name": "expert_load_js_divergence",
-      "scope": "router_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.11021330045422195,
-      "detail": "Jensen-Shannon divergence (bits) between reference and pilot expert-load distributions."
-    },
-    {
-      "name": "router_logit_rank_correlation",
-      "scope": "router_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.7528366815476191,
-      "detail": "Mean per-token Spearman correlation over the router logits."
-    },
-    {
-      "name": "block_output_cosine",
-      "scope": "block_behavior",
-      "status": "fail",
-      "threshold": ">= 0.995",
-      "observed": 0.8492034016757434,
-      "detail": "Scoped to the quantized projection output, not a full block forward (attention roles are unassigned upstream; MoE not executed)."
-    },
-    {
-      "name": "block_output_rmse",
-      "scope": "block_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.7658854546679026,
-      "detail": "RMSE of the projection output against the f32 reference path."
-    },
-    {
-      "name": "residual_stream_drift",
-      "scope": "block_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.5341102824225851,
-      "detail": "Projection-output RMSE normalized by reference output RMS."
-    },
-    {
-      "name": "weight_reconstruction_mse",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 2.7619841182005376e-05,
-      "detail": "Worst quantized tensor, at the least-squares optimal ternary scale."
-    },
-    {
-      "name": "weight_cosine_similarity",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.8596620582316677,
-      "detail": "Worst quantized tensor; independent of the chosen ternary scale."
-    },
-    {
-      "name": "weight_max_absolute_error",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.16381083792034784,
-      "detail": "Exact max |w - alpha*t| over all quantized tensors."
-    },
-    {
-      "name": "per_channel_scale_error_summary",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.6438901094327641,
-      "detail": "Worst per-output-channel relative reconstruction error; full per-tensor spread under `weights`."
-    },
-    {
-      "name": "logit_kl",
-      "scope": "model_behavior",
-      "status": "unknown",
-      "threshold": null,
-      "observed": null,
-      "detail": "Requires whole-model inference; out of scope for a bounded single-block pilot (#53 non-goal)."
-    },
-    {
-      "name": "perplexity_delta",
-      "scope": "model_behavior",
-      "status": "unknown",
-      "threshold": null,
-      "observed": null,
-      "detail": "Requires a calibration corpus and whole-model inference; not run."
-    },
-    {
-      "name": "generation_sanity_summary",
-      "scope": "model_behavior",
-      "status": "unknown",
-      "threshold": null,
-      "observed": null,
-      "detail": "Requires whole-model inference; not run."
-    }
-  ],
-  "weights": {
-    "block_000.slot_03.attn_proj_i8.narrow": {
-      "elements": 6291456,
-      "zeros": 2117334,
-      "sparsity": 0.33654117584228516,
-      "rms": 0.010578140941314469,
-      "alpha_optimal": 0.011270628247707765,
-      "weight_cosine_similarity": 0.8678521892011365,
-      "weight_reconstruction_mse": 2.7619841182005376e-05,
-      "weight_nrmse": 0.4968224810722588,
-      "weight_max_absolute_error": 0.14666546794369847,
-      "per_channel_scale_error": {
-        "channels": 1024,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
-        "alpha_min": 0.006836130454696068,
-        "alpha_median": 0.010566048929377264,
-        "alpha_max": 0.017267009752871754,
-        "relative_error_min": 0.42969516475250813,
-        "relative_error_median": 0.4560618527348418,
-        "relative_error_max": 0.5195065313718404
-      },
-      "effective_tau": 0.4
-    },
-    "block_000.slot_04.attn_proj_i8.model_width": {
-      "elements": 37748736,
-      "zeros": 12596418,
-      "sparsity": 0.3336911201477051,
-      "rms": 0.007302213918588603,
-      "alpha_optimal": 0.00769032174762091,
-      "weight_cosine_similarity": 0.8596620582316677,
-      "weight_reconstruction_mse": 1.3916122278912443e-05,
-      "weight_nrmse": 0.5108631378724569,
-      "weight_max_absolute_error": 0.16381083792034784,
-      "per_channel_scale_error": {
-        "channels": 6144,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
-        "alpha_min": 0.006207052114847544,
-        "alpha_median": 0.007478435324833169,
-        "alpha_max": 0.03994824617600841,
-        "relative_error_min": 0.40419477855512526,
-        "relative_error_median": 0.46801929305190104,
-        "relative_error_max": 0.6438901094327641
-      },
-      "effective_tau": 0.4
-    },
-    "block_000.slot_05.attn_proj_i8.model_width": {
-      "elements": 37748736,
-      "zeros": 12161834,
-      "sparsity": 0.3221785757276747,
-      "rms": 0.0105771638496767,
-      "alpha_optimal": 0.011285860723522544,
-      "weight_cosine_similarity": 0.8784622437138425,
-      "weight_reconstruction_mse": 2.5541838170253586e-05,
-      "weight_nrmse": 0.4778117687638526,
-      "weight_max_absolute_error": 0.1272715733585087,
-      "per_channel_scale_error": {
-        "channels": 6144,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
-        "alpha_min": 0.0069844022693250005,
-        "alpha_median": 0.011054195166908821,
-        "alpha_max": 0.021125657010477607,
-        "relative_error_min": 0.42282016873465333,
-        "relative_error_median": 0.4610193731608061,
-        "relative_error_max": 0.5241617605562177
-      },
-      "effective_tau": 0.4
-    },
-    "block_000.slot_06.attn_proj_i8.narrow": {
-      "elements": 6291456,
-      "zeros": 2047031,
-      "sparsity": 0.3253668149312337,
-      "rms": 0.010577328232367855,
-      "alpha_optimal": 0.011283784705669356,
-      "weight_cosine_similarity": 0.8762189872473086,
-      "weight_reconstruction_mse": 2.5983013638560264e-05,
-      "weight_nrmse": 0.4819131523286129,
-      "weight_max_absolute_error": 0.11128625313612751,
-      "per_channel_scale_error": {
-        "channels": 1024,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
-        "alpha_min": 0.008036103038273021,
-        "alpha_median": 0.010932057911501905,
-        "alpha_max": 0.01778287054721133,
-        "relative_error_min": 0.4296315201504765,
-        "relative_error_median": 0.46042890588686025,
-        "relative_error_max": 0.5166798793234245
-      },
-      "effective_tau": 0.4
-    }
+    "paths_note": "Host-local absolute paths removed for publication; regenerate with BLOCK=<n> MODE=<mode> scripts/block_pilot_goz1.sh (the npy stage is a per-run mktemp directory deleted on exit).",
+    "preserve_tensors": 5,
+    "seed": 20260805,
+    "ternary_scale": "least-squares optimal alpha = sum(|w| fired)/count(fired); GOZ1 v1 stores no scale",
+    "ternary_tensors": 4,
+    "tokens": 4096
   },
   "preserve_fp16_roundtrip": {
     "block_000.slot_07.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0013875961303710938,
-      "relative_rmse": 0.0002078451996099635,
-      "bit_exact": false
+      "relative_rmse": 0.0002078451996099635
     },
     "block_000.slot_08.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0019283294677734375,
-      "relative_rmse": 0.0001965988264285251,
-      "bit_exact": false
+      "relative_rmse": 0.0001965988264285251
     },
     "block_000.slot_09.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0008301734924316406,
-      "relative_rmse": 0.00021666898691768515,
-      "bit_exact": false
+      "relative_rmse": 0.00021666898691768515
     },
     "block_000.slot_10.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0009748935699462891,
-      "relative_rmse": 0.00020079402752299537,
-      "bit_exact": false
+      "relative_rmse": 0.00020079402752299537
     },
     "block_000.slot_11.router": {
+      "bit_exact": false,
       "max_absolute_error": 6.00963830947876e-05,
-      "relative_rmse": 0.0002092983467282326,
-      "bit_exact": false
+      "relative_rmse": 0.0002092983467282326
     }
   },
+  "produced_by": "grok-ozempic scripts/route_preservation_metrics.py (GH #53 / RM-222)",
   "routing": {
     "block_000.slot_04.attn_proj_i8.model_width": {
-      "tokens": 4096,
-      "router_top1_agreement": 0.686279296875,
-      "router_top2_set_agreement": 0.4423828125,
-      "router_logit_rank_correlation": 0.7739606584821428,
+      "activations": {
+        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
+        "rmsnorm_gain": "block_000.slot_07.block_norm",
+        "rows_sampled": 4096,
+        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
+        "shard_basename": "tensor00000_000",
+        "source": "token_embedding_rows",
+        "vocab_size": 131072
+      },
+      "block_output_cosine": 0.8492034016757434,
+      "block_output_cosine_min": 0.7120308525669509,
+      "block_output_rmse": 0.26373385065945526,
+      "effective_tau": 0.4,
       "expert_load_distribution_delta": 0.140869140625,
       "expert_load_js_divergence": 0.06889692300140215,
-      "expert_load_reference": [
-        0.03076171875,
-        0.15673828125,
-        0.03076171875,
-        0.450927734375,
-        0.012451171875,
-        0.2197265625,
-        0.08935546875,
-        0.00927734375
-      ],
       "expert_load_pilot": [
         0.061279296875,
         0.085205078125,
@@ -296,38 +83,38 @@
         0.1884765625,
         0.051513671875
       ],
-      "block_output_cosine": 0.8492034016757434,
-      "block_output_cosine_min": 0.7120308525669509,
-      "block_output_rmse": 0.26373385065945526,
+      "expert_load_reference": [
+        0.03076171875,
+        0.15673828125,
+        0.03076171875,
+        0.450927734375,
+        0.012451171875,
+        0.2197265625,
+        0.08935546875,
+        0.00927734375
+      ],
       "residual_stream_drift": 0.5341102824225851,
-      "activations": {
-        "source": "token_embedding_rows",
-        "vocab_size": 131072,
-        "rows_sampled": 4096,
-        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
-        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
-        "rmsnorm_gain": "block_000.slot_07.block_norm",
-        "shard_basename": "tensor00000_000"
-      },
-      "effective_tau": 0.4
+      "router_logit_rank_correlation": 0.7739606584821428,
+      "router_top1_agreement": 0.686279296875,
+      "router_top2_set_agreement": 0.4423828125,
+      "tokens": 4096
     },
     "block_000.slot_05.attn_proj_i8.model_width": {
-      "tokens": 4096,
-      "router_top1_agreement": 0.6396484375,
-      "router_top2_set_agreement": 0.421142578125,
-      "router_logit_rank_correlation": 0.7528366815476191,
+      "activations": {
+        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
+        "rmsnorm_gain": "block_000.slot_07.block_norm",
+        "rows_sampled": 4096,
+        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
+        "shard_basename": "tensor00000_000",
+        "source": "token_embedding_rows",
+        "vocab_size": 131072
+      },
+      "block_output_cosine": 0.9630472132115836,
+      "block_output_cosine_min": 0.938282154715757,
+      "block_output_rmse": 0.7658854546679026,
+      "effective_tau": 0.4,
       "expert_load_distribution_delta": 0.24853515625,
       "expert_load_js_divergence": 0.11021330045422195,
-      "expert_load_reference": [
-        0.46337890625,
-        0.0,
-        0.0,
-        0.44873046875,
-        0.04736328125,
-        0.038330078125,
-        0.002197265625,
-        0.0
-      ],
       "expert_load_pilot": [
         0.42724609375,
         0.000244140625,
@@ -338,20 +125,233 @@
         0.000732421875,
         0.0
       ],
-      "block_output_cosine": 0.9630472132115836,
-      "block_output_cosine_min": 0.938282154715757,
-      "block_output_rmse": 0.7658854546679026,
+      "expert_load_reference": [
+        0.46337890625,
+        0.0,
+        0.0,
+        0.44873046875,
+        0.04736328125,
+        0.038330078125,
+        0.002197265625,
+        0.0
+      ],
       "residual_stream_drift": 0.3356917020354853,
-      "activations": {
-        "source": "token_embedding_rows",
-        "vocab_size": 131072,
-        "rows_sampled": 4096,
-        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
-        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
-        "rmsnorm_gain": "block_000.slot_07.block_norm",
-        "shard_basename": "tensor00000_000"
+      "router_logit_rank_correlation": 0.7528366815476191,
+      "router_top1_agreement": 0.6396484375,
+      "router_top2_set_agreement": 0.421142578125,
+      "tokens": 4096
+    }
+  },
+  "summary": [
+    {
+      "detail": "Worst case over evaluated d_model x d_model projections; router read from the pack (fp16 preserve tier).",
+      "name": "router_top1_agreement",
+      "observed": 0.6396484375,
+      "scope": "router_behavior",
+      "status": "fail",
+      "threshold": ">= 99.0%"
+    },
+    {
+      "detail": "Fraction of tokens whose unordered top-2 expert set is unchanged.",
+      "name": "router_top2_set_agreement",
+      "observed": 0.421142578125,
+      "scope": "router_behavior",
+      "status": "fail",
+      "threshold": ">= 99.5%"
+    },
+    {
+      "detail": "Max per-expert share change in the top-1 load histogram.",
+      "name": "expert_load_distribution_delta",
+      "observed": 0.24853515625,
+      "scope": "router_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Jensen-Shannon divergence (bits) between reference and pilot expert-load distributions.",
+      "name": "expert_load_js_divergence",
+      "observed": 0.11021330045422195,
+      "scope": "router_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Mean per-token Spearman correlation over the router logits.",
+      "name": "router_logit_rank_correlation",
+      "observed": 0.7528366815476191,
+      "scope": "router_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Scoped to the quantized projection output, not a full block forward (attention roles are unassigned upstream; MoE not executed).",
+      "name": "block_output_cosine",
+      "observed": 0.8492034016757434,
+      "scope": "block_behavior",
+      "status": "fail",
+      "threshold": ">= 0.995"
+    },
+    {
+      "detail": "RMSE of the projection output against the f32 reference path.",
+      "name": "block_output_rmse",
+      "observed": 0.7658854546679026,
+      "scope": "block_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Projection-output RMSE normalized by reference output RMS.",
+      "name": "residual_stream_drift",
+      "observed": 0.5341102824225851,
+      "scope": "block_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Worst quantized tensor, at the least-squares optimal ternary scale.",
+      "name": "weight_reconstruction_mse",
+      "observed": 2.7619841182005376e-05,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Worst quantized tensor; independent of the chosen ternary scale.",
+      "name": "weight_cosine_similarity",
+      "observed": 0.8596620582316677,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Exact max |w - alpha*t| over all quantized tensors.",
+      "name": "weight_max_absolute_error",
+      "observed": 0.16381083792034784,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Worst per-output-channel relative reconstruction error; full per-tensor spread under `weights`.",
+      "name": "per_channel_scale_error_summary",
+      "observed": 0.6438901094327641,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Requires whole-model inference; out of scope for a bounded single-block pilot (#53 non-goal).",
+      "name": "logit_kl",
+      "observed": null,
+      "scope": "model_behavior",
+      "status": "unknown",
+      "threshold": null
+    },
+    {
+      "detail": "Requires a calibration corpus and whole-model inference; not run.",
+      "name": "perplexity_delta",
+      "observed": null,
+      "scope": "model_behavior",
+      "status": "unknown",
+      "threshold": null
+    },
+    {
+      "detail": "Requires whole-model inference; not run.",
+      "name": "generation_sanity_summary",
+      "observed": null,
+      "scope": "model_behavior",
+      "status": "unknown",
+      "threshold": null
+    }
+  ],
+  "weights": {
+    "block_000.slot_03.attn_proj_i8.narrow": {
+      "alpha_optimal": 0.011270628247707765,
+      "effective_tau": 0.4,
+      "elements": 6291456,
+      "per_channel_scale_error": {
+        "alpha_max": 0.017267009752871754,
+        "alpha_median": 0.010566048929377264,
+        "alpha_min": 0.006836130454696068,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
+        "channels": 1024,
+        "relative_error_max": 0.5195065313718404,
+        "relative_error_median": 0.4560618527348418,
+        "relative_error_min": 0.42969516475250813
       },
-      "effective_tau": 0.4
+      "rms": 0.010578140941314469,
+      "sparsity": 0.33654117584228516,
+      "weight_cosine_similarity": 0.8678521892011365,
+      "weight_max_absolute_error": 0.14666546794369847,
+      "weight_nrmse": 0.4968224810722588,
+      "weight_reconstruction_mse": 2.7619841182005376e-05,
+      "zeros": 2117334
+    },
+    "block_000.slot_04.attn_proj_i8.model_width": {
+      "alpha_optimal": 0.00769032174762091,
+      "effective_tau": 0.4,
+      "elements": 37748736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.03994824617600841,
+        "alpha_median": 0.007478435324833169,
+        "alpha_min": 0.006207052114847544,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
+        "channels": 6144,
+        "relative_error_max": 0.6438901094327641,
+        "relative_error_median": 0.46801929305190104,
+        "relative_error_min": 0.40419477855512526
+      },
+      "rms": 0.007302213918588603,
+      "sparsity": 0.3336911201477051,
+      "weight_cosine_similarity": 0.8596620582316677,
+      "weight_max_absolute_error": 0.16381083792034784,
+      "weight_nrmse": 0.5108631378724569,
+      "weight_reconstruction_mse": 1.3916122278912443e-05,
+      "zeros": 12596418
+    },
+    "block_000.slot_05.attn_proj_i8.model_width": {
+      "alpha_optimal": 0.011285860723522544,
+      "effective_tau": 0.4,
+      "elements": 37748736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.021125657010477607,
+        "alpha_median": 0.011054195166908821,
+        "alpha_min": 0.0069844022693250005,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
+        "channels": 6144,
+        "relative_error_max": 0.5241617605562177,
+        "relative_error_median": 0.4610193731608061,
+        "relative_error_min": 0.42282016873465333
+      },
+      "rms": 0.0105771638496767,
+      "sparsity": 0.3221785757276747,
+      "weight_cosine_similarity": 0.8784622437138425,
+      "weight_max_absolute_error": 0.1272715733585087,
+      "weight_nrmse": 0.4778117687638526,
+      "weight_reconstruction_mse": 2.5541838170253586e-05,
+      "zeros": 12161834
+    },
+    "block_000.slot_06.attn_proj_i8.narrow": {
+      "alpha_optimal": 0.011283784705669356,
+      "effective_tau": 0.4,
+      "elements": 6291456,
+      "per_channel_scale_error": {
+        "alpha_max": 0.01778287054721133,
+        "alpha_median": 0.010932057911501905,
+        "alpha_min": 0.008036103038273021,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
+        "channels": 1024,
+        "relative_error_max": 0.5166798793234245,
+        "relative_error_median": 0.46042890588686025,
+        "relative_error_min": 0.4296315201504765
+      },
+      "rms": 0.010577328232367855,
+      "sparsity": 0.3253668149312337,
+      "weight_cosine_similarity": 0.8762189872473086,
+      "weight_max_absolute_error": 0.11128625313612751,
+      "weight_nrmse": 0.4819131523286129,
+      "weight_reconstruction_mse": 2.5983013638560264e-05,
+      "zeros": 2047031
     }
   }
 }

--- a/reports/grok-1-block-pilot/artifacts/block_000-attention_plus_expert-histogram.json
+++ b/reports/grok-1-block-pilot/artifacts/block_000-attention_plus_expert-histogram.json
@@ -1,6 +1,6 @@
 {
+  "file_basename": "block_000-attention_plus_expert.goz1",
   "file_size": 1230128448,
-  "version": 1,
   "metadata": {
     "grok1.architecture": "grok-1",
     "grok1.attention.head_count": 48,
@@ -11,174 +11,174 @@
     "grok1.expert_count": 8,
     "grok1.feed_forward_length": 32768,
     "oz.gif_threshold": "0.05",
+    "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05",
     "oz.name": "grok-ozempic",
-    "oz.quantization_version": 1,
-    "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05"
+    "oz.quantization_version": 1
   },
   "tensors": [
     {
+      "effective_tau": 0.9,
+      "histogram": {
+        "invalid": 0,
+        "neg": 281636429,
+        "pos": 277489751,
+        "zeros": 1051486556
+      },
       "name": "block_000.slot_00.moe_expert.gate",
+      "num_elements": 1610612736,
       "shape": [
         8,
         6144,
         32768
       ],
-      "num_elements": 1610612736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 1051486556,
-        "pos": 277489751,
-        "neg": 281636429,
-        "invalid": 0
-      },
       "sparsity": 0.6528487776716551,
-      "effective_tau": 0.9
+      "type": "ternary"
     },
     {
+      "effective_tau": 0.9,
+      "histogram": {
+        "invalid": 0,
+        "neg": 292094023,
+        "pos": 292110401,
+        "zeros": 1026408312
+      },
       "name": "block_000.slot_01.moe_expert.down",
+      "num_elements": 1610612736,
       "shape": [
         8,
         32768,
         6144
       ],
-      "num_elements": 1610612736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 1026408312,
-        "pos": 292110401,
-        "neg": 292094023,
-        "invalid": 0
-      },
       "sparsity": 0.6372781544923782,
-      "effective_tau": 0.9
+      "type": "ternary"
     },
     {
+      "effective_tau": 0.9,
+      "histogram": {
+        "invalid": 0,
+        "neg": 286400759,
+        "pos": 286380703,
+        "zeros": 1037831274
+      },
       "name": "block_000.slot_02.moe_expert.up",
+      "num_elements": 1610612736,
       "shape": [
         8,
         6144,
         32768
       ],
-      "num_elements": 1610612736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 1037831274,
-        "pos": 286380703,
-        "neg": 286400759,
-        "invalid": 0
-      },
       "sparsity": 0.6443704627454281,
-      "effective_tau": 0.9
+      "type": "ternary"
     },
     {
-      "name": "block_000.slot_03.attn_proj_i8.narrow",
-      "shape": [
-        6144,
-        1024
-      ],
-      "num_elements": 6291456,
-      "type": "ternary",
+      "effective_tau": 0.4,
       "histogram": {
-        "zeros": 2117334,
-        "pos": 2085009,
+        "invalid": 0,
         "neg": 2089113,
-        "invalid": 0
+        "pos": 2085009,
+        "zeros": 2117334
       },
-      "sparsity": 0.33654117584228516,
-      "effective_tau": 0.4
-    },
-    {
-      "name": "block_000.slot_04.attn_proj_i8.model_width",
-      "shape": [
-        6144,
-        6144
-      ],
-      "num_elements": 37748736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 12596418,
-        "pos": 12576958,
-        "neg": 12575360,
-        "invalid": 0
-      },
-      "sparsity": 0.3336911201477051,
-      "effective_tau": 0.4
-    },
-    {
-      "name": "block_000.slot_05.attn_proj_i8.model_width",
-      "shape": [
-        6144,
-        6144
-      ],
-      "num_elements": 37748736,
-      "type": "ternary",
-      "histogram": {
-        "zeros": 12161834,
-        "pos": 12792574,
-        "neg": 12794328,
-        "invalid": 0
-      },
-      "sparsity": 0.3221785757276747,
-      "effective_tau": 0.4
-    },
-    {
-      "name": "block_000.slot_06.attn_proj_i8.narrow",
+      "name": "block_000.slot_03.attn_proj_i8.narrow",
+      "num_elements": 6291456,
       "shape": [
         6144,
         1024
       ],
-      "num_elements": 6291456,
-      "type": "ternary",
+      "sparsity": 0.33654117584228516,
+      "type": "ternary"
+    },
+    {
+      "effective_tau": 0.4,
       "histogram": {
-        "zeros": 2047031,
-        "pos": 2122564,
-        "neg": 2121861,
-        "invalid": 0
+        "invalid": 0,
+        "neg": 12575360,
+        "pos": 12576958,
+        "zeros": 12596418
       },
+      "name": "block_000.slot_04.attn_proj_i8.model_width",
+      "num_elements": 37748736,
+      "shape": [
+        6144,
+        6144
+      ],
+      "sparsity": 0.3336911201477051,
+      "type": "ternary"
+    },
+    {
+      "effective_tau": 0.4,
+      "histogram": {
+        "invalid": 0,
+        "neg": 12794328,
+        "pos": 12792574,
+        "zeros": 12161834
+      },
+      "name": "block_000.slot_05.attn_proj_i8.model_width",
+      "num_elements": 37748736,
+      "shape": [
+        6144,
+        6144
+      ],
+      "sparsity": 0.3221785757276747,
+      "type": "ternary"
+    },
+    {
+      "effective_tau": 0.4,
+      "histogram": {
+        "invalid": 0,
+        "neg": 2121861,
+        "pos": 2122564,
+        "zeros": 2047031
+      },
+      "name": "block_000.slot_06.attn_proj_i8.narrow",
+      "num_elements": 6291456,
+      "shape": [
+        6144,
+        1024
+      ],
       "sparsity": 0.3253668149312337,
-      "effective_tau": 0.4
+      "type": "ternary"
     },
     {
       "name": "block_000.slot_07.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_08.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_09.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_10.block_norm",
+      "num_elements": 6144,
       "shape": [
         6144
       ],
-      "num_elements": 6144,
       "type": "f16"
     },
     {
       "name": "block_000.slot_11.router",
+      "num_elements": 49152,
       "shape": [
         6144,
         8
       ],
-      "num_elements": 49152,
       "type": "f16"
     }
   ],
-  "file_basename": "block_000-attention_plus_expert.goz1"
+  "version": 1
 }

--- a/reports/grok-1-block-pilot/artifacts/block_000-attention_plus_expert-manifest.json
+++ b/reports/grok-1-block-pilot/artifacts/block_000-attention_plus_expert-manifest.json
@@ -1,18 +1,14 @@
 {
-  "schema": "xai-dissect.manifest",
-  "schema_version": 1,
+  "_i8_streaming_note": "These 7 patterns (4 attention + 3 MoE expert) cover the 448 i8 tensors from xai-dissect inventory for *alignment verification only* (see grok1_inventory.rs NOTE and alignment.rs). Current stream.rs filters SourceDtype::Other (raw ckpt has no i8; parse_safetensors_dtype + npy only F32/F16/BF16). int8 enter via xai-dissect exports + wrap_existing_int8_* in src/artifact.rs + report validation. Do not remove patterns \u2014 would regress 770-tensor full coverage + classify_full_inventory test. Kilo agent xAI/Grok Build 0.1 addressing Codex P1 on PR #26.",
+  "blocks": [],
+  "defaults": {
+    "precision": "ternary_snn"
+  },
+  "fp16": [],
   "model": {
     "family": "grok-1",
     "source": "xai-org/grok-1",
     "tensor_name_convention": "block_{NNN}.slot_{SS}.{kind}"
-  },
-  "produced_by": {
-    "tool": "grok-ozempic scripts/block_pilot_goz1.sh (derived; xai-dissect remains authoritative)",
-    "commit": null,
-    "version": "0.2.0"
-  },
-  "defaults": {
-    "precision": "ternary_snn"
   },
   "preserve": [
     {
@@ -40,37 +36,41 @@
       "reason": "normalization-critical; must remain FP32"
     }
   ],
-  "fp16": [],
+  "produced_by": {
+    "commit": null,
+    "tool": "grok-ozempic scripts/block_pilot_goz1.sh (derived; xai-dissect remains authoritative)",
+    "version": "0.2.0"
+  },
+  "schema": "xai-dissect.manifest",
+  "schema_version": 1,
   "ternary_candidates": [
     {
-      "name": "block_*.slot_00.moe_expert.gate",
-      "gif_threshold": 0.9
+      "gif_threshold": 0.9,
+      "name": "block_*.slot_00.moe_expert.gate"
     },
     {
-      "name": "block_*.slot_01.moe_expert.down",
-      "gif_threshold": 0.9
+      "gif_threshold": 0.9,
+      "name": "block_*.slot_01.moe_expert.down"
     },
     {
-      "name": "block_*.slot_02.moe_expert.up",
-      "gif_threshold": 0.9
+      "gif_threshold": 0.9,
+      "name": "block_*.slot_02.moe_expert.up"
     },
     {
-      "name": "block_*.slot_03.attn_proj_i8.narrow",
-      "gif_threshold": 0.4
+      "gif_threshold": 0.4,
+      "name": "block_*.slot_03.attn_proj_i8.narrow"
     },
     {
-      "name": "block_*.slot_04.attn_proj_i8.model_width",
-      "gif_threshold": 0.4
+      "gif_threshold": 0.4,
+      "name": "block_*.slot_04.attn_proj_i8.model_width"
     },
     {
-      "name": "block_*.slot_05.attn_proj_i8.model_width",
-      "gif_threshold": 0.4
+      "gif_threshold": 0.4,
+      "name": "block_*.slot_05.attn_proj_i8.model_width"
     },
     {
-      "name": "block_*.slot_06.attn_proj_i8.narrow",
-      "gif_threshold": 0.4
+      "gif_threshold": 0.4,
+      "name": "block_*.slot_06.attn_proj_i8.narrow"
     }
-  ],
-  "_i8_streaming_note": "These 7 patterns (4 attention + 3 MoE expert) cover the 448 i8 tensors from xai-dissect inventory for *alignment verification only* (see grok1_inventory.rs NOTE and alignment.rs). Current stream.rs filters SourceDtype::Other (raw ckpt has no i8; parse_safetensors_dtype + npy only F32/F16/BF16). int8 enter via xai-dissect exports + wrap_existing_int8_* in src/artifact.rs + report validation. Do not remove patterns \u2014 would regress 770-tensor full coverage + classify_full_inventory test. Kilo agent xAI/Grok Build 0.1 addressing Codex P1 on PR #26.",
-  "blocks": []
+  ]
 }

--- a/reports/grok-1-block-pilot/artifacts/block_000-attention_plus_expert-route-preservation.json
+++ b/reports/grok-1-block-pilot/artifacts/block_000-attention_plus_expert-route-preservation.json
@@ -1,357 +1,78 @@
 {
-  "model_family": "grok-1",
-  "produced_by": "grok-ozempic scripts/route_preservation_metrics.py (GH #53 / RM-222)",
   "certification": {
-    "certified": true,
     "basis": "pack inventory verified against the xai-dissect conversion manifest",
+    "certified": true,
     "conversion_manifest_basename": "conversion-manifest.json"
   },
+  "model_family": "grok-1",
   "pilot": {
-    "block": 0,
-    "mode": "attention_plus_expert",
-    "tokens": 4096,
-    "seed": 20260805,
-    "ternary_tensors": 7,
-    "preserve_tensors": 5,
-    "pack_metadata": {
-      "oz.gif_threshold": "0.05",
-      "oz.name": "grok-ozempic",
-      "oz.quantization_version": 1,
-      "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05"
-    },
-    "ternary_scale": "least-squares optimal alpha = sum(|w| fired)/count(fired); GOZ1 v1 stores no scale",
     "activations": "real token-embedding rows through the block's RMSNorm gain",
+    "block": 0,
     "effective_tau_policy": {
       "attn_proj_i8.*": 0.4,
       "moe_expert.*": 0.9
     },
-    "pack_basename": "block_000-attention_plus_expert.goz1",
+    "mode": "attention_plus_expert",
     "npy_dir_basename": "npy",
-    "paths_note": "Host-local absolute paths removed for publication; regenerate with BLOCK=<n> MODE=<mode> scripts/block_pilot_goz1.sh (the npy stage is a per-run mktemp directory deleted on exit)."
-  },
-  "summary": [
-    {
-      "name": "router_top1_agreement",
-      "scope": "router_behavior",
-      "status": "fail",
-      "threshold": ">= 99.0%",
-      "observed": 0.6396484375,
-      "detail": "Worst case over evaluated d_model x d_model projections; router read from the pack (fp16 preserve tier)."
+    "pack_basename": "block_000-attention_plus_expert.goz1",
+    "pack_metadata": {
+      "oz.gif_threshold": "0.05",
+      "oz.gif_threshold_note": "per-tensor effective_tau: 0.4 for attn_proj_i8.*, 0.9 for moe_expert.*; pipeline default 0.05",
+      "oz.name": "grok-ozempic",
+      "oz.quantization_version": 1
     },
-    {
-      "name": "router_top2_set_agreement",
-      "scope": "router_behavior",
-      "status": "fail",
-      "threshold": ">= 99.5%",
-      "observed": 0.421142578125,
-      "detail": "Fraction of tokens whose unordered top-2 expert set is unchanged."
-    },
-    {
-      "name": "expert_load_distribution_delta",
-      "scope": "router_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.24853515625,
-      "detail": "Max per-expert share change in the top-1 load histogram."
-    },
-    {
-      "name": "expert_load_js_divergence",
-      "scope": "router_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.11021330045422195,
-      "detail": "Jensen-Shannon divergence (bits) between reference and pilot expert-load distributions."
-    },
-    {
-      "name": "router_logit_rank_correlation",
-      "scope": "router_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.7528366815476191,
-      "detail": "Mean per-token Spearman correlation over the router logits."
-    },
-    {
-      "name": "block_output_cosine",
-      "scope": "block_behavior",
-      "status": "fail",
-      "threshold": ">= 0.995",
-      "observed": 0.8492034016757434,
-      "detail": "Scoped to the quantized projection output, not a full block forward (attention roles are unassigned upstream; MoE not executed)."
-    },
-    {
-      "name": "block_output_rmse",
-      "scope": "block_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.7658854546679026,
-      "detail": "RMSE of the projection output against the f32 reference path."
-    },
-    {
-      "name": "residual_stream_drift",
-      "scope": "block_behavior",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.5341102824225851,
-      "detail": "Projection-output RMSE normalized by reference output RMS."
-    },
-    {
-      "name": "weight_reconstruction_mse",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.0001426260740471938,
-      "detail": "Worst quantized tensor, at the least-squares optimal ternary scale."
-    },
-    {
-      "name": "weight_cosine_similarity",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.8596620582316677,
-      "detail": "Worst quantized tensor; independent of the chosen ternary scale."
-    },
-    {
-      "name": "weight_max_absolute_error",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.7098091729063252,
-      "detail": "Exact max |w - alpha*t| over all quantized tensors."
-    },
-    {
-      "name": "per_channel_scale_error_summary",
-      "scope": "weight_reconstruction",
-      "status": "measured",
-      "threshold": null,
-      "observed": 0.7654989064033166,
-      "detail": "Worst per-output-channel relative reconstruction error; full per-tensor spread under `weights`."
-    },
-    {
-      "name": "logit_kl",
-      "scope": "model_behavior",
-      "status": "unknown",
-      "threshold": null,
-      "observed": null,
-      "detail": "Requires whole-model inference; out of scope for a bounded single-block pilot (#53 non-goal)."
-    },
-    {
-      "name": "perplexity_delta",
-      "scope": "model_behavior",
-      "status": "unknown",
-      "threshold": null,
-      "observed": null,
-      "detail": "Requires a calibration corpus and whole-model inference; not run."
-    },
-    {
-      "name": "generation_sanity_summary",
-      "scope": "model_behavior",
-      "status": "unknown",
-      "threshold": null,
-      "observed": null,
-      "detail": "Requires whole-model inference; not run."
-    }
-  ],
-  "weights": {
-    "block_000.slot_00.moe_expert.gate": {
-      "elements": 1610612736,
-      "zeros": 1051486556,
-      "sparsity": 0.6528487776716551,
-      "rms": 0.023557757634404944,
-      "alpha_optimal": 0.03446429262403113,
-      "weight_cosine_similarity": 0.8619751964369022,
-      "weight_reconstruction_mse": 0.0001426260740471938,
-      "weight_nrmse": 0.5069504519453197,
-      "weight_max_absolute_error": 0.3879905413603439,
-      "per_channel_scale_error": {
-        "channels": 262144,
-        "channel_definition": "(leading index, last axis) pairs: 8 x 32768, 6144 elements each",
-        "alpha_min": 0.028118791881937995,
-        "alpha_median": 0.03403930523622656,
-        "alpha_max": 0.0870242716704669,
-        "relative_error_min": 0.3634878046928346,
-        "relative_error_median": 0.49800192292541123,
-        "relative_error_max": 0.6629830233906198
-      },
-      "effective_tau": 0.9
-    },
-    "block_000.slot_01.moe_expert.down": {
-      "elements": 1610612736,
-      "zeros": 1026408312,
-      "sparsity": 0.6372781544923782,
-      "rms": 0.015693050566611258,
-      "alpha_optimal": 0.022704254828049837,
-      "weight_cosine_similarity": 0.8713381608146713,
-      "weight_reconstruction_mse": 5.9294823061690226e-05,
-      "weight_nrmse": 0.49068300307643237,
-      "weight_max_absolute_error": 0.7098091729063252,
-      "per_channel_scale_error": {
-        "channels": 49152,
-        "channel_definition": "(leading index, last axis) pairs: 8 x 6144, 32768 elements each",
-        "alpha_min": 0.01841033930450419,
-        "alpha_median": 0.022658524682175385,
-        "alpha_max": 0.07389202658827633,
-        "relative_error_min": 0.46961685056316743,
-        "relative_error_median": 0.4829285653138257,
-        "relative_error_max": 0.7654989064033166
-      },
-      "effective_tau": 0.9
-    },
-    "block_000.slot_02.moe_expert.up": {
-      "elements": 1610612736,
-      "zeros": 1037831274,
-      "sparsity": 0.6443704627454281,
-      "rms": 0.023556988649650997,
-      "alpha_optimal": 0.034396705025337225,
-      "weight_cosine_similarity": 0.8707550095889084,
-      "weight_reconstruction_mse": 0.00013417456034684003,
-      "weight_nrmse": 0.4917171069586859,
-      "weight_max_absolute_error": 0.4656032949746628,
-      "per_channel_scale_error": {
-        "channels": 262144,
-        "channel_definition": "(leading index, last axis) pairs: 8 x 32768, 6144 elements each",
-        "alpha_min": 0.026669803182221657,
-        "alpha_median": 0.033621509961957834,
-        "alpha_max": 0.1206848401921898,
-        "relative_error_min": 0.3132606326996389,
-        "relative_error_median": 0.48894518830345157,
-        "relative_error_max": 0.7478036794405515
-      },
-      "effective_tau": 0.9
-    },
-    "block_000.slot_03.attn_proj_i8.narrow": {
-      "elements": 6291456,
-      "zeros": 2117334,
-      "sparsity": 0.33654117584228516,
-      "rms": 0.010578140941314469,
-      "alpha_optimal": 0.011270628247707765,
-      "weight_cosine_similarity": 0.8678521892011365,
-      "weight_reconstruction_mse": 2.7619841182005376e-05,
-      "weight_nrmse": 0.4968224810722588,
-      "weight_max_absolute_error": 0.14666546794369847,
-      "per_channel_scale_error": {
-        "channels": 1024,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
-        "alpha_min": 0.006836130454696068,
-        "alpha_median": 0.010566048929377264,
-        "alpha_max": 0.017267009752871754,
-        "relative_error_min": 0.42969516475250813,
-        "relative_error_median": 0.4560618527348418,
-        "relative_error_max": 0.5195065313718404
-      },
-      "effective_tau": 0.4
-    },
-    "block_000.slot_04.attn_proj_i8.model_width": {
-      "elements": 37748736,
-      "zeros": 12596418,
-      "sparsity": 0.3336911201477051,
-      "rms": 0.007302213918588603,
-      "alpha_optimal": 0.00769032174762091,
-      "weight_cosine_similarity": 0.8596620582316677,
-      "weight_reconstruction_mse": 1.3916122278912443e-05,
-      "weight_nrmse": 0.5108631378724569,
-      "weight_max_absolute_error": 0.16381083792034784,
-      "per_channel_scale_error": {
-        "channels": 6144,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
-        "alpha_min": 0.006207052114847544,
-        "alpha_median": 0.007478435324833169,
-        "alpha_max": 0.03994824617600841,
-        "relative_error_min": 0.40419477855512526,
-        "relative_error_median": 0.46801929305190104,
-        "relative_error_max": 0.6438901094327641
-      },
-      "effective_tau": 0.4
-    },
-    "block_000.slot_05.attn_proj_i8.model_width": {
-      "elements": 37748736,
-      "zeros": 12161834,
-      "sparsity": 0.3221785757276747,
-      "rms": 0.0105771638496767,
-      "alpha_optimal": 0.011285860723522544,
-      "weight_cosine_similarity": 0.8784622437138425,
-      "weight_reconstruction_mse": 2.5541838170253586e-05,
-      "weight_nrmse": 0.4778117687638526,
-      "weight_max_absolute_error": 0.1272715733585087,
-      "per_channel_scale_error": {
-        "channels": 6144,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
-        "alpha_min": 0.0069844022693250005,
-        "alpha_median": 0.011054195166908821,
-        "alpha_max": 0.021125657010477607,
-        "relative_error_min": 0.42282016873465333,
-        "relative_error_median": 0.4610193731608061,
-        "relative_error_max": 0.5241617605562177
-      },
-      "effective_tau": 0.4
-    },
-    "block_000.slot_06.attn_proj_i8.narrow": {
-      "elements": 6291456,
-      "zeros": 2047031,
-      "sparsity": 0.3253668149312337,
-      "rms": 0.010577328232367855,
-      "alpha_optimal": 0.011283784705669356,
-      "weight_cosine_similarity": 0.8762189872473086,
-      "weight_reconstruction_mse": 2.5983013638560264e-05,
-      "weight_nrmse": 0.4819131523286129,
-      "weight_max_absolute_error": 0.11128625313612751,
-      "per_channel_scale_error": {
-        "channels": 1024,
-        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
-        "alpha_min": 0.008036103038273021,
-        "alpha_median": 0.010932057911501905,
-        "alpha_max": 0.01778287054721133,
-        "relative_error_min": 0.4296315201504765,
-        "relative_error_median": 0.46042890588686025,
-        "relative_error_max": 0.5166798793234245
-      },
-      "effective_tau": 0.4
-    }
+    "paths_note": "Host-local absolute paths removed for publication; regenerate with BLOCK=<n> MODE=<mode> scripts/block_pilot_goz1.sh (the npy stage is a per-run mktemp directory deleted on exit).",
+    "preserve_tensors": 5,
+    "seed": 20260805,
+    "ternary_scale": "least-squares optimal alpha = sum(|w| fired)/count(fired); GOZ1 v1 stores no scale",
+    "ternary_tensors": 7,
+    "tokens": 4096
   },
   "preserve_fp16_roundtrip": {
     "block_000.slot_07.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0013875961303710938,
-      "relative_rmse": 0.0002078451996099635,
-      "bit_exact": false
+      "relative_rmse": 0.0002078451996099635
     },
     "block_000.slot_08.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0019283294677734375,
-      "relative_rmse": 0.0001965988264285251,
-      "bit_exact": false
+      "relative_rmse": 0.0001965988264285251
     },
     "block_000.slot_09.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0008301734924316406,
-      "relative_rmse": 0.00021666898691768515,
-      "bit_exact": false
+      "relative_rmse": 0.00021666898691768515
     },
     "block_000.slot_10.block_norm": {
+      "bit_exact": false,
       "max_absolute_error": 0.0009748935699462891,
-      "relative_rmse": 0.00020079402752299537,
-      "bit_exact": false
+      "relative_rmse": 0.00020079402752299537
     },
     "block_000.slot_11.router": {
+      "bit_exact": false,
       "max_absolute_error": 6.00963830947876e-05,
-      "relative_rmse": 0.0002092983467282326,
-      "bit_exact": false
+      "relative_rmse": 0.0002092983467282326
     }
   },
+  "produced_by": "grok-ozempic scripts/route_preservation_metrics.py (GH #53 / RM-222)",
   "routing": {
     "block_000.slot_04.attn_proj_i8.model_width": {
-      "tokens": 4096,
-      "router_top1_agreement": 0.686279296875,
-      "router_top2_set_agreement": 0.4423828125,
-      "router_logit_rank_correlation": 0.7739606584821428,
+      "activations": {
+        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
+        "rmsnorm_gain": "block_000.slot_07.block_norm",
+        "rows_sampled": 4096,
+        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
+        "shard_basename": "tensor00000_000",
+        "source": "token_embedding_rows",
+        "vocab_size": 131072
+      },
+      "block_output_cosine": 0.8492034016757434,
+      "block_output_cosine_min": 0.7120308525669509,
+      "block_output_rmse": 0.26373385065945526,
+      "effective_tau": 0.4,
       "expert_load_distribution_delta": 0.140869140625,
       "expert_load_js_divergence": 0.06889692300140215,
-      "expert_load_reference": [
-        0.03076171875,
-        0.15673828125,
-        0.03076171875,
-        0.450927734375,
-        0.012451171875,
-        0.2197265625,
-        0.08935546875,
-        0.00927734375
-      ],
       "expert_load_pilot": [
         0.061279296875,
         0.085205078125,
@@ -362,38 +83,38 @@
         0.1884765625,
         0.051513671875
       ],
-      "block_output_cosine": 0.8492034016757434,
-      "block_output_cosine_min": 0.7120308525669509,
-      "block_output_rmse": 0.26373385065945526,
+      "expert_load_reference": [
+        0.03076171875,
+        0.15673828125,
+        0.03076171875,
+        0.450927734375,
+        0.012451171875,
+        0.2197265625,
+        0.08935546875,
+        0.00927734375
+      ],
       "residual_stream_drift": 0.5341102824225851,
-      "activations": {
-        "source": "token_embedding_rows",
-        "vocab_size": 131072,
-        "rows_sampled": 4096,
-        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
-        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
-        "rmsnorm_gain": "block_000.slot_07.block_norm",
-        "shard_basename": "tensor00000_000"
-      },
-      "effective_tau": 0.4
+      "router_logit_rank_correlation": 0.7739606584821428,
+      "router_top1_agreement": 0.686279296875,
+      "router_top2_set_agreement": 0.4423828125,
+      "tokens": 4096
     },
     "block_000.slot_05.attn_proj_i8.model_width": {
-      "tokens": 4096,
-      "router_top1_agreement": 0.6396484375,
-      "router_top2_set_agreement": 0.421142578125,
-      "router_logit_rank_correlation": 0.7528366815476191,
+      "activations": {
+        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
+        "rmsnorm_gain": "block_000.slot_07.block_norm",
+        "rows_sampled": 4096,
+        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
+        "shard_basename": "tensor00000_000",
+        "source": "token_embedding_rows",
+        "vocab_size": 131072
+      },
+      "block_output_cosine": 0.9630472132115836,
+      "block_output_cosine_min": 0.938282154715757,
+      "block_output_rmse": 0.7658854546679026,
+      "effective_tau": 0.4,
       "expert_load_distribution_delta": 0.24853515625,
       "expert_load_js_divergence": 0.11021330045422195,
-      "expert_load_reference": [
-        0.46337890625,
-        0.0,
-        0.0,
-        0.44873046875,
-        0.04736328125,
-        0.038330078125,
-        0.002197265625,
-        0.0
-      ],
       "expert_load_pilot": [
         0.42724609375,
         0.000244140625,
@@ -404,20 +125,299 @@
         0.000732421875,
         0.0
       ],
-      "block_output_cosine": 0.9630472132115836,
-      "block_output_cosine_min": 0.938282154715757,
-      "block_output_rmse": 0.7658854546679026,
+      "expert_load_reference": [
+        0.46337890625,
+        0.0,
+        0.0,
+        0.44873046875,
+        0.04736328125,
+        0.038330078125,
+        0.002197265625,
+        0.0
+      ],
       "residual_stream_drift": 0.3356917020354853,
-      "activations": {
-        "source": "token_embedding_rows",
-        "vocab_size": 131072,
-        "rows_sampled": 4096,
-        "sampling": "uniform over vocab without replacement (no corpus token frequencies)",
-        "detail": "block 0's attention input is rmsnorm(embedding lookup), so these are real activations for this block rather than a synthetic distribution",
-        "rmsnorm_gain": "block_000.slot_07.block_norm",
-        "shard_basename": "tensor00000_000"
+      "router_logit_rank_correlation": 0.7528366815476191,
+      "router_top1_agreement": 0.6396484375,
+      "router_top2_set_agreement": 0.421142578125,
+      "tokens": 4096
+    }
+  },
+  "summary": [
+    {
+      "detail": "Worst case over evaluated d_model x d_model projections; router read from the pack (fp16 preserve tier).",
+      "name": "router_top1_agreement",
+      "observed": 0.6396484375,
+      "scope": "router_behavior",
+      "status": "fail",
+      "threshold": ">= 99.0%"
+    },
+    {
+      "detail": "Fraction of tokens whose unordered top-2 expert set is unchanged.",
+      "name": "router_top2_set_agreement",
+      "observed": 0.421142578125,
+      "scope": "router_behavior",
+      "status": "fail",
+      "threshold": ">= 99.5%"
+    },
+    {
+      "detail": "Max per-expert share change in the top-1 load histogram.",
+      "name": "expert_load_distribution_delta",
+      "observed": 0.24853515625,
+      "scope": "router_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Jensen-Shannon divergence (bits) between reference and pilot expert-load distributions.",
+      "name": "expert_load_js_divergence",
+      "observed": 0.11021330045422195,
+      "scope": "router_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Mean per-token Spearman correlation over the router logits.",
+      "name": "router_logit_rank_correlation",
+      "observed": 0.7528366815476191,
+      "scope": "router_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Scoped to the quantized projection output, not a full block forward (attention roles are unassigned upstream; MoE not executed).",
+      "name": "block_output_cosine",
+      "observed": 0.8492034016757434,
+      "scope": "block_behavior",
+      "status": "fail",
+      "threshold": ">= 0.995"
+    },
+    {
+      "detail": "RMSE of the projection output against the f32 reference path.",
+      "name": "block_output_rmse",
+      "observed": 0.7658854546679026,
+      "scope": "block_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Projection-output RMSE normalized by reference output RMS.",
+      "name": "residual_stream_drift",
+      "observed": 0.5341102824225851,
+      "scope": "block_behavior",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Worst quantized tensor, at the least-squares optimal ternary scale.",
+      "name": "weight_reconstruction_mse",
+      "observed": 0.0001426260740471938,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Worst quantized tensor; independent of the chosen ternary scale.",
+      "name": "weight_cosine_similarity",
+      "observed": 0.8596620582316677,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Exact max |w - alpha*t| over all quantized tensors.",
+      "name": "weight_max_absolute_error",
+      "observed": 0.7098091729063252,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Worst per-output-channel relative reconstruction error; full per-tensor spread under `weights`.",
+      "name": "per_channel_scale_error_summary",
+      "observed": 0.7654989064033166,
+      "scope": "weight_reconstruction",
+      "status": "measured",
+      "threshold": null
+    },
+    {
+      "detail": "Requires whole-model inference; out of scope for a bounded single-block pilot (#53 non-goal).",
+      "name": "logit_kl",
+      "observed": null,
+      "scope": "model_behavior",
+      "status": "unknown",
+      "threshold": null
+    },
+    {
+      "detail": "Requires a calibration corpus and whole-model inference; not run.",
+      "name": "perplexity_delta",
+      "observed": null,
+      "scope": "model_behavior",
+      "status": "unknown",
+      "threshold": null
+    },
+    {
+      "detail": "Requires whole-model inference; not run.",
+      "name": "generation_sanity_summary",
+      "observed": null,
+      "scope": "model_behavior",
+      "status": "unknown",
+      "threshold": null
+    }
+  ],
+  "weights": {
+    "block_000.slot_00.moe_expert.gate": {
+      "alpha_optimal": 0.03446429262403113,
+      "effective_tau": 0.9,
+      "elements": 1610612736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.0870242716704669,
+        "alpha_median": 0.03403930523622656,
+        "alpha_min": 0.028118791881937995,
+        "channel_definition": "(leading index, last axis) pairs: 8 x 32768, 6144 elements each",
+        "channels": 262144,
+        "relative_error_max": 0.6629830233906198,
+        "relative_error_median": 0.49800192292541123,
+        "relative_error_min": 0.3634878046928346
       },
-      "effective_tau": 0.4
+      "rms": 0.023557757634404944,
+      "sparsity": 0.6528487776716551,
+      "weight_cosine_similarity": 0.8619751964369022,
+      "weight_max_absolute_error": 0.3879905413603439,
+      "weight_nrmse": 0.5069504519453197,
+      "weight_reconstruction_mse": 0.0001426260740471938,
+      "zeros": 1051486556
+    },
+    "block_000.slot_01.moe_expert.down": {
+      "alpha_optimal": 0.022704254828049837,
+      "effective_tau": 0.9,
+      "elements": 1610612736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.07389202658827633,
+        "alpha_median": 0.022658524682175385,
+        "alpha_min": 0.01841033930450419,
+        "channel_definition": "(leading index, last axis) pairs: 8 x 6144, 32768 elements each",
+        "channels": 49152,
+        "relative_error_max": 0.7654989064033166,
+        "relative_error_median": 0.4829285653138257,
+        "relative_error_min": 0.46961685056316743
+      },
+      "rms": 0.015693050566611258,
+      "sparsity": 0.6372781544923782,
+      "weight_cosine_similarity": 0.8713381608146713,
+      "weight_max_absolute_error": 0.7098091729063252,
+      "weight_nrmse": 0.49068300307643237,
+      "weight_reconstruction_mse": 5.9294823061690226e-05,
+      "zeros": 1026408312
+    },
+    "block_000.slot_02.moe_expert.up": {
+      "alpha_optimal": 0.034396705025337225,
+      "effective_tau": 0.9,
+      "elements": 1610612736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.1206848401921898,
+        "alpha_median": 0.033621509961957834,
+        "alpha_min": 0.026669803182221657,
+        "channel_definition": "(leading index, last axis) pairs: 8 x 32768, 6144 elements each",
+        "channels": 262144,
+        "relative_error_max": 0.7478036794405515,
+        "relative_error_median": 0.48894518830345157,
+        "relative_error_min": 0.3132606326996389
+      },
+      "rms": 0.023556988649650997,
+      "sparsity": 0.6443704627454281,
+      "weight_cosine_similarity": 0.8707550095889084,
+      "weight_max_absolute_error": 0.4656032949746628,
+      "weight_nrmse": 0.4917171069586859,
+      "weight_reconstruction_mse": 0.00013417456034684003,
+      "zeros": 1037831274
+    },
+    "block_000.slot_03.attn_proj_i8.narrow": {
+      "alpha_optimal": 0.011270628247707765,
+      "effective_tau": 0.4,
+      "elements": 6291456,
+      "per_channel_scale_error": {
+        "alpha_max": 0.017267009752871754,
+        "alpha_median": 0.010566048929377264,
+        "alpha_min": 0.006836130454696068,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
+        "channels": 1024,
+        "relative_error_max": 0.5195065313718404,
+        "relative_error_median": 0.4560618527348418,
+        "relative_error_min": 0.42969516475250813
+      },
+      "rms": 0.010578140941314469,
+      "sparsity": 0.33654117584228516,
+      "weight_cosine_similarity": 0.8678521892011365,
+      "weight_max_absolute_error": 0.14666546794369847,
+      "weight_nrmse": 0.4968224810722588,
+      "weight_reconstruction_mse": 2.7619841182005376e-05,
+      "zeros": 2117334
+    },
+    "block_000.slot_04.attn_proj_i8.model_width": {
+      "alpha_optimal": 0.00769032174762091,
+      "effective_tau": 0.4,
+      "elements": 37748736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.03994824617600841,
+        "alpha_median": 0.007478435324833169,
+        "alpha_min": 0.006207052114847544,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
+        "channels": 6144,
+        "relative_error_max": 0.6438901094327641,
+        "relative_error_median": 0.46801929305190104,
+        "relative_error_min": 0.40419477855512526
+      },
+      "rms": 0.007302213918588603,
+      "sparsity": 0.3336911201477051,
+      "weight_cosine_similarity": 0.8596620582316677,
+      "weight_max_absolute_error": 0.16381083792034784,
+      "weight_nrmse": 0.5108631378724569,
+      "weight_reconstruction_mse": 1.3916122278912443e-05,
+      "zeros": 12596418
+    },
+    "block_000.slot_05.attn_proj_i8.model_width": {
+      "alpha_optimal": 0.011285860723522544,
+      "effective_tau": 0.4,
+      "elements": 37748736,
+      "per_channel_scale_error": {
+        "alpha_max": 0.021125657010477607,
+        "alpha_median": 0.011054195166908821,
+        "alpha_min": 0.0069844022693250005,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 6144, 6144 elements each",
+        "channels": 6144,
+        "relative_error_max": 0.5241617605562177,
+        "relative_error_median": 0.4610193731608061,
+        "relative_error_min": 0.42282016873465333
+      },
+      "rms": 0.0105771638496767,
+      "sparsity": 0.3221785757276747,
+      "weight_cosine_similarity": 0.8784622437138425,
+      "weight_max_absolute_error": 0.1272715733585087,
+      "weight_nrmse": 0.4778117687638526,
+      "weight_reconstruction_mse": 2.5541838170253586e-05,
+      "zeros": 12161834
+    },
+    "block_000.slot_06.attn_proj_i8.narrow": {
+      "alpha_optimal": 0.011283784705669356,
+      "effective_tau": 0.4,
+      "elements": 6291456,
+      "per_channel_scale_error": {
+        "alpha_max": 0.01778287054721133,
+        "alpha_median": 0.010932057911501905,
+        "alpha_min": 0.008036103038273021,
+        "channel_definition": "(leading index, last axis) pairs: 1 x 1024, 6144 elements each",
+        "channels": 1024,
+        "relative_error_max": 0.5166798793234245,
+        "relative_error_median": 0.46042890588686025,
+        "relative_error_min": 0.4296315201504765
+      },
+      "rms": 0.010577328232367855,
+      "sparsity": 0.3253668149312337,
+      "weight_cosine_similarity": 0.8762189872473086,
+      "weight_max_absolute_error": 0.11128625313612751,
+      "weight_nrmse": 0.4819131523286129,
+      "weight_reconstruction_mse": 2.5983013638560264e-05,
+      "zeros": 2047031
     }
   }
 }

--- a/reports/grok-1-expert-only-multiblock/metrics.json
+++ b/reports/grok-1-expert-only-multiblock/metrics.json
@@ -1,42 +1,4 @@
 {
-  "provenance": {
-    "issue": "GH #68 / Linear RM-255",
-    "agent": "Grok Build: Grok 4.5 (xAI) \u00b7 Model: grok-4.5 \u00b7 Issue: #68 / Linear RM-255 \u00b7 beads goz-vvgm5z",
-    "model": "grok-4.5",
-    "design": "Grok Build super-research design (sequential chain, pack-only v3)",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "agent_measurement": "Claude Code: Fable 5",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      },
-      "fp16_control": {
-        "block_output_cosine": 0.999987,
-        "router_top1_agreement": 0.99707,
-        "router_top2_set_agreement": 0.999023
-      }
-    },
-    "implementation": {
-      "commit": "a829f4bd45497dccb5dae511fc38bfbd52cd03e1",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residual trajectories; block0=embed*EMBEDDING_MULTIPLIER; no Gaussian; no embedding rows for b!=0",
-    "ternary_policy": "experts only; attention/routers/norms high precision",
-    "scale_policy": "GOZ1 v3 pack-only; abort on legacy_oracle",
-    "metrics_note": "Numeric chain metrics from the original 2048-token decision run; end_of_chain keys and decision rationale re-derived under the review-hardened harness (chain_exit residual naming + FP16 gates). Host paths stored as basenames only."
-  },
   "chain": {
     "blocks": [
       0,
@@ -44,876 +6,24 @@
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 22.509279012680054,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 32.48499941825867,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.7734826618659498,
-          "block_output_cosine": 0.9635717953874715,
-          "block_output_cosine_per_token": 0.9610040055361724,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.2773508234849458,
-          "attn_delta_over_stream": 0.876171414302045,
-          "moe_delta_over_stream": 0.5761949397414952,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030204767217204893,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.006170911132304002,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 26.696443557739258,
-          "attention_output_cosine": 0.9999999984424572,
-          "attention_output_cosine_per_token": 0.9999999986030829,
-          "residual_stream_cosine": 0.9999999831365632,
-          "moe_input_normalized_cosine": 0.9999999606124855,
-          "router_logit_cosine": 0.9999999971511485,
-          "moe_output_cosine": 0.9999813002410165,
-          "block_output_cosine": 0.9999870040318545,
-          "block_output_cosine_per_token": 0.9999880581321908,
-          "residual_drift_relative_norm": 0.00021537234101925558,
-          "block_output_drift_relative_norm": 0.005098830221729304,
-          "attn_delta_over_stream": 0.8760054853350859,
-          "moe_delta_over_stream": 0.482784499720899,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030207654444896787,
-          "router_margin_mean_delta": 2.8872276918900968e-06,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.0061808020273402264,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        }
-      },
-      {
-        "block": 1,
-        "reference_seconds": 21.940149307250977,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 35.479469537734985,
-          "attention_output_cosine": 0.9451666095439264,
-          "attention_output_cosine_per_token": 0.9468242743871829,
-          "residual_stream_cosine": 0.9687463905726936,
-          "moe_input_normalized_cosine": 0.949999970457743,
-          "router_logit_cosine": 0.9938496092111954,
-          "moe_output_cosine": 0.6760987510545793,
-          "block_output_cosine": 0.9457649757080199,
-          "block_output_cosine_per_token": 0.9435165184130898,
-          "residual_drift_relative_norm": 0.2568268586347572,
-          "block_output_drift_relative_norm": 0.3419351871629902,
-          "attn_delta_over_stream": 0.37358909903748555,
-          "moe_delta_over_stream": 0.36501880457430963,
-          "router_top1_agreement": 0.8876953125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.6806640625,
-          "router_top2_set_agreement": 0.6806640625,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.171875,
-            0.1142578125,
-            0.118408203125,
-            0.0625,
-            0.12744140625,
-            0.19775390625,
-            0.097412109375,
-            0.1103515625
-          ],
-          "expert_load_js_bits": 0.005558745183592211,
-          "expert_load_max_abs_delta": 0.03955078125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.195868570026339,
-          "router_margin_mean_delta": 0.012919048645340278,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.16081369486833108,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 49,
-              "top1_flip_rate": 0.5104166666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 114,
-              "top1_flip_rate": 0.35403726708074534
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 57,
-              "top1_flip_rate": 0.09612141652613827
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 10,
-              "top1_flip_rate": 0.01040582726326743
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9635717953874715,
-            "residual_in_drift_relative_norm": 0.2773508234849458
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 25.522230863571167,
-          "attention_output_cosine": 0.9999955239311591,
-          "attention_output_cosine_per_token": 0.9999949975985942,
-          "residual_stream_cosine": 0.9999902372591066,
-          "moe_input_normalized_cosine": 0.9999833030390249,
-          "router_logit_cosine": 0.9999982162936869,
-          "moe_output_cosine": 0.9999664606659787,
-          "block_output_cosine": 0.9999859463222839,
-          "block_output_cosine_per_token": 0.9999851320664912,
-          "residual_drift_relative_norm": 0.0044204095195649025,
-          "block_output_drift_relative_norm": 0.005302552236880725,
-          "attn_delta_over_stream": 0.3961794228342294,
-          "moe_delta_over_stream": 0.2896839054949744,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18297782060234993,
-          "router_margin_mean_delta": 2.8299221351235133e-05,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15256866411484876,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040318545,
-            "residual_in_drift_relative_norm": 0.005098830221729304
-          }
-        }
-      },
-      {
-        "block": 2,
-        "reference_seconds": 21.12557363510132,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 32.423715114593506,
-          "attention_output_cosine": 0.8463850208729656,
-          "attention_output_cosine_per_token": 0.8463833787171269,
-          "residual_stream_cosine": 0.94602094245887,
-          "moe_input_normalized_cosine": 0.8805220539144903,
-          "router_logit_cosine": 0.9850696090591446,
-          "moe_output_cosine": 0.5554677289227715,
-          "block_output_cosine": 0.8849563895413532,
-          "block_output_cosine_per_token": 0.8843057686973383,
-          "residual_drift_relative_norm": 0.34089289777264364,
-          "block_output_drift_relative_norm": 0.4983081493750823,
-          "attn_delta_over_stream": 0.6052562600183821,
-          "moe_delta_over_stream": 0.49054008195221765,
-          "router_top1_agreement": 0.66650390625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.548828125,
-          "router_top2_set_agreement": 0.548828125,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.059326171875,
-            0.11962890625,
-            0.082275390625,
-            0.28466796875,
-            0.04931640625,
-            0.0703125,
-            0.11279296875,
-            0.2216796875
-          ],
-          "expert_load_js_bits": 0.009346989149893015,
-          "expert_load_max_abs_delta": 0.059814453125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03512862301068634,
-          "router_margin_mean_delta": -0.0006863225563370202,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025580163745612103,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 260,
-              "top1_flip_rate": 0.5652173913043478
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 375,
-              "top1_flip_rate": 0.35545023696682465
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 48,
-              "top1_flip_rate": 0.0935672514619883
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9457649757080199,
-            "residual_in_drift_relative_norm": 0.3419351871629902
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 23.63537621498108,
-          "attention_output_cosine": 0.9999951789408488,
-          "attention_output_cosine_per_token": 0.9999948156177104,
-          "residual_stream_cosine": 0.999991030697749,
-          "moe_input_normalized_cosine": 0.9999805357628218,
-          "router_logit_cosine": 0.99999830045166,
-          "moe_output_cosine": 0.9998240608794524,
-          "block_output_cosine": 0.9999682697724989,
-          "block_output_cosine_per_token": 0.9999678107548897,
-          "residual_drift_relative_norm": 0.004235465975258782,
-          "block_output_drift_relative_norm": 0.007966186310686194,
-          "attn_delta_over_stream": 0.584956965059082,
-          "moe_delta_over_stream": 0.4112808355956077,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03582240155308043,
-          "router_margin_mean_delta": 7.4559860570678075e-06,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025836218008428474,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463222839,
-            "residual_in_drift_relative_norm": 0.005302552236880725
-          }
-        }
-      },
-      {
-        "block": 3,
-        "reference_seconds": 18.186565160751343,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 32.569278717041016,
-          "attention_output_cosine": 0.7487876815565065,
-          "attention_output_cosine_per_token": 0.7479570726776106,
-          "residual_stream_cosine": 0.9090301495788085,
-          "moe_input_normalized_cosine": 0.7301063140660665,
-          "router_logit_cosine": 0.9906749555170711,
-          "moe_output_cosine": 0.46845028315780785,
-          "block_output_cosine": 0.8391436864849655,
-          "block_output_cosine_per_token": 0.8388874485622377,
-          "residual_drift_relative_norm": 0.4501339157711618,
-          "block_output_drift_relative_norm": 0.6538863846584987,
-          "attn_delta_over_stream": 0.5179399263712111,
-          "moe_delta_over_stream": 0.40142055735129356,
-          "router_top1_agreement": 0.5283203125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.28955078125,
-          "router_top2_set_agreement": 0.28955078125,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0498046875,
-            0.1162109375,
-            0.0712890625,
-            0.1787109375,
-            0.336669921875,
-            0.015869140625,
-            0.10205078125,
-            0.12939453125
-          ],
-          "expert_load_js_bits": 0.024023367865451135,
-          "expert_load_max_abs_delta": 0.092041015625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.03817417452748727,
-          "router_margin_mean_delta": -0.005893638437747729,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.02537104014453366,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 293,
-              "top1_flip_rate": 0.6959619952494062
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 527,
-              "top1_flip_rate": 0.5334008097165992
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 144,
-              "top1_flip_rate": 0.2535211267605634
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 2,
-              "top1_flip_rate": 0.028169014084507043
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.8849563895413532,
-            "residual_in_drift_relative_norm": 0.4983081493750823
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 24.126708030700684,
-          "attention_output_cosine": 0.999967551568842,
-          "attention_output_cosine_per_token": 0.9999677009593164,
-          "residual_stream_cosine": 0.9999786349806121,
-          "moe_input_normalized_cosine": 0.9999317807120685,
-          "router_logit_cosine": 0.9999963366294831,
-          "moe_output_cosine": 0.9996961823732479,
-          "block_output_cosine": 0.9999195401900538,
-          "block_output_cosine_per_token": 0.9999220112059125,
-          "residual_drift_relative_norm": 0.006536817583550683,
-          "block_output_drift_relative_norm": 0.012685837908964355,
-          "attn_delta_over_stream": 0.5008011118859926,
-          "moe_delta_over_stream": 0.35685089524601604,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.04404335021260723,
-          "router_margin_mean_delta": -2.446275262776493e-05,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.029497699031347163,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697724989,
-            "residual_in_drift_relative_norm": 0.007966186310686194
-          }
-        }
-      }
-    ],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.8391436864849655,
-        "residual_drift_relative_norm": 0.6538863846584987,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.6538863846584987
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401900538,
-        "residual_drift_relative_norm": 0.012685837908964355,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685837908964355
       }
     },
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -944,47 +54,47 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1015,47 +125,47 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1086,47 +196,47 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1157,17 +267,870 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171414302045,
+          "block_output_cosine": 0.9635717953874715,
+          "block_output_cosine_per_token": 0.9610040055361724,
+          "block_output_drift_relative_norm": 0.2773508234849458,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.5761949397414952,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.7734826618659498,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204767217204893,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.006170911132304002,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 32.48499941825867,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984424572,
+          "attention_output_cosine_per_token": 0.9999999986030829,
+          "attn_delta_over_stream": 0.8760054853350859,
+          "block_output_cosine": 0.9999870040318545,
+          "block_output_cosine_per_token": 0.9999880581321908,
+          "block_output_drift_relative_norm": 0.005098830221729304,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.482784499720899,
+          "moe_input_normalized_cosine": 0.9999999606124855,
+          "moe_output_cosine": 0.9999813002410165,
+          "residual_drift_relative_norm": 0.00021537234101925558,
+          "residual_stream_cosine": 0.9999999831365632,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971511485,
+          "router_margin_mean_delta": 2.8872276918900968e-06,
+          "router_margin_mean_observed": 0.030207654444896787,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.0061808020273402264,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 26.696443557739258,
+          "selected_experts": 2
+        },
+        "reference_seconds": 22.509279012680054
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9451666095439264,
+          "attention_output_cosine_per_token": 0.9468242743871829,
+          "attn_delta_over_stream": 0.37358909903748555,
+          "block_output_cosine": 0.9457649757080199,
+          "block_output_cosine_per_token": 0.9435165184130898,
+          "block_output_drift_relative_norm": 0.3419351871629902,
+          "expert_load_js_bits": 0.005558745183592211,
+          "expert_load_max_abs_delta": 0.03955078125,
+          "expert_load_observed": [
+            0.171875,
+            0.1142578125,
+            0.118408203125,
+            0.0625,
+            0.12744140625,
+            0.19775390625,
+            0.097412109375,
+            0.1103515625
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.5104166666666666,
+              "top1_flips": 49
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.35403726708074534,
+              "top1_flips": 114
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.09612141652613827,
+              "top1_flips": 57
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.01040582726326743,
+              "top1_flips": 10
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.36501880457430963,
+          "moe_input_normalized_cosine": 0.949999970457743,
+          "moe_output_cosine": 0.6760987510545793,
+          "residual_drift_relative_norm": 0.2568268586347572,
+          "residual_stream_cosine": 0.9687463905726936,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9635717953874715,
+            "residual_in_drift_relative_norm": 0.2773508234849458
+          },
+          "router_logit_cosine": 0.9938496092111954,
+          "router_margin_mean_delta": 0.012919048645340278,
+          "router_margin_mean_observed": 0.195868570026339,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.16081369486833108,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.8876953125,
+          "router_top2_set_agreement": 0.6806640625,
+          "router_topk_set_agreement": 0.6806640625,
+          "seconds": 35.479469537734985,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239311591,
+          "attention_output_cosine_per_token": 0.9999949975985942,
+          "attn_delta_over_stream": 0.3961794228342294,
+          "block_output_cosine": 0.9999859463222839,
+          "block_output_cosine_per_token": 0.9999851320664912,
+          "block_output_drift_relative_norm": 0.005302552236880725,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839054949744,
+          "moe_input_normalized_cosine": 0.9999833030390249,
+          "moe_output_cosine": 0.9999664606659787,
+          "residual_drift_relative_norm": 0.0044204095195649025,
+          "residual_stream_cosine": 0.9999902372591066,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040318545,
+            "residual_in_drift_relative_norm": 0.005098830221729304
+          },
+          "router_logit_cosine": 0.9999982162936869,
+          "router_margin_mean_delta": 2.8299221351235133e-05,
+          "router_margin_mean_observed": 0.18297782060234993,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15256866411484876,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 25.522230863571167,
+          "selected_experts": 2
+        },
+        "reference_seconds": 21.940149307250977
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.8463850208729656,
+          "attention_output_cosine_per_token": 0.8463833787171269,
+          "attn_delta_over_stream": 0.6052562600183821,
+          "block_output_cosine": 0.8849563895413532,
+          "block_output_cosine_per_token": 0.8843057686973383,
+          "block_output_drift_relative_norm": 0.4983081493750823,
+          "expert_load_js_bits": 0.009346989149893015,
+          "expert_load_max_abs_delta": 0.059814453125,
+          "expert_load_observed": [
+            0.059326171875,
+            0.11962890625,
+            0.082275390625,
+            0.28466796875,
+            0.04931640625,
+            0.0703125,
+            0.11279296875,
+            0.2216796875
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.5652173913043478,
+              "top1_flips": 260
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.35545023696682465,
+              "top1_flips": 375
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0935672514619883,
+              "top1_flips": 48
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.49054008195221765,
+          "moe_input_normalized_cosine": 0.8805220539144903,
+          "moe_output_cosine": 0.5554677289227715,
+          "residual_drift_relative_norm": 0.34089289777264364,
+          "residual_stream_cosine": 0.94602094245887,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9457649757080199,
+            "residual_in_drift_relative_norm": 0.3419351871629902
+          },
+          "router_logit_cosine": 0.9850696090591446,
+          "router_margin_mean_delta": -0.0006863225563370202,
+          "router_margin_mean_observed": 0.03512862301068634,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025580163745612103,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.66650390625,
+          "router_top2_set_agreement": 0.548828125,
+          "router_topk_set_agreement": 0.548828125,
+          "seconds": 32.423715114593506,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789408488,
+          "attention_output_cosine_per_token": 0.9999948156177104,
+          "attn_delta_over_stream": 0.584956965059082,
+          "block_output_cosine": 0.9999682697724989,
+          "block_output_cosine_per_token": 0.9999678107548897,
+          "block_output_drift_relative_norm": 0.007966186310686194,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808355956077,
+          "moe_input_normalized_cosine": 0.9999805357628218,
+          "moe_output_cosine": 0.9998240608794524,
+          "residual_drift_relative_norm": 0.004235465975258782,
+          "residual_stream_cosine": 0.999991030697749,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463222839,
+            "residual_in_drift_relative_norm": 0.005302552236880725
+          },
+          "router_logit_cosine": 0.99999830045166,
+          "router_margin_mean_delta": 7.4559860570678075e-06,
+          "router_margin_mean_observed": 0.03582240155308043,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025836218008428474,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 23.63537621498108,
+          "selected_experts": 2
+        },
+        "reference_seconds": 21.12557363510132
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.7487876815565065,
+          "attention_output_cosine_per_token": 0.7479570726776106,
+          "attn_delta_over_stream": 0.5179399263712111,
+          "block_output_cosine": 0.8391436864849655,
+          "block_output_cosine_per_token": 0.8388874485622377,
+          "block_output_drift_relative_norm": 0.6538863846584987,
+          "expert_load_js_bits": 0.024023367865451135,
+          "expert_load_max_abs_delta": 0.092041015625,
+          "expert_load_observed": [
+            0.0498046875,
+            0.1162109375,
+            0.0712890625,
+            0.1787109375,
+            0.336669921875,
+            0.015869140625,
+            0.10205078125,
+            0.12939453125
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.6959619952494062,
+              "top1_flips": 293
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.5334008097165992,
+              "top1_flips": 527
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.2535211267605634,
+              "top1_flips": 144
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.028169014084507043,
+              "top1_flips": 2
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.40142055735129356,
+          "moe_input_normalized_cosine": 0.7301063140660665,
+          "moe_output_cosine": 0.46845028315780785,
+          "residual_drift_relative_norm": 0.4501339157711618,
+          "residual_stream_cosine": 0.9090301495788085,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.8849563895413532,
+            "residual_in_drift_relative_norm": 0.4983081493750823
+          },
+          "router_logit_cosine": 0.9906749555170711,
+          "router_margin_mean_delta": -0.005893638437747729,
+          "router_margin_mean_observed": 0.03817417452748727,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.02537104014453366,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.5283203125,
+          "router_top2_set_agreement": 0.28955078125,
+          "router_topk_set_agreement": 0.28955078125,
+          "seconds": 32.569278717041016,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.999967551568842,
+          "attention_output_cosine_per_token": 0.9999677009593164,
+          "attn_delta_over_stream": 0.5008011118859926,
+          "block_output_cosine": 0.9999195401900538,
+          "block_output_cosine_per_token": 0.9999220112059125,
+          "block_output_drift_relative_norm": 0.012685837908964355,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.35685089524601604,
+          "moe_input_normalized_cosine": 0.9999317807120685,
+          "moe_output_cosine": 0.9996961823732479,
+          "residual_drift_relative_norm": 0.006536817583550683,
+          "residual_stream_cosine": 0.9999786349806121,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697724989,
+            "residual_in_drift_relative_norm": 0.007966186310686194
+          },
+          "router_logit_cosine": 0.9999963366294831,
+          "router_margin_mean_delta": -2.446275262776493e-05,
+          "router_margin_mean_observed": 0.04404335021260723,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.029497699031347163,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 24.126708030700684,
+          "selected_experts": 2
+        },
+        "reference_seconds": 18.186565160751343
+      }
+    ],
+    "skip_fp16_control": false,
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
   },
   "decision": {
+    "compounding": "roughly_linear",
     "decision": 3,
     "decision_text": "Expert tier needs higher precision than single-scale ternary for multi-block (material residual / routing degradation across the chain).",
     "rationale": [
@@ -1182,7 +1145,44 @@
       "last_block_residual_in_drift=0.4983081493750823",
       "chain_exit_residual_drift=0.6538863846584987",
       "#64 block0 expert-only block_output_cosine baseline=0.963572"
-    ],
-    "compounding": "roughly_linear"
+    ]
+  },
+  "provenance": {
+    "activation_policy": "paired residual trajectories; block0=embed*EMBEDDING_MULTIPLIER; no Gaussian; no embedding rows for b!=0",
+    "agent": "Grok Build: Grok 4.5 (xAI) \u00b7 Model: grok-4.5 \u00b7 Issue: #68 / Linear RM-255 \u00b7 beads goz-vvgm5z",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "baseline_64": {
+      "agent_measurement": "Claude Code: Fable 5",
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "fp16_control": {
+        "block_output_cosine": 0.999987,
+        "router_top1_agreement": 0.99707,
+        "router_top2_set_agreement": 0.999023
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "design": "Grok Build super-research design (sequential chain, pack-only v3)",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "implementation": {
+      "commit": "a829f4bd45497dccb5dae511fc38bfbd52cd03e1",
+      "dirty": false
+    },
+    "issue": "GH #68 / Linear RM-255",
+    "metrics_note": "Numeric chain metrics from the original 2048-token decision run; end_of_chain keys and decision rationale re-derived under the review-hardened harness (chain_exit residual naming + FP16 gates). Host paths stored as basenames only.",
+    "model": "grok-4.5",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "GOZ1 v3 pack-only; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v2/hp-ceiling/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v2/hp-ceiling/metrics.json
@@ -1,1033 +1,41 @@
 {
-  "provenance": {
-    "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
-    "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
-    "model": "GPT-5.6 Sol (xhigh)",
-    "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "implementation": {
-      "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.4.6",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-    "arm": "hp_ceiling",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-    "evidence_role": "secondary; no independent decision"
-  },
   "chain": {
+    "arm_label": "expert_hp_ceiling",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 19.067675828933716,
-        "expert_only": {
-          "label": "expert_hp_ceiling",
-          "seconds": 31.015775203704834,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.9999999941389839,
-          "block_output_cosine": 0.9999999987176428,
-          "block_output_cosine_per_token": 0.9999999986849318,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 5.0647684479044405e-05,
-          "attn_delta_over_stream": 0.876171419076819,
-          "moe_delta_over_stream": 0.4827432384719955,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204764995743812,
-          "router_margin_mean_observed": 0.030204764995743812,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170867767470903,
-          "router_margin_median_observed": 0.006170867767470903,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 21.891437768936157,
-          "attention_output_cosine": 0.9999999984425272,
-          "attention_output_cosine_per_token": 0.9999999986030998,
-          "residual_stream_cosine": 0.9999999831366344,
-          "moe_input_normalized_cosine": 0.9999999606112848,
-          "router_logit_cosine": 0.9999999971505857,
-          "moe_output_cosine": 0.9999813002301362,
-          "block_output_cosine": 0.9999870040322685,
-          "block_output_cosine_per_token": 0.9999880581319095,
-          "residual_drift_relative_norm": 0.00021537206570514935,
-          "block_output_drift_relative_norm": 0.005098830132430907,
-          "attn_delta_over_stream": 0.8760054891005306,
-          "moe_delta_over_stream": 0.4827844972000442,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204764995743812,
-          "router_margin_mean_observed": 0.03020765553259007,
-          "router_margin_mean_delta": 2.8905368462560425e-06,
-          "router_margin_median_reference": 0.006170867767470903,
-          "router_margin_median_observed": 0.006180739225395249,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "expert_hp_ceiling"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 20.357039213180542,
-        "expert_only": {
-          "label": "expert_hp_ceiling",
-          "seconds": 26.211087226867676,
-          "attention_output_cosine": 0.9999999994946557,
-          "attention_output_cosine_per_token": 0.9999999995122413,
-          "residual_stream_cosine": 0.9999999990198687,
-          "moe_input_normalized_cosine": 0.9999999982554377,
-          "router_logit_cosine": 0.9999999998249586,
-          "moe_output_cosine": 0.9999911806399926,
-          "block_output_cosine": 0.9999973569164325,
-          "block_output_cosine_per_token": 0.999997468422053,
-          "residual_drift_relative_norm": 4.428102064805694e-05,
-          "block_output_drift_relative_norm": 0.0022991889781694423,
-          "attn_delta_over_stream": 0.3961665999906308,
-          "moe_delta_over_stream": 0.2896296326293033,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 1.476654090930979e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495230124742,
-          "router_margin_mean_observed": 0.1829498613523623,
-          "router_margin_mean_delta": 3.383398881246126e-07,
-          "router_margin_median_reference": 0.15255130555045132,
-          "router_margin_median_observed": 0.15255614636969325,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999999987176428,
-            "residual_in_drift_relative_norm": 5.0647684479044405e-05
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 25.633192539215088,
-          "attention_output_cosine": 0.9999955239221966,
-          "attention_output_cosine_per_token": 0.9999949975916551,
-          "residual_stream_cosine": 0.9999902372606576,
-          "moe_input_normalized_cosine": 0.9999833030380135,
-          "router_logit_cosine": 0.9999982162936379,
-          "moe_output_cosine": 0.999966460633255,
-          "block_output_cosine": 0.9999859463229576,
-          "block_output_cosine_per_token": 0.9999851320664717,
-          "residual_drift_relative_norm": 0.004420409079612701,
-          "block_output_drift_relative_norm": 0.005302552089727011,
-          "attn_delta_over_stream": 0.39617942472540063,
-          "moe_delta_over_stream": 0.2896839036553375,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495230124742,
-          "router_margin_mean_observed": 0.18297782217151998,
-          "router_margin_mean_delta": 2.8299159045821673e-05,
-          "router_margin_median_reference": 0.15255130555045132,
-          "router_margin_median_observed": 0.15256852706410196,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040322685,
-            "residual_in_drift_relative_norm": 0.005098830132430907
-          }
-        },
-        "pilot_label": "expert_hp_ceiling"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 22.211421012878418,
-        "expert_only": {
-          "label": "expert_hp_ceiling",
-          "seconds": 35.33976721763611,
-          "attention_output_cosine": 0.9999992604583983,
-          "attention_output_cosine_per_token": 0.9999992162168846,
-          "residual_stream_cosine": 0.9999983536330732,
-          "moe_input_normalized_cosine": 0.9999961313227412,
-          "router_logit_cosine": 0.9999994195752296,
-          "moe_output_cosine": 0.9999935905490286,
-          "block_output_cosine": 0.9999981084993045,
-          "block_output_cosine_per_token": 0.9999982467477101,
-          "residual_drift_relative_norm": 0.001814590431474731,
-          "block_output_drift_relative_norm": 0.001945010680576157,
-          "attn_delta_over_stream": 0.5848367409943813,
-          "moe_delta_over_stream": 0.41127854614413184,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814944739152074,
-          "router_margin_mean_observed": 0.03582018331560345,
-          "router_margin_mean_delta": 5.2385764513785335e-06,
-          "router_margin_median_reference": 0.025870433832144726,
-          "router_margin_median_observed": 0.025857554793095913,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999973569164325,
-            "residual_in_drift_relative_norm": 0.0022991889781694423
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 28.80967140197754,
-          "attention_output_cosine": 0.9999951789248877,
-          "attention_output_cosine_per_token": 0.9999948155995892,
-          "residual_stream_cosine": 0.999991030692396,
-          "moe_input_normalized_cosine": 0.9999805357479619,
-          "router_logit_cosine": 0.9999983004394833,
-          "moe_output_cosine": 0.9998240607737604,
-          "block_output_cosine": 0.9999682697635905,
-          "block_output_cosine_per_token": 0.9999678107431367,
-          "residual_drift_relative_norm": 0.0042354673885935425,
-          "block_output_drift_relative_norm": 0.00796618737672334,
-          "attn_delta_over_stream": 0.5849569779392093,
-          "moe_delta_over_stream": 0.4112808484149002,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814944739152074,
-          "router_margin_mean_observed": 0.03582240482002213,
-          "router_margin_mean_delta": 7.460080870050531e-06,
-          "router_margin_median_reference": 0.025870433832144726,
-          "router_margin_median_observed": 0.025836179844010404,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463229576,
-            "residual_in_drift_relative_norm": 0.005302552089727011
-          }
-        },
-        "pilot_label": "expert_hp_ceiling"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 24.783018827438354,
-        "expert_only": {
-          "label": "expert_hp_ceiling",
-          "seconds": 37.97921562194824,
-          "attention_output_cosine": 0.9999984526093284,
-          "attention_output_cosine_per_token": 0.999998399621349,
-          "residual_stream_cosine": 0.9999987730401033,
-          "moe_input_normalized_cosine": 0.9999965061636095,
-          "router_logit_cosine": 0.9999998371455628,
-          "moe_output_cosine": 0.9999385489797917,
-          "block_output_cosine": 0.9999838103358131,
-          "block_output_cosine_per_token": 0.9999829487004541,
-          "residual_drift_relative_norm": 0.0015665364755571474,
-          "block_output_drift_relative_norm": 0.005690267932494616,
-          "attn_delta_over_stream": 0.5008300570103207,
-          "moe_delta_over_stream": 0.3569048369424699,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.08447265625
-          ],
-          "expert_load_js_bits": 1.8240947719967162e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.04406781801268037,
-          "router_margin_mean_observed": 0.044075594755017454,
-          "router_margin_mean_delta": 7.776742337081259e-06,
-          "router_margin_median_reference": 0.029539565545719543,
-          "router_margin_median_observed": 0.02952833859452031,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999981084993045,
-            "residual_in_drift_relative_norm": 0.001945010680576157
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 26.30705761909485,
-          "attention_output_cosine": 0.9999675515960312,
-          "attention_output_cosine_per_token": 0.9999677009830585,
-          "residual_stream_cosine": 0.9999786349765859,
-          "moe_input_normalized_cosine": 0.9999317806884749,
-          "router_logit_cosine": 0.9999963366268846,
-          "moe_output_cosine": 0.9996961822039626,
-          "block_output_cosine": 0.9999195401569629,
-          "block_output_cosine_per_token": 0.9999220111693956,
-          "residual_drift_relative_norm": 0.006536818304715071,
-          "block_output_drift_relative_norm": 0.012685839893226303,
-          "attn_delta_over_stream": 0.5008011430468392,
-          "moe_delta_over_stream": 0.3568508941802894,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.04406781801268037,
-          "router_margin_mean_observed": 0.04404334536098494,
-          "router_margin_mean_delta": -2.4472651695435334e-05,
-          "router_margin_median_reference": 0.029539565545719543,
-          "router_margin_median_observed": 0.02949765995199495,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697635905,
-            "residual_in_drift_relative_norm": 0.00796618737672334
-          }
-        },
-        "pilot_label": "expert_hp_ceiling"
-      }
-    ],
+    "channel_alpha_blocks": [],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.9999838103358131,
-        "residual_drift_relative_norm": 0.005690267932494616,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.005690267932494616
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401569629,
-        "residual_drift_relative_norm": 0.012685839893226303,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685839893226303
       }
     },
+    "expert_mode": "all_hp",
+    "hp_blocks": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "hp_period": null,
+    "hp_schedule_kind": "all",
+    "hp_schedule_prose": "HP expert ceiling: FP16 experts on every measured block.",
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "fp16_control",
-          "block_000.slot_00.moe_expert.gate": "fp16_control",
-          "block_000.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1058,52 +66,52 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "fp16_control",
+          "block_000.slot_01.moe_expert.down": "fp16_control",
+          "block_000.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "fp16_control",
-          "block_001.slot_00.moe_expert.gate": "fp16_control",
-          "block_001.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1134,52 +142,52 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "fp16_control",
+          "block_001.slot_01.moe_expert.down": "fp16_control",
+          "block_001.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "fp16_control",
-          "block_002.slot_00.moe_expert.gate": "fp16_control",
-          "block_002.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1210,52 +218,52 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "fp16_control",
+          "block_002.slot_01.moe_expert.down": "fp16_control",
+          "block_002.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "fp16_control",
-          "block_003.slot_00.moe_expert.gate": "fp16_control",
-          "block_003.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1286,33 +294,1025 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "fp16_control",
+          "block_003.slot_01.moe_expert.down": "fp16_control",
+          "block_003.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "all_hp",
-    "hp_period": null,
-    "hp_schedule_kind": "all",
-    "hp_blocks": [
-      0,
-      1,
-      2,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171419076819,
+          "block_output_cosine": 0.9999999987176428,
+          "block_output_cosine_per_token": 0.9999999986849318,
+          "block_output_drift_relative_norm": 5.0647684479044405e-05,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_hp_ceiling",
+          "moe_delta_over_stream": 0.4827432384719955,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.9999999941389839,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204764995743812,
+          "router_margin_mean_reference": 0.030204764995743812,
+          "router_margin_median_observed": 0.006170867767470903,
+          "router_margin_median_reference": 0.006170867767470903,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 31.015775203704834,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984425272,
+          "attention_output_cosine_per_token": 0.9999999986030998,
+          "attn_delta_over_stream": 0.8760054891005306,
+          "block_output_cosine": 0.9999870040322685,
+          "block_output_cosine_per_token": 0.9999880581319095,
+          "block_output_drift_relative_norm": 0.005098830132430907,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4827844972000442,
+          "moe_input_normalized_cosine": 0.9999999606112848,
+          "moe_output_cosine": 0.9999813002301362,
+          "residual_drift_relative_norm": 0.00021537206570514935,
+          "residual_stream_cosine": 0.9999999831366344,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971505857,
+          "router_margin_mean_delta": 2.8905368462560425e-06,
+          "router_margin_mean_observed": 0.03020765553259007,
+          "router_margin_mean_reference": 0.030204764995743812,
+          "router_margin_median_observed": 0.006180739225395249,
+          "router_margin_median_reference": 0.006170867767470903,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 21.891437768936157,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_hp_ceiling",
+        "reference_seconds": 19.067675828933716
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9999999994946557,
+          "attention_output_cosine_per_token": 0.9999999995122413,
+          "attn_delta_over_stream": 0.3961665999906308,
+          "block_output_cosine": 0.9999973569164325,
+          "block_output_cosine_per_token": 0.999997468422053,
+          "block_output_drift_relative_norm": 0.0022991889781694423,
+          "expert_load_js_bits": 1.476654090930979e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_hp_ceiling",
+          "moe_delta_over_stream": 0.2896296326293033,
+          "moe_input_normalized_cosine": 0.9999999982554377,
+          "moe_output_cosine": 0.9999911806399926,
+          "residual_drift_relative_norm": 4.428102064805694e-05,
+          "residual_stream_cosine": 0.9999999990198687,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999999987176428,
+            "residual_in_drift_relative_norm": 5.0647684479044405e-05
+          },
+          "router_logit_cosine": 0.9999999998249586,
+          "router_margin_mean_delta": 3.383398881246126e-07,
+          "router_margin_mean_observed": 0.1829498613523623,
+          "router_margin_mean_reference": 0.1829495230124742,
+          "router_margin_median_observed": 0.15255614636969325,
+          "router_margin_median_reference": 0.15255130555045132,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 26.211087226867676,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239221966,
+          "attention_output_cosine_per_token": 0.9999949975916551,
+          "attn_delta_over_stream": 0.39617942472540063,
+          "block_output_cosine": 0.9999859463229576,
+          "block_output_cosine_per_token": 0.9999851320664717,
+          "block_output_drift_relative_norm": 0.005302552089727011,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839036553375,
+          "moe_input_normalized_cosine": 0.9999833030380135,
+          "moe_output_cosine": 0.999966460633255,
+          "residual_drift_relative_norm": 0.004420409079612701,
+          "residual_stream_cosine": 0.9999902372606576,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040322685,
+            "residual_in_drift_relative_norm": 0.005098830132430907
+          },
+          "router_logit_cosine": 0.9999982162936379,
+          "router_margin_mean_delta": 2.8299159045821673e-05,
+          "router_margin_mean_observed": 0.18297782217151998,
+          "router_margin_mean_reference": 0.1829495230124742,
+          "router_margin_median_observed": 0.15256852706410196,
+          "router_margin_median_reference": 0.15255130555045132,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 25.633192539215088,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_hp_ceiling",
+        "reference_seconds": 20.357039213180542
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.9999992604583983,
+          "attention_output_cosine_per_token": 0.9999992162168846,
+          "attn_delta_over_stream": 0.5848367409943813,
+          "block_output_cosine": 0.9999981084993045,
+          "block_output_cosine_per_token": 0.9999982467477101,
+          "block_output_drift_relative_norm": 0.001945010680576157,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_hp_ceiling",
+          "moe_delta_over_stream": 0.41127854614413184,
+          "moe_input_normalized_cosine": 0.9999961313227412,
+          "moe_output_cosine": 0.9999935905490286,
+          "residual_drift_relative_norm": 0.001814590431474731,
+          "residual_stream_cosine": 0.9999983536330732,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999973569164325,
+            "residual_in_drift_relative_norm": 0.0022991889781694423
+          },
+          "router_logit_cosine": 0.9999994195752296,
+          "router_margin_mean_delta": 5.2385764513785335e-06,
+          "router_margin_mean_observed": 0.03582018331560345,
+          "router_margin_mean_reference": 0.035814944739152074,
+          "router_margin_median_observed": 0.025857554793095913,
+          "router_margin_median_reference": 0.025870433832144726,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 35.33976721763611,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789248877,
+          "attention_output_cosine_per_token": 0.9999948155995892,
+          "attn_delta_over_stream": 0.5849569779392093,
+          "block_output_cosine": 0.9999682697635905,
+          "block_output_cosine_per_token": 0.9999678107431367,
+          "block_output_drift_relative_norm": 0.00796618737672334,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808484149002,
+          "moe_input_normalized_cosine": 0.9999805357479619,
+          "moe_output_cosine": 0.9998240607737604,
+          "residual_drift_relative_norm": 0.0042354673885935425,
+          "residual_stream_cosine": 0.999991030692396,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463229576,
+            "residual_in_drift_relative_norm": 0.005302552089727011
+          },
+          "router_logit_cosine": 0.9999983004394833,
+          "router_margin_mean_delta": 7.460080870050531e-06,
+          "router_margin_mean_observed": 0.03582240482002213,
+          "router_margin_mean_reference": 0.035814944739152074,
+          "router_margin_median_observed": 0.025836179844010404,
+          "router_margin_median_reference": 0.025870433832144726,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 28.80967140197754,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_hp_ceiling",
+        "reference_seconds": 22.211421012878418
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.9999984526093284,
+          "attention_output_cosine_per_token": 0.999998399621349,
+          "attn_delta_over_stream": 0.5008300570103207,
+          "block_output_cosine": 0.9999838103358131,
+          "block_output_cosine_per_token": 0.9999829487004541,
+          "block_output_drift_relative_norm": 0.005690267932494616,
+          "expert_load_js_bits": 1.8240947719967162e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.08447265625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_hp_ceiling",
+          "moe_delta_over_stream": 0.3569048369424699,
+          "moe_input_normalized_cosine": 0.9999965061636095,
+          "moe_output_cosine": 0.9999385489797917,
+          "residual_drift_relative_norm": 0.0015665364755571474,
+          "residual_stream_cosine": 0.9999987730401033,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999981084993045,
+            "residual_in_drift_relative_norm": 0.001945010680576157
+          },
+          "router_logit_cosine": 0.9999998371455628,
+          "router_margin_mean_delta": 7.776742337081259e-06,
+          "router_margin_mean_observed": 0.044075594755017454,
+          "router_margin_mean_reference": 0.04406781801268037,
+          "router_margin_median_observed": 0.02952833859452031,
+          "router_margin_median_reference": 0.029539565545719543,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 37.97921562194824,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999675515960312,
+          "attention_output_cosine_per_token": 0.9999677009830585,
+          "attn_delta_over_stream": 0.5008011430468392,
+          "block_output_cosine": 0.9999195401569629,
+          "block_output_cosine_per_token": 0.9999220111693956,
+          "block_output_drift_relative_norm": 0.012685839893226303,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.3568508941802894,
+          "moe_input_normalized_cosine": 0.9999317806884749,
+          "moe_output_cosine": 0.9996961822039626,
+          "residual_drift_relative_norm": 0.006536818304715071,
+          "residual_stream_cosine": 0.9999786349765859,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697635905,
+            "residual_in_drift_relative_norm": 0.00796618737672334
+          },
+          "router_logit_cosine": 0.9999963366268846,
+          "router_margin_mean_delta": -2.4472651695435334e-05,
+          "router_margin_mean_observed": 0.04404334536098494,
+          "router_margin_mean_reference": 0.04406781801268037,
+          "router_margin_median_observed": 0.02949765995199495,
+          "router_margin_median_reference": 0.029539565545719543,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 26.30705761909485,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_hp_ceiling",
+        "reference_seconds": 24.783018827438354
+      }
     ],
-    "ternary_blocks": [],
-    "channel_alpha_blocks": [],
-    "hp_schedule_prose": "HP expert ceiling: FP16 experts on every measured block.",
-    "arm_label": "expert_hp_ceiling",
     "pilot_labels_per_block": [
       "expert_hp_ceiling",
       "expert_hp_ceiling",
       "expert_hp_ceiling",
       "expert_hp_ceiling"
-    ]
+    ],
+    "skip_fp16_control": false,
+    "ternary_blocks": [],
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "hp_ceiling",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "secondary; no independent decision",
+    "implementation": {
+      "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
+      "dirty": false
+    },
+    "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+    "model": "GPT-5.6 Sol (xhigh)",
+    "numpy": "2.4.6",
+    "python": "3.14.6",
+    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v2/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v2/metrics.json
@@ -1,1033 +1,40 @@
 {
-  "provenance": {
-    "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
-    "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
-    "model": "GPT-5.6 Sol (xhigh)",
-    "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "implementation": {
-      "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.4.6",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-    "arm": "periodic_hp",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-    "evidence_role": "primary; sole canonical #75 decision"
-  },
   "chain": {
+    "arm_label": "expert_periodic_hp_123",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 22.908037662506104,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 47.501216888427734,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0000000000000002,
-          "moe_output_cosine": 0.7734826591585969,
-          "block_output_cosine": 0.9635717950590136,
-          "block_output_cosine_per_token": 0.9610040052042206,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.27735082427370883,
-          "attn_delta_over_stream": 0.876171419076819,
-          "moe_delta_over_stream": 0.5761949397790738,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204764995743812,
-          "router_margin_mean_observed": 0.030204764995743812,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170867767470903,
-          "router_margin_median_observed": 0.006170867767470903,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 31.141470432281494,
-          "attention_output_cosine": 0.9999999984425272,
-          "attention_output_cosine_per_token": 0.9999999986030998,
-          "residual_stream_cosine": 0.9999999831366344,
-          "moe_input_normalized_cosine": 0.9999999606112848,
-          "router_logit_cosine": 0.9999999971505857,
-          "moe_output_cosine": 0.9999813002301362,
-          "block_output_cosine": 0.9999870040322685,
-          "block_output_cosine_per_token": 0.9999880581319095,
-          "residual_drift_relative_norm": 0.00021537206570514935,
-          "block_output_drift_relative_norm": 0.005098830132430907,
-          "attn_delta_over_stream": 0.8760054891005306,
-          "moe_delta_over_stream": 0.4827844972000442,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204764995743812,
-          "router_margin_mean_observed": 0.03020765553259007,
-          "router_margin_mean_delta": 2.8905368462560425e-06,
-          "router_margin_median_reference": 0.006170867767470903,
-          "router_margin_median_observed": 0.006180739225395249,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "goz1_expert_ternary_only"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 27.001158952713013,
-        "expert_only": {
-          "label": "expert_periodic_hp_123",
-          "seconds": 31.405871391296387,
-          "attention_output_cosine": 0.9451666071835441,
-          "attention_output_cosine_per_token": 0.9468242682023654,
-          "residual_stream_cosine": 0.9687463898148214,
-          "moe_input_normalized_cosine": 0.9499999688655877,
-          "router_logit_cosine": 0.9938496094388861,
-          "moe_output_cosine": 0.9017609448803363,
-          "block_output_cosine": 0.9632111934148898,
-          "block_output_cosine_per_token": 0.9612838382268775,
-          "residual_drift_relative_norm": 0.2568268608375463,
-          "block_output_drift_relative_norm": 0.27932072855348866,
-          "attn_delta_over_stream": 0.3735890931741386,
-          "moe_delta_over_stream": 0.2943754277445982,
-          "router_top1_agreement": 0.8876953125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.6806640625,
-          "router_top2_set_agreement": 0.6806640625,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.171875,
-            0.1142578125,
-            0.118408203125,
-            0.0625,
-            0.12744140625,
-            0.19775390625,
-            0.097412109375,
-            0.1103515625
-          ],
-          "expert_load_js_bits": 0.005558745183592211,
-          "expert_load_max_abs_delta": 0.03955078125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495230124742,
-          "router_margin_mean_observed": 0.1958685730595011,
-          "router_margin_mean_delta": 0.012919050047026918,
-          "router_margin_median_reference": 0.15255130555045132,
-          "router_margin_median_observed": 0.16081368735264204,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 49,
-              "top1_flip_rate": 0.5104166666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 114,
-              "top1_flip_rate": 0.35403726708074534
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 57,
-              "top1_flip_rate": 0.09612141652613827
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 10,
-              "top1_flip_rate": 0.01040582726326743
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9635717950590136,
-            "residual_in_drift_relative_norm": 0.27735082427370883
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 28.017794609069824,
-          "attention_output_cosine": 0.9999955239221966,
-          "attention_output_cosine_per_token": 0.9999949975916551,
-          "residual_stream_cosine": 0.9999902372606576,
-          "moe_input_normalized_cosine": 0.9999833030380135,
-          "router_logit_cosine": 0.9999982162936379,
-          "moe_output_cosine": 0.999966460633255,
-          "block_output_cosine": 0.9999859463229576,
-          "block_output_cosine_per_token": 0.9999851320664717,
-          "residual_drift_relative_norm": 0.004420409079612701,
-          "block_output_drift_relative_norm": 0.005302552089727011,
-          "attn_delta_over_stream": 0.39617942472540063,
-          "moe_delta_over_stream": 0.2896839036553375,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495230124742,
-          "router_margin_mean_observed": 0.18297782217151998,
-          "router_margin_mean_delta": 2.8299159045821673e-05,
-          "router_margin_median_reference": 0.15255130555045132,
-          "router_margin_median_observed": 0.15256852706410196,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040322685,
-            "residual_in_drift_relative_norm": 0.005098830132430907
-          }
-        },
-        "pilot_label": "expert_periodic_hp_123"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 25.806989908218384,
-        "expert_only": {
-          "label": "expert_periodic_hp_123",
-          "seconds": 37.104421854019165,
-          "attention_output_cosine": 0.9047310840572476,
-          "attention_output_cosine_per_token": 0.9037478531323986,
-          "residual_stream_cosine": 0.9648533615412695,
-          "moe_input_normalized_cosine": 0.9259939437811224,
-          "router_logit_cosine": 0.9883752621002644,
-          "moe_output_cosine": 0.8516885736177814,
-          "block_output_cosine": 0.9396838167556127,
-          "block_output_cosine_per_token": 0.9394190121397878,
-          "residual_drift_relative_norm": 0.27894133081790423,
-          "block_output_drift_relative_norm": 0.3484754820003742,
-          "attn_delta_over_stream": 0.6183179312175628,
-          "moe_delta_over_stream": 0.3989767407607716,
-          "router_top1_agreement": 0.72900390625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.5927734375,
-          "router_top2_set_agreement": 0.5927734375,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.065185546875,
-            0.09619140625,
-            0.085205078125,
-            0.285400390625,
-            0.047119140625,
-            0.067626953125,
-            0.134033203125,
-            0.21923828125
-          ],
-          "expert_load_js_bits": 0.008547932604502501,
-          "expert_load_max_abs_delta": 0.03857421875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814944739152074,
-          "router_margin_mean_observed": 0.035114173211049815,
-          "router_margin_mean_delta": -0.0007007715281022598,
-          "router_margin_median_reference": 0.025870433832144726,
-          "router_margin_median_observed": 0.02509604319802744,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 238,
-              "top1_flip_rate": 0.5173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 299,
-              "top1_flip_rate": 0.2834123222748815
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 18,
-              "top1_flip_rate": 0.03508771929824561
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9632111934148898,
-            "residual_in_drift_relative_norm": 0.27932072855348866
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 31.272974491119385,
-          "attention_output_cosine": 0.9999951789248877,
-          "attention_output_cosine_per_token": 0.9999948155995892,
-          "residual_stream_cosine": 0.999991030692396,
-          "moe_input_normalized_cosine": 0.9999805357479619,
-          "router_logit_cosine": 0.9999983004394833,
-          "moe_output_cosine": 0.9998240607737604,
-          "block_output_cosine": 0.9999682697635905,
-          "block_output_cosine_per_token": 0.9999678107431367,
-          "residual_drift_relative_norm": 0.0042354673885935425,
-          "block_output_drift_relative_norm": 0.00796618737672334,
-          "attn_delta_over_stream": 0.5849569779392093,
-          "moe_delta_over_stream": 0.4112808484149002,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814944739152074,
-          "router_margin_mean_observed": 0.03582240482002213,
-          "router_margin_mean_delta": 7.460080870050531e-06,
-          "router_margin_median_reference": 0.025870433832144726,
-          "router_margin_median_observed": 0.025836179844010404,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463229576,
-            "residual_in_drift_relative_norm": 0.005302552089727011
-          }
-        },
-        "pilot_label": "expert_periodic_hp_123"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 28.459043264389038,
-        "expert_only": {
-          "label": "expert_periodic_hp_123",
-          "seconds": 35.27063488960266,
-          "attention_output_cosine": 0.861026105379999,
-          "attention_output_cosine_per_token": 0.8602708900365974,
-          "residual_stream_cosine": 0.950362815193596,
-          "moe_input_normalized_cosine": 0.8581794302414218,
-          "router_logit_cosine": 0.9931827507155361,
-          "moe_output_cosine": 0.7858660280792586,
-          "block_output_cosine": 0.9138530769863993,
-          "block_output_cosine_per_token": 0.9141545911262708,
-          "residual_drift_relative_norm": 0.316837309330924,
-          "block_output_drift_relative_norm": 0.4370545723375058,
-          "attn_delta_over_stream": 0.511872601327306,
-          "moe_delta_over_stream": 0.35360662010358945,
-          "router_top1_agreement": 0.61572265625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.40869140625,
-          "router_top2_set_agreement": 0.40869140625,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.052001953125,
-            0.159423828125,
-            0.05712890625,
-            0.148681640625,
-            0.35595703125,
-            0.016357421875,
-            0.108642578125,
-            0.101806640625
-          ],
-          "expert_load_js_bits": 0.0244658927183635,
-          "expert_load_max_abs_delta": 0.0888671875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.04406781801268037,
-          "router_margin_mean_observed": 0.04217268985368655,
-          "router_margin_mean_delta": -0.0018951281589938197,
-          "router_margin_median_reference": 0.029539565545719543,
-          "router_margin_median_observed": 0.02771209140637189,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 275,
-              "top1_flip_rate": 0.6532066508313539
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 420,
-              "top1_flip_rate": 0.4251012145748988
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 92,
-              "top1_flip_rate": 0.1619718309859155
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9396838167556127,
-            "residual_in_drift_relative_norm": 0.3484754820003742
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 27.70035982131958,
-          "attention_output_cosine": 0.9999675515960312,
-          "attention_output_cosine_per_token": 0.9999677009830585,
-          "residual_stream_cosine": 0.9999786349765859,
-          "moe_input_normalized_cosine": 0.9999317806884749,
-          "router_logit_cosine": 0.9999963366268846,
-          "moe_output_cosine": 0.9996961822039626,
-          "block_output_cosine": 0.9999195401569629,
-          "block_output_cosine_per_token": 0.9999220111693956,
-          "residual_drift_relative_norm": 0.006536818304715071,
-          "block_output_drift_relative_norm": 0.012685839893226303,
-          "attn_delta_over_stream": 0.5008011430468392,
-          "moe_delta_over_stream": 0.3568508941802894,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.04406781801268037,
-          "router_margin_mean_observed": 0.04404334536098494,
-          "router_margin_mean_delta": -2.4472651695435334e-05,
-          "router_margin_median_reference": 0.029539565545719543,
-          "router_margin_median_observed": 0.02949765995199495,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697635905,
-            "residual_in_drift_relative_norm": 0.00796618737672334
-          }
-        },
-        "pilot_label": "expert_periodic_hp_123"
-      }
-    ],
+    "channel_alpha_blocks": [],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.9138530769863993,
-        "residual_drift_relative_norm": 0.4370545723375058,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.4370545723375058
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401569629,
-        "residual_drift_relative_norm": 0.012685839893226303,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685839893226303
       }
     },
+    "expert_mode": "periodic_hp",
+    "hp_blocks": [
+      1,
+      2,
+      3
+    ],
+    "hp_period": null,
+    "hp_schedule_kind": "explicit",
+    "hp_schedule_prose": "Arm C label `expert_periodic_hp_123`: ternary on {0}, HP (FP16 experts) on {1,2,3}.",
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1058,52 +65,52 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "fp16_control",
-          "block_001.slot_00.moe_expert.gate": "fp16_control",
-          "block_001.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1134,52 +141,52 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "fp16_control",
+          "block_001.slot_01.moe_expert.down": "fp16_control",
+          "block_001.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "fp16_control",
-          "block_002.slot_00.moe_expert.gate": "fp16_control",
-          "block_002.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1210,52 +217,52 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "fp16_control",
+          "block_002.slot_01.moe_expert.down": "fp16_control",
+          "block_002.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "fp16_control",
-          "block_003.slot_00.moe_expert.gate": "fp16_control",
-          "block_003.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1286,1069 +293,927 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "fp16_control",
+          "block_003.slot_01.moe_expert.down": "fp16_control",
+          "block_003.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "periodic_hp",
-    "hp_period": null,
-    "hp_schedule_kind": "explicit",
-    "hp_blocks": [
-      1,
-      2,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171419076819,
+          "block_output_cosine": 0.9635717950590136,
+          "block_output_cosine_per_token": 0.9610040052042206,
+          "block_output_drift_relative_norm": 0.27735082427370883,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.5761949397790738,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.7734826591585969,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0000000000000002,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204764995743812,
+          "router_margin_mean_reference": 0.030204764995743812,
+          "router_margin_median_observed": 0.006170867767470903,
+          "router_margin_median_reference": 0.006170867767470903,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 47.501216888427734,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984425272,
+          "attention_output_cosine_per_token": 0.9999999986030998,
+          "attn_delta_over_stream": 0.8760054891005306,
+          "block_output_cosine": 0.9999870040322685,
+          "block_output_cosine_per_token": 0.9999880581319095,
+          "block_output_drift_relative_norm": 0.005098830132430907,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4827844972000442,
+          "moe_input_normalized_cosine": 0.9999999606112848,
+          "moe_output_cosine": 0.9999813002301362,
+          "residual_drift_relative_norm": 0.00021537206570514935,
+          "residual_stream_cosine": 0.9999999831366344,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971505857,
+          "router_margin_mean_delta": 2.8905368462560425e-06,
+          "router_margin_mean_observed": 0.03020765553259007,
+          "router_margin_mean_reference": 0.030204764995743812,
+          "router_margin_median_observed": 0.006180739225395249,
+          "router_margin_median_reference": 0.006170867767470903,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 31.141470432281494,
+          "selected_experts": 2
+        },
+        "pilot_label": "goz1_expert_ternary_only",
+        "reference_seconds": 22.908037662506104
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9451666071835441,
+          "attention_output_cosine_per_token": 0.9468242682023654,
+          "attn_delta_over_stream": 0.3735890931741386,
+          "block_output_cosine": 0.9632111934148898,
+          "block_output_cosine_per_token": 0.9612838382268775,
+          "block_output_drift_relative_norm": 0.27932072855348866,
+          "expert_load_js_bits": 0.005558745183592211,
+          "expert_load_max_abs_delta": 0.03955078125,
+          "expert_load_observed": [
+            0.171875,
+            0.1142578125,
+            0.118408203125,
+            0.0625,
+            0.12744140625,
+            0.19775390625,
+            0.097412109375,
+            0.1103515625
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.5104166666666666,
+              "top1_flips": 49
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.35403726708074534,
+              "top1_flips": 114
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.09612141652613827,
+              "top1_flips": 57
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.01040582726326743,
+              "top1_flips": 10
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_123",
+          "moe_delta_over_stream": 0.2943754277445982,
+          "moe_input_normalized_cosine": 0.9499999688655877,
+          "moe_output_cosine": 0.9017609448803363,
+          "residual_drift_relative_norm": 0.2568268608375463,
+          "residual_stream_cosine": 0.9687463898148214,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9635717950590136,
+            "residual_in_drift_relative_norm": 0.27735082427370883
+          },
+          "router_logit_cosine": 0.9938496094388861,
+          "router_margin_mean_delta": 0.012919050047026918,
+          "router_margin_mean_observed": 0.1958685730595011,
+          "router_margin_mean_reference": 0.1829495230124742,
+          "router_margin_median_observed": 0.16081368735264204,
+          "router_margin_median_reference": 0.15255130555045132,
+          "router_top1_agreement": 0.8876953125,
+          "router_top2_set_agreement": 0.6806640625,
+          "router_topk_set_agreement": 0.6806640625,
+          "seconds": 31.405871391296387,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239221966,
+          "attention_output_cosine_per_token": 0.9999949975916551,
+          "attn_delta_over_stream": 0.39617942472540063,
+          "block_output_cosine": 0.9999859463229576,
+          "block_output_cosine_per_token": 0.9999851320664717,
+          "block_output_drift_relative_norm": 0.005302552089727011,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839036553375,
+          "moe_input_normalized_cosine": 0.9999833030380135,
+          "moe_output_cosine": 0.999966460633255,
+          "residual_drift_relative_norm": 0.004420409079612701,
+          "residual_stream_cosine": 0.9999902372606576,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040322685,
+            "residual_in_drift_relative_norm": 0.005098830132430907
+          },
+          "router_logit_cosine": 0.9999982162936379,
+          "router_margin_mean_delta": 2.8299159045821673e-05,
+          "router_margin_mean_observed": 0.18297782217151998,
+          "router_margin_mean_reference": 0.1829495230124742,
+          "router_margin_median_observed": 0.15256852706410196,
+          "router_margin_median_reference": 0.15255130555045132,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 28.017794609069824,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_123",
+        "reference_seconds": 27.001158952713013
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.9047310840572476,
+          "attention_output_cosine_per_token": 0.9037478531323986,
+          "attn_delta_over_stream": 0.6183179312175628,
+          "block_output_cosine": 0.9396838167556127,
+          "block_output_cosine_per_token": 0.9394190121397878,
+          "block_output_drift_relative_norm": 0.3484754820003742,
+          "expert_load_js_bits": 0.008547932604502501,
+          "expert_load_max_abs_delta": 0.03857421875,
+          "expert_load_observed": [
+            0.065185546875,
+            0.09619140625,
+            0.085205078125,
+            0.285400390625,
+            0.047119140625,
+            0.067626953125,
+            0.134033203125,
+            0.21923828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.5173913043478261,
+              "top1_flips": 238
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.2834123222748815,
+              "top1_flips": 299
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.03508771929824561,
+              "top1_flips": 18
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_123",
+          "moe_delta_over_stream": 0.3989767407607716,
+          "moe_input_normalized_cosine": 0.9259939437811224,
+          "moe_output_cosine": 0.8516885736177814,
+          "residual_drift_relative_norm": 0.27894133081790423,
+          "residual_stream_cosine": 0.9648533615412695,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9632111934148898,
+            "residual_in_drift_relative_norm": 0.27932072855348866
+          },
+          "router_logit_cosine": 0.9883752621002644,
+          "router_margin_mean_delta": -0.0007007715281022598,
+          "router_margin_mean_observed": 0.035114173211049815,
+          "router_margin_mean_reference": 0.035814944739152074,
+          "router_margin_median_observed": 0.02509604319802744,
+          "router_margin_median_reference": 0.025870433832144726,
+          "router_top1_agreement": 0.72900390625,
+          "router_top2_set_agreement": 0.5927734375,
+          "router_topk_set_agreement": 0.5927734375,
+          "seconds": 37.104421854019165,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789248877,
+          "attention_output_cosine_per_token": 0.9999948155995892,
+          "attn_delta_over_stream": 0.5849569779392093,
+          "block_output_cosine": 0.9999682697635905,
+          "block_output_cosine_per_token": 0.9999678107431367,
+          "block_output_drift_relative_norm": 0.00796618737672334,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808484149002,
+          "moe_input_normalized_cosine": 0.9999805357479619,
+          "moe_output_cosine": 0.9998240607737604,
+          "residual_drift_relative_norm": 0.0042354673885935425,
+          "residual_stream_cosine": 0.999991030692396,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463229576,
+            "residual_in_drift_relative_norm": 0.005302552089727011
+          },
+          "router_logit_cosine": 0.9999983004394833,
+          "router_margin_mean_delta": 7.460080870050531e-06,
+          "router_margin_mean_observed": 0.03582240482002213,
+          "router_margin_mean_reference": 0.035814944739152074,
+          "router_margin_median_observed": 0.025836179844010404,
+          "router_margin_median_reference": 0.025870433832144726,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 31.272974491119385,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_123",
+        "reference_seconds": 25.806989908218384
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.861026105379999,
+          "attention_output_cosine_per_token": 0.8602708900365974,
+          "attn_delta_over_stream": 0.511872601327306,
+          "block_output_cosine": 0.9138530769863993,
+          "block_output_cosine_per_token": 0.9141545911262708,
+          "block_output_drift_relative_norm": 0.4370545723375058,
+          "expert_load_js_bits": 0.0244658927183635,
+          "expert_load_max_abs_delta": 0.0888671875,
+          "expert_load_observed": [
+            0.052001953125,
+            0.159423828125,
+            0.05712890625,
+            0.148681640625,
+            0.35595703125,
+            0.016357421875,
+            0.108642578125,
+            0.101806640625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.6532066508313539,
+              "top1_flips": 275
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.4251012145748988,
+              "top1_flips": 420
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.1619718309859155,
+              "top1_flips": 92
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_123",
+          "moe_delta_over_stream": 0.35360662010358945,
+          "moe_input_normalized_cosine": 0.8581794302414218,
+          "moe_output_cosine": 0.7858660280792586,
+          "residual_drift_relative_norm": 0.316837309330924,
+          "residual_stream_cosine": 0.950362815193596,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9396838167556127,
+            "residual_in_drift_relative_norm": 0.3484754820003742
+          },
+          "router_logit_cosine": 0.9931827507155361,
+          "router_margin_mean_delta": -0.0018951281589938197,
+          "router_margin_mean_observed": 0.04217268985368655,
+          "router_margin_mean_reference": 0.04406781801268037,
+          "router_margin_median_observed": 0.02771209140637189,
+          "router_margin_median_reference": 0.029539565545719543,
+          "router_top1_agreement": 0.61572265625,
+          "router_top2_set_agreement": 0.40869140625,
+          "router_topk_set_agreement": 0.40869140625,
+          "seconds": 35.27063488960266,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999675515960312,
+          "attention_output_cosine_per_token": 0.9999677009830585,
+          "attn_delta_over_stream": 0.5008011430468392,
+          "block_output_cosine": 0.9999195401569629,
+          "block_output_cosine_per_token": 0.9999220111693956,
+          "block_output_drift_relative_norm": 0.012685839893226303,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.3568508941802894,
+          "moe_input_normalized_cosine": 0.9999317806884749,
+          "moe_output_cosine": 0.9996961822039626,
+          "residual_drift_relative_norm": 0.006536818304715071,
+          "residual_stream_cosine": 0.9999786349765859,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697635905,
+            "residual_in_drift_relative_norm": 0.00796618737672334
+          },
+          "router_logit_cosine": 0.9999963366268846,
+          "router_margin_mean_delta": -2.4472651695435334e-05,
+          "router_margin_mean_observed": 0.04404334536098494,
+          "router_margin_mean_reference": 0.04406781801268037,
+          "router_margin_median_observed": 0.02949765995199495,
+          "router_margin_median_reference": 0.029539565545719543,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 27.70035982131958,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_123",
+        "reference_seconds": 28.459043264389038
+      }
     ],
-    "ternary_blocks": [
-      0
-    ],
-    "channel_alpha_blocks": [],
-    "hp_schedule_prose": "Arm C label `expert_periodic_hp_123`: ternary on {0}, HP (FP16 experts) on {1,2,3}.",
-    "arm_label": "expert_periodic_hp_123",
     "pilot_labels_per_block": [
       "goz1_expert_ternary_only",
       "expert_periodic_hp_123",
       "expert_periodic_hp_123",
       "expert_periodic_hp_123"
-    ]
+    ],
+    "skip_fp16_control": false,
+    "ternary_blocks": [
+      0
+    ],
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
   },
   "comparison": {
     "primary_arm": "expert_periodic_hp_123",
     "secondary_arms": {
-      "expert_periodic_hp_n2_plus_channel_alpha": {
-        "provenance": {
-          "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
-          "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
-          "model": "GPT-5.6 Sol (xhigh)",
-          "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
-          "baseline_64": {
-            "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-            "tokens": 2048,
-            "expert_only": {
-              "block_output_cosine": 0.963572,
-              "residual_stream_cosine": 1.0,
-              "residual_drift_relative_norm": 0.0,
-              "router_top1_agreement": 1.0,
-              "router_top2_set_agreement": 1.0,
-              "expert_load_js_bits": 0.0,
-              "moe_output_cosine": 0.773483
-            }
-          },
-          "baseline_72": {
-            "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 3,
-            "block_output_cosine": [
-              0.963572,
-              0.945765,
-              0.884956,
-              0.839144
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.341935,
-              0.498308
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.666504,
-              0.52832
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.548828,
-              0.289551
-            ],
-            "chain_exit_residual_drift": 0.6538863846584987,
-            "arm_label": "goz1_expert_ternary_only",
-            "pack_sha256": {
-              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-            },
-            "pack_names": {
-              "0": "block_000-attention_plus_expert.goz1",
-              "1": "block_001-attention_plus_expert.goz1",
-              "2": "block_002-attention_plus_expert.goz1",
-              "3": "block_003-attention_plus_expert.goz1"
-            }
-          },
-          "baseline_74": {
-            "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 2,
-            "block_output_cosine": [
-              0.963572,
-              0.963211,
-              0.90536,
-              0.882308
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.279321,
-              0.449088
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.729004,
-              0.547852
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.592773,
-              0.317383
-            ],
-            "expert_load_js_bits": [
-              0.0,
-              0.005559,
-              0.008548,
-              0.025243
-            ],
-            "chain_exit_residual_drift": 0.5292121735722244,
-            "arm_label": "expert_periodic_hp_n2",
-            "pack_sha256": {
-              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-            },
-            "pack_names": {
-              "0": "block_000-attention_plus_expert.goz1",
-              "1": "block_001-attention_plus_expert.goz1",
-              "2": "block_002-attention_plus_expert.goz1",
-              "3": "block_003-attention_plus_expert.goz1"
-            }
-          },
-          "implementation": {
-            "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
-            "dirty": false
-          },
-          "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-          "numpy": "2.4.6",
-          "python": "3.14.6",
-          "embedding_shard": "embedding__slot_00__token_embedding.npy",
-          "skip_fp16_control": false,
-          "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-          "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-          "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-          "arm": "stacked_hp_channel_alpha",
-          "metrics_filename": "metrics.json",
-          "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-          "evidence_role": "secondary; no independent decision"
-        },
+      "expert_hp_ceiling": {
         "chain": {
+          "arm_label": "expert_hp_ceiling",
           "blocks": [
             0,
             1,
             2,
             3
           ],
-          "tokens": 2048,
-          "token_seed": 20260806,
-          "token_id_first": 61,
-          "token_id_last": 130950,
-          "top_k": 2,
-          "per_block": [
-            {
-              "block": 0,
-              "reference_seconds": 27.824715614318848,
-              "expert_only": {
-                "label": "research_per_channel_side",
-                "seconds": 76.4285888671875,
-                "attention_output_cosine": 1.0,
-                "attention_output_cosine_per_token": 1.0,
-                "residual_stream_cosine": 1.0000000000000002,
-                "moe_input_normalized_cosine": 1.0,
-                "router_logit_cosine": 1.0000000000000002,
-                "moe_output_cosine": 0.8575021309291444,
-                "block_output_cosine": 0.9726518417788741,
-                "block_output_cosine_per_token": 0.9711405778196809,
-                "residual_drift_relative_norm": 0.0,
-                "block_output_drift_relative_norm": 0.23605953012535466,
-                "attn_delta_over_stream": 0.876171419076819,
-                "moe_delta_over_stream": 0.5075108768099885,
-                "router_top1_agreement": 1.0,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 1.0,
-                "router_top2_set_agreement": 1.0,
-                "expert_load_reference": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
-                "expert_load_observed": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
-                "expert_load_js_bits": 0.0,
-                "expert_load_max_abs_delta": 0.0,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.030204764995743812,
-                "router_margin_mean_observed": 0.030204764995743812,
-                "router_margin_mean_delta": 0.0,
-                "router_margin_median_reference": 0.006170867767470903,
-                "router_margin_median_observed": 0.006170867767470903,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 1173,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 443,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 346,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 86,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 1.0,
-                  "residual_in_drift_relative_norm": 0.0
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 28.394131422042847,
-                "attention_output_cosine": 0.9999999984425272,
-                "attention_output_cosine_per_token": 0.9999999986030998,
-                "residual_stream_cosine": 0.9999999831366344,
-                "moe_input_normalized_cosine": 0.9999999606112848,
-                "router_logit_cosine": 0.9999999971505857,
-                "moe_output_cosine": 0.9999813002301362,
-                "block_output_cosine": 0.9999870040322685,
-                "block_output_cosine_per_token": 0.9999880581319095,
-                "residual_drift_relative_norm": 0.00021537206570514935,
-                "block_output_drift_relative_norm": 0.005098830132430907,
-                "attn_delta_over_stream": 0.8760054891005306,
-                "moe_delta_over_stream": 0.4827844972000442,
-                "router_top1_agreement": 0.9970703125,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.9990234375,
-                "router_top2_set_agreement": 0.9990234375,
-                "expert_load_reference": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
-                "expert_load_observed": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.11376953125,
-                  0.127685546875,
-                  0.12841796875,
-                  0.104248046875
-                ],
-                "expert_load_js_bits": 5.347430923457726e-07,
-                "expert_load_max_abs_delta": 0.00048828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.030204764995743812,
-                "router_margin_mean_observed": 0.03020765553259007,
-                "router_margin_mean_delta": 2.8905368462560425e-06,
-                "router_margin_median_reference": 0.006170867767470903,
-                "router_margin_median_observed": 0.006180739225395249,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 1173,
-                    "top1_flips": 6,
-                    "top1_flip_rate": 0.005115089514066497
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 443,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 346,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 86,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 1.0,
-                  "residual_in_drift_relative_norm": 0.0
-                }
-              },
-              "pilot_label": "research_per_channel_side"
-            },
-            {
-              "block": 1,
-              "reference_seconds": 25.78087615966797,
-              "expert_only": {
-                "label": "expert_periodic_hp_n2_plus_channel_alpha",
-                "seconds": 35.44246172904968,
-                "attention_output_cosine": 0.9537457125461298,
-                "attention_output_cosine_per_token": 0.9547903696062463,
-                "residual_stream_cosine": 0.9756508161996449,
-                "moe_input_normalized_cosine": 0.9601410662488471,
-                "router_logit_cosine": 0.9955318341244036,
-                "moe_output_cosine": 0.9253828305545667,
-                "block_output_cosine": 0.9711911788092129,
-                "block_output_cosine_per_token": 0.9700905664055086,
-                "residual_drift_relative_norm": 0.22226741647500073,
-                "block_output_drift_relative_norm": 0.2421697110066684,
-                "attn_delta_over_stream": 0.375156781950687,
-                "moe_delta_over_stream": 0.29349700977658827,
-                "router_top1_agreement": 0.9052734375,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.7041015625,
-                "router_top2_set_agreement": 0.7041015625,
-                "expert_load_reference": [
-                  0.1611328125,
-                  0.120361328125,
-                  0.109619140625,
-                  0.096923828125,
-                  0.117431640625,
-                  0.158203125,
-                  0.103515625,
-                  0.1328125
-                ],
-                "expert_load_observed": [
-                  0.167724609375,
-                  0.11767578125,
-                  0.117431640625,
-                  0.065185546875,
-                  0.128173828125,
-                  0.187255859375,
-                  0.103271484375,
-                  0.11328125
-                ],
-                "expert_load_js_bits": 0.004022827027534971,
-                "expert_load_max_abs_delta": 0.03173828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.1829495230124742,
-                "router_margin_mean_observed": 0.1899807654745718,
-                "router_margin_mean_delta": 0.007031242462097614,
-                "router_margin_median_reference": 0.15255130555045132,
-                "router_margin_median_observed": 0.15411161022976289,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 96,
-                    "top1_flips": 47,
-                    "top1_flip_rate": 0.4895833333333333
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 322,
-                    "top1_flips": 100,
-                    "top1_flip_rate": 0.3105590062111801
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 593,
-                    "top1_flips": 44,
-                    "top1_flip_rate": 0.07419898819561552
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 961,
-                    "top1_flips": 3,
-                    "top1_flip_rate": 0.003121748178980229
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 76,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9726518417788741,
-                  "residual_in_drift_relative_norm": 0.23605953012535466
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 28.875547170639038,
-                "attention_output_cosine": 0.9999955239221966,
-                "attention_output_cosine_per_token": 0.9999949975916551,
-                "residual_stream_cosine": 0.9999902372606576,
-                "moe_input_normalized_cosine": 0.9999833030380135,
-                "router_logit_cosine": 0.9999982162936379,
-                "moe_output_cosine": 0.999966460633255,
-                "block_output_cosine": 0.9999859463229576,
-                "block_output_cosine_per_token": 0.9999851320664717,
-                "residual_drift_relative_norm": 0.004420409079612701,
-                "block_output_drift_relative_norm": 0.005302552089727011,
-                "attn_delta_over_stream": 0.39617942472540063,
-                "moe_delta_over_stream": 0.2896839036553375,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.9990234375,
-                "router_top2_set_agreement": 0.9990234375,
-                "expert_load_reference": [
-                  0.1611328125,
-                  0.120361328125,
-                  0.109619140625,
-                  0.096923828125,
-                  0.117431640625,
-                  0.158203125,
-                  0.103515625,
-                  0.1328125
-                ],
-                "expert_load_observed": [
-                  0.161376953125,
-                  0.1201171875,
-                  0.109619140625,
-                  0.096923828125,
-                  0.11767578125,
-                  0.158203125,
-                  0.103515625,
-                  0.132568359375
-                ],
-                "expert_load_js_bits": 3.2849983466729546e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.1829495230124742,
-                "router_margin_mean_observed": 0.18297782217151998,
-                "router_margin_mean_delta": 2.8299159045821673e-05,
-                "router_margin_median_reference": 0.15255130555045132,
-                "router_margin_median_observed": 0.15256852706410196,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 96,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.010416666666666666
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 322,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 593,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 961,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 76,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999870040322685,
-                  "residual_in_drift_relative_norm": 0.005098830132430907
-                }
-              },
-              "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha"
-            },
-            {
-              "block": 2,
-              "reference_seconds": 24.830881118774414,
-              "expert_only": {
-                "label": "research_per_channel_side",
-                "seconds": 90.06016898155212,
-                "attention_output_cosine": 0.9363165443022808,
-                "attention_output_cosine_per_token": 0.9352787224605859,
-                "residual_stream_cosine": 0.9733152957026273,
-                "moe_input_normalized_cosine": 0.9444280200483108,
-                "router_logit_cosine": 0.9908098965713827,
-                "moe_output_cosine": 0.751475071369639,
-                "block_output_cosine": 0.927501659519474,
-                "block_output_cosine_per_token": 0.9270459433841975,
-                "residual_drift_relative_norm": 0.23735262757428446,
-                "block_output_drift_relative_norm": 0.3845522132305317,
-                "attn_delta_over_stream": 0.6152390393459595,
-                "moe_delta_over_stream": 0.4327739826033704,
-                "router_top1_agreement": 0.76953125,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.654296875,
-                "router_top2_set_agreement": 0.654296875,
-                "expert_load_reference": [
-                  0.047607421875,
-                  0.12646484375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.238525390625
-                ],
-                "expert_load_observed": [
-                  0.055908203125,
-                  0.11083984375,
-                  0.08203125,
-                  0.258544921875,
-                  0.04638671875,
-                  0.068359375,
-                  0.144287109375,
-                  0.233642578125
-                ],
-                "expert_load_js_bits": 0.004506355398090289,
-                "expert_load_max_abs_delta": 0.0283203125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.035814944739152074,
-                "router_margin_mean_observed": 0.034389825678646624,
-                "router_margin_mean_delta": -0.0014251190605054568,
-                "router_margin_median_reference": 0.025870433832144726,
-                "router_margin_median_observed": 0.02456068145770847,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 460,
-                    "top1_flips": 222,
-                    "top1_flip_rate": 0.4826086956521739
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 1055,
-                    "top1_flips": 238,
-                    "top1_flip_rate": 0.22559241706161137
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 513,
-                    "top1_flips": 12,
-                    "top1_flip_rate": 0.023391812865497075
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 20,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9711911788092129,
-                  "residual_in_drift_relative_norm": 0.2421697110066684
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 26.93336820602417,
-                "attention_output_cosine": 0.9999951789248877,
-                "attention_output_cosine_per_token": 0.9999948155995892,
-                "residual_stream_cosine": 0.999991030692396,
-                "moe_input_normalized_cosine": 0.9999805357479619,
-                "router_logit_cosine": 0.9999983004394833,
-                "moe_output_cosine": 0.9998240607737604,
-                "block_output_cosine": 0.9999682697635905,
-                "block_output_cosine_per_token": 0.9999678107431367,
-                "residual_drift_relative_norm": 0.0042354673885935425,
-                "block_output_drift_relative_norm": 0.00796618737672334,
-                "attn_delta_over_stream": 0.5849569779392093,
-                "moe_delta_over_stream": 0.4112808484149002,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.99951171875,
-                "router_top2_set_agreement": 0.99951171875,
-                "expert_load_reference": [
-                  0.047607421875,
-                  0.12646484375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.238525390625
-                ],
-                "expert_load_observed": [
-                  0.047607421875,
-                  0.126708984375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.23828125
-                ],
-                "expert_load_js_bits": 1.300004449968095e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.035814944739152074,
-                "router_margin_mean_observed": 0.03582240482002213,
-                "router_margin_mean_delta": 7.460080870050531e-06,
-                "router_margin_median_reference": 0.025870433832144726,
-                "router_margin_median_observed": 0.025836179844010404,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 460,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.002173913043478261
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 1055,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 513,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 20,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999859463229576,
-                  "residual_in_drift_relative_norm": 0.005302552089727011
-                }
-              },
-              "pilot_label": "research_per_channel_side"
-            },
-            {
-              "block": 3,
-              "reference_seconds": 23.51032519340515,
-              "expert_only": {
-                "label": "expert_periodic_hp_n2_plus_channel_alpha",
-                "seconds": 30.9284565448761,
-                "attention_output_cosine": 0.8684372308517955,
-                "attention_output_cosine_per_token": 0.868727231980265,
-                "residual_stream_cosine": 0.9442427287247533,
-                "moe_input_normalized_cosine": 0.8297263063959471,
-                "router_logit_cosine": 0.9937154787260877,
-                "moe_output_cosine": 0.7915950015847938,
-                "block_output_cosine": 0.9053794674153043,
-                "block_output_cosine_per_token": 0.9056925047079109,
-                "residual_drift_relative_norm": 0.33689389427292654,
-                "block_output_drift_relative_norm": 0.454412543309536,
-                "attn_delta_over_stream": 0.4979273102836338,
-                "moe_delta_over_stream": 0.3448629974189175,
-                "router_top1_agreement": 0.59228515625,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.37646484375,
-                "router_top2_set_agreement": 0.37646484375,
-                "expert_load_reference": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.15625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.194091796875,
-                  0.084716796875
-                ],
-                "expert_load_observed": [
-                  0.0576171875,
-                  0.103759765625,
-                  0.050048828125,
-                  0.170654296875,
-                  0.346435546875,
-                  0.015869140625,
-                  0.128173828125,
-                  0.12744140625
-                ],
-                "expert_load_js_bits": 0.012466325561227416,
-                "expert_load_max_abs_delta": 0.06591796875,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.04406781801268037,
-                "router_margin_mean_observed": 0.0390648383830293,
-                "router_margin_mean_delta": -0.005002979629651071,
-                "router_margin_median_reference": 0.029539565545719543,
-                "router_margin_median_observed": 0.026195236656197385,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 421,
-                    "top1_flips": 285,
-                    "top1_flip_rate": 0.6769596199524941
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 988,
-                    "top1_flips": 462,
-                    "top1_flip_rate": 0.4676113360323887
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 568,
-                    "top1_flips": 88,
-                    "top1_flip_rate": 0.15492957746478872
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 71,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.927501659519474,
-                  "residual_in_drift_relative_norm": 0.3845522132305317
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 35.764336824417114,
-                "attention_output_cosine": 0.9999675515960312,
-                "attention_output_cosine_per_token": 0.9999677009830585,
-                "residual_stream_cosine": 0.9999786349765859,
-                "moe_input_normalized_cosine": 0.9999317806884749,
-                "router_logit_cosine": 0.9999963366268846,
-                "moe_output_cosine": 0.9996961822039626,
-                "block_output_cosine": 0.9999195401569629,
-                "block_output_cosine_per_token": 0.9999220111693956,
-                "residual_drift_relative_norm": 0.006536818304715071,
-                "block_output_drift_relative_norm": 0.012685839893226303,
-                "attn_delta_over_stream": 0.5008011430468392,
-                "moe_delta_over_stream": 0.3568508941802894,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.998046875,
-                "router_top2_set_agreement": 0.998046875,
-                "expert_load_reference": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.15625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.194091796875,
-                  0.084716796875
-                ],
-                "expert_load_observed": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.156494140625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.1943359375,
-                  0.084228515625
-                ],
-                "expert_load_js_bits": 6.330749621763374e-07,
-                "expert_load_max_abs_delta": 0.00048828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.04406781801268037,
-                "router_margin_mean_observed": 0.04404334536098494,
-                "router_margin_mean_delta": -2.4472651695435334e-05,
-                "router_margin_median_reference": 0.029539565545719543,
-                "router_margin_median_observed": 0.02949765995199495,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 421,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.0023752969121140144
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 988,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 568,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 71,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999682697635905,
-                  "residual_in_drift_relative_norm": 0.00796618737672334
-                }
-              },
-              "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha"
-            }
-          ],
+          "channel_alpha_blocks": [],
           "end_of_chain": {
             "expert_only_chain_exit": {
-              "residual_cosine": 0.9053794674153043,
-              "residual_drift_relative_norm": 0.454412543309536,
-              "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+              "note": "post-final-block residual stream (chain exit), not last-block residual-in",
+              "residual_cosine": 0.9999838103358131,
+              "residual_drift_relative_norm": 0.005690267932494616
             },
             "fp16_chain_exit": {
+              "note": "post-final-block residual stream under FP16 control",
               "residual_cosine": 0.9999195401569629,
-              "residual_drift_relative_norm": 0.012685839893226303,
-              "note": "post-final-block residual stream under FP16 control"
+              "residual_drift_relative_norm": 0.012685839893226303
             }
           },
+          "expert_mode": "all_hp",
+          "hp_blocks": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "hp_period": null,
+          "hp_schedule_kind": "all",
+          "hp_schedule_prose": "HP expert ceiling: FP16 experts on every measured block.",
           "pack_provenance": [
             {
               "block": 0,
-              "pack": "block_000-attention_plus_expert.goz1",
-              "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_000-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_000.slot_01.moe_expert.down": "research_per_channel_side",
-                "block_000.slot_00.moe_expert.gate": "research_per_channel_side",
-                "block_000.slot_02.moe_expert.up": "research_per_channel_side"
-              },
-              "pack_scale_sources": {
-                "block_000.slot_01.moe_expert.down": "pack_v2",
-                "block_000.slot_00.moe_expert.gate": "pack_v2",
-                "block_000.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_000.slot_00.moe_expert.gate": {
-                  "alpha": 0.03446429222822189,
-                  "sparsity": 0.652848777671655,
-                  "fired": 559126180,
-                  "total": 1610612736
-                },
-                "block_000.slot_01.moe_expert.down": {
-                  "alpha": 0.02270425483584404,
-                  "sparsity": 0.6372781544923782,
-                  "fired": 584204424,
-                  "total": 1610612736
-                },
-                "block_000.slot_02.moe_expert.up": {
-                  "alpha": 0.0343967042863369,
-                  "sparsity": 0.6443704627454281,
-                  "fired": 572781462,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_000.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2379,52 +1244,52 @@
                   "threshold_abs": 0.004230931401252747
                 }
               },
+              "npy_dir": "goz68-block_000-attn",
+              "pack": "block_000-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_000.slot_00.moe_expert.gate": "pack_v2",
+                "block_000.slot_01.moe_expert.down": "pack_v2",
+                "block_000.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "scale_sources": {
+                "block_000.slot_00.moe_expert.gate": "fp16_control",
+                "block_000.slot_01.moe_expert.down": "fp16_control",
+                "block_000.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_000.slot_00.moe_expert.gate": {
+                  "alpha": 0.03446429222822189,
+                  "fired": 559126180,
+                  "sparsity": 0.652848777671655,
+                  "total": 1610612736
+                },
+                "block_000.slot_01.moe_expert.down": {
+                  "alpha": 0.02270425483584404,
+                  "fired": 584204424,
+                  "sparsity": 0.6372781544923782,
+                  "total": 1610612736
+                },
+                "block_000.slot_02.moe_expert.up": {
+                  "alpha": 0.0343967042863369,
+                  "fired": 572781462,
+                  "sparsity": 0.6443704627454281,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 1,
-              "pack": "block_001-attention_plus_expert.goz1",
-              "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_001-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_001.slot_01.moe_expert.down": "fp16_control",
-                "block_001.slot_00.moe_expert.gate": "fp16_control",
-                "block_001.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_001.slot_01.moe_expert.down": "pack_v2",
-                "block_001.slot_00.moe_expert.gate": "pack_v2",
-                "block_001.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_001.slot_00.moe_expert.gate": {
-                  "alpha": 0.04331796243786812,
-                  "sparsity": 0.633674278234442,
-                  "fired": 590008873,
-                  "total": 1610612736
-                },
-                "block_001.slot_01.moe_expert.down": {
-                  "alpha": 0.010844916105270386,
-                  "sparsity": 0.6404839977622032,
-                  "fired": 579041052,
-                  "total": 1610612736
-                },
-                "block_001.slot_02.moe_expert.up": {
-                  "alpha": 0.04337596148252487,
-                  "sparsity": 0.6348795853555202,
-                  "fired": 588067590,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_001.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2455,52 +1320,52 @@
                   "threshold_abs": 0.007041923236101866
                 }
               },
+              "npy_dir": "goz68-block_001-attn",
+              "pack": "block_001-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_001.slot_00.moe_expert.gate": "pack_v2",
+                "block_001.slot_01.moe_expert.down": "pack_v2",
+                "block_001.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "scale_sources": {
+                "block_001.slot_00.moe_expert.gate": "fp16_control",
+                "block_001.slot_01.moe_expert.down": "fp16_control",
+                "block_001.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_001.slot_00.moe_expert.gate": {
+                  "alpha": 0.04331796243786812,
+                  "fired": 590008873,
+                  "sparsity": 0.633674278234442,
+                  "total": 1610612736
+                },
+                "block_001.slot_01.moe_expert.down": {
+                  "alpha": 0.010844916105270386,
+                  "fired": 579041052,
+                  "sparsity": 0.6404839977622032,
+                  "total": 1610612736
+                },
+                "block_001.slot_02.moe_expert.up": {
+                  "alpha": 0.04337596148252487,
+                  "fired": 588067590,
+                  "sparsity": 0.6348795853555202,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 2,
-              "pack": "block_002-attention_plus_expert.goz1",
-              "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_002-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_002.slot_01.moe_expert.down": "research_per_channel_side",
-                "block_002.slot_00.moe_expert.gate": "research_per_channel_side",
-                "block_002.slot_02.moe_expert.up": "research_per_channel_side"
-              },
-              "pack_scale_sources": {
-                "block_002.slot_01.moe_expert.down": "pack_v2",
-                "block_002.slot_00.moe_expert.gate": "pack_v2",
-                "block_002.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_002.slot_00.moe_expert.gate": {
-                  "alpha": 0.047630175948143005,
-                  "sparsity": 0.6356016273299854,
-                  "fired": 586904660,
-                  "total": 1610612736
-                },
-                "block_002.slot_01.moe_expert.down": {
-                  "alpha": 0.022462978959083557,
-                  "sparsity": 0.6368899804850419,
-                  "fired": 584829622,
-                  "total": 1610612736
-                },
-                "block_002.slot_02.moe_expert.up": {
-                  "alpha": 0.047669243067502975,
-                  "sparsity": 0.6359017888704936,
-                  "fired": 586421216,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_002.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2531,52 +1396,52 @@
                   "threshold_abs": 0.01309292297810316
                 }
               },
+              "npy_dir": "goz68-block_002-attn",
+              "pack": "block_002-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_002.slot_00.moe_expert.gate": "pack_v2",
+                "block_002.slot_01.moe_expert.down": "pack_v2",
+                "block_002.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "scale_sources": {
+                "block_002.slot_00.moe_expert.gate": "fp16_control",
+                "block_002.slot_01.moe_expert.down": "fp16_control",
+                "block_002.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_002.slot_00.moe_expert.gate": {
+                  "alpha": 0.047630175948143005,
+                  "fired": 586904660,
+                  "sparsity": 0.6356016273299854,
+                  "total": 1610612736
+                },
+                "block_002.slot_01.moe_expert.down": {
+                  "alpha": 0.022462978959083557,
+                  "fired": 584829622,
+                  "sparsity": 0.6368899804850419,
+                  "total": 1610612736
+                },
+                "block_002.slot_02.moe_expert.up": {
+                  "alpha": 0.047669243067502975,
+                  "fired": 586421216,
+                  "sparsity": 0.6359017888704936,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 3,
-              "pack": "block_003-attention_plus_expert.goz1",
-              "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_003-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_003.slot_01.moe_expert.down": "fp16_control",
-                "block_003.slot_00.moe_expert.gate": "fp16_control",
-                "block_003.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_003.slot_01.moe_expert.down": "pack_v2",
-                "block_003.slot_00.moe_expert.gate": "pack_v2",
-                "block_003.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_003.slot_00.moe_expert.gate": {
-                  "alpha": 0.03307119756937027,
-                  "sparsity": 0.6364477450648944,
-                  "fired": 585541892,
-                  "total": 1610612736
-                },
-                "block_003.slot_01.moe_expert.down": {
-                  "alpha": 0.015412655659019947,
-                  "sparsity": 0.6372132208198309,
-                  "fired": 584309007,
-                  "total": 1610612736
-                },
-                "block_003.slot_02.moe_expert.up": {
-                  "alpha": 0.033106379210948944,
-                  "sparsity": 0.6368649223198493,
-                  "fired": 584869981,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_003.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2607,229 +1472,60 @@
                   "threshold_abs": 0.0016606772551313043
                 }
               },
+              "npy_dir": "goz68-block_003-attn",
+              "pack": "block_003-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_003.slot_00.moe_expert.gate": "pack_v2",
+                "block_003.slot_01.moe_expert.down": "pack_v2",
+                "block_003.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+              "scale_sources": {
+                "block_003.slot_00.moe_expert.gate": "fp16_control",
+                "block_003.slot_01.moe_expert.down": "fp16_control",
+                "block_003.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_003.slot_00.moe_expert.gate": {
+                  "alpha": 0.03307119756937027,
+                  "fired": 585541892,
+                  "sparsity": 0.6364477450648944,
+                  "total": 1610612736
+                },
+                "block_003.slot_01.moe_expert.down": {
+                  "alpha": 0.015412655659019947,
+                  "fired": 584309007,
+                  "sparsity": 0.6372132208198309,
+                  "total": 1610612736
+                },
+                "block_003.slot_02.moe_expert.up": {
+                  "alpha": 0.033106379210948944,
+                  "fired": 584869981,
+                  "sparsity": 0.6368649223198493,
+                  "total": 1610612736
+                }
               }
             }
           ],
-          "skip_fp16_control": false,
-          "expert_mode": "periodic_hp_plus_channel_alpha",
-          "hp_period": 2,
-          "hp_schedule_kind": "periodic",
-          "hp_blocks": [
-            1,
-            3
-          ],
-          "ternary_blocks": [
-            0,
-            2
-          ],
-          "channel_alpha_blocks": [
-            0,
-            2
-          ],
-          "hp_schedule_prose": "Stacked C+A label `expert_periodic_hp_n2_plus_channel_alpha`: channel-\u03b1 trits on {0,2}, HP (FP16 experts) on {1,3}.",
-          "arm_label": "expert_periodic_hp_n2_plus_channel_alpha",
-          "pilot_labels_per_block": [
-            "research_per_channel_side",
-            "expert_periodic_hp_n2_plus_channel_alpha",
-            "research_per_channel_side",
-            "expert_periodic_hp_n2_plus_channel_alpha"
-          ]
-        }
-      },
-      "expert_hp_ceiling": {
-        "provenance": {
-          "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
-          "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
-          "model": "GPT-5.6 Sol (xhigh)",
-          "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
-          "baseline_64": {
-            "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-            "tokens": 2048,
-            "expert_only": {
-              "block_output_cosine": 0.963572,
-              "residual_stream_cosine": 1.0,
-              "residual_drift_relative_norm": 0.0,
-              "router_top1_agreement": 1.0,
-              "router_top2_set_agreement": 1.0,
-              "expert_load_js_bits": 0.0,
-              "moe_output_cosine": 0.773483
-            }
-          },
-          "baseline_72": {
-            "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 3,
-            "block_output_cosine": [
-              0.963572,
-              0.945765,
-              0.884956,
-              0.839144
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.341935,
-              0.498308
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.666504,
-              0.52832
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.548828,
-              0.289551
-            ],
-            "chain_exit_residual_drift": 0.6538863846584987,
-            "arm_label": "goz1_expert_ternary_only",
-            "pack_sha256": {
-              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-            },
-            "pack_names": {
-              "0": "block_000-attention_plus_expert.goz1",
-              "1": "block_001-attention_plus_expert.goz1",
-              "2": "block_002-attention_plus_expert.goz1",
-              "3": "block_003-attention_plus_expert.goz1"
-            }
-          },
-          "baseline_74": {
-            "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 2,
-            "block_output_cosine": [
-              0.963572,
-              0.963211,
-              0.90536,
-              0.882308
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.279321,
-              0.449088
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.729004,
-              0.547852
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.592773,
-              0.317383
-            ],
-            "expert_load_js_bits": [
-              0.0,
-              0.005559,
-              0.008548,
-              0.025243
-            ],
-            "chain_exit_residual_drift": 0.5292121735722244,
-            "arm_label": "expert_periodic_hp_n2",
-            "pack_sha256": {
-              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-            },
-            "pack_names": {
-              "0": "block_000-attention_plus_expert.goz1",
-              "1": "block_001-attention_plus_expert.goz1",
-              "2": "block_002-attention_plus_expert.goz1",
-              "3": "block_003-attention_plus_expert.goz1"
-            }
-          },
-          "implementation": {
-            "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
-            "dirty": false
-          },
-          "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-          "numpy": "2.4.6",
-          "python": "3.14.6",
-          "embedding_shard": "embedding__slot_00__token_embedding.npy",
-          "skip_fp16_control": false,
-          "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-          "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-          "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-          "arm": "hp_ceiling",
-          "metrics_filename": "metrics.json",
-          "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-          "evidence_role": "secondary; no independent decision"
-        },
-        "chain": {
-          "blocks": [
-            0,
-            1,
-            2,
-            3
-          ],
-          "tokens": 2048,
-          "token_seed": 20260806,
-          "token_id_first": 61,
-          "token_id_last": 130950,
-          "top_k": 2,
           "per_block": [
             {
               "block": 0,
-              "reference_seconds": 19.067675828933716,
               "expert_only": {
-                "label": "expert_hp_ceiling",
-                "seconds": 31.015775203704834,
                 "attention_output_cosine": 1.0,
                 "attention_output_cosine_per_token": 1.0,
-                "residual_stream_cosine": 1.0000000000000002,
-                "moe_input_normalized_cosine": 1.0,
-                "router_logit_cosine": 1.0000000000000002,
-                "moe_output_cosine": 0.9999999941389839,
+                "attn_delta_over_stream": 0.876171419076819,
                 "block_output_cosine": 0.9999999987176428,
                 "block_output_cosine_per_token": 0.9999999986849318,
-                "residual_drift_relative_norm": 0.0,
                 "block_output_drift_relative_norm": 5.0647684479044405e-05,
-                "attn_delta_over_stream": 0.876171419076819,
-                "moe_delta_over_stream": 0.4827432384719955,
-                "router_top1_agreement": 1.0,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 1.0,
-                "router_top2_set_agreement": 1.0,
-                "expert_load_reference": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
+                "expert_load_js_bits": 0.0,
+                "expert_load_max_abs_delta": 0.0,
                 "expert_load_observed": [
                   0.131591796875,
                   0.102294921875,
@@ -2840,51 +1536,15 @@
                   0.12841796875,
                   0.1044921875
                 ],
-                "expert_load_js_bits": 0.0,
-                "expert_load_max_abs_delta": 0.0,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.030204764995743812,
-                "router_margin_mean_observed": 0.030204764995743812,
-                "router_margin_mean_delta": 0.0,
-                "router_margin_median_reference": 0.006170867767470903,
-                "router_margin_median_observed": 0.006170867767470903,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 1173,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 443,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 346,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 86,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
+                "expert_load_reference": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
                 ],
                 "experts_touched": [
                   0,
@@ -2896,40 +1556,76 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 1173,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 443,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 346,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 86,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_hp_ceiling",
+                "moe_delta_over_stream": 0.4827432384719955,
+                "moe_input_normalized_cosine": 1.0,
+                "moe_output_cosine": 0.9999999941389839,
+                "residual_drift_relative_norm": 0.0,
+                "residual_stream_cosine": 1.0000000000000002,
                 "residual_stream_in": {
                   "residual_in_cosine": 1.0,
                   "residual_in_drift_relative_norm": 0.0
-                }
+                },
+                "router_logit_cosine": 1.0000000000000002,
+                "router_margin_mean_delta": 0.0,
+                "router_margin_mean_observed": 0.030204764995743812,
+                "router_margin_mean_reference": 0.030204764995743812,
+                "router_margin_median_observed": 0.006170867767470903,
+                "router_margin_median_reference": 0.006170867767470903,
+                "router_top1_agreement": 1.0,
+                "router_top2_set_agreement": 1.0,
+                "router_topk_set_agreement": 1.0,
+                "seconds": 31.015775203704834,
+                "selected_experts": 2
               },
               "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 21.891437768936157,
                 "attention_output_cosine": 0.9999999984425272,
                 "attention_output_cosine_per_token": 0.9999999986030998,
-                "residual_stream_cosine": 0.9999999831366344,
-                "moe_input_normalized_cosine": 0.9999999606112848,
-                "router_logit_cosine": 0.9999999971505857,
-                "moe_output_cosine": 0.9999813002301362,
+                "attn_delta_over_stream": 0.8760054891005306,
                 "block_output_cosine": 0.9999870040322685,
                 "block_output_cosine_per_token": 0.9999880581319095,
-                "residual_drift_relative_norm": 0.00021537206570514935,
                 "block_output_drift_relative_norm": 0.005098830132430907,
-                "attn_delta_over_stream": 0.8760054891005306,
-                "moe_delta_over_stream": 0.4827844972000442,
-                "router_top1_agreement": 0.9970703125,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.9990234375,
-                "router_top2_set_agreement": 0.9990234375,
-                "expert_load_reference": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
+                "expert_load_js_bits": 5.347430923457726e-07,
+                "expert_load_max_abs_delta": 0.00048828125,
                 "expert_load_observed": [
                   0.131591796875,
                   0.102294921875,
@@ -2940,51 +1636,15 @@
                   0.12841796875,
                   0.104248046875
                 ],
-                "expert_load_js_bits": 5.347430923457726e-07,
-                "expert_load_max_abs_delta": 0.00048828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.030204764995743812,
-                "router_margin_mean_observed": 0.03020765553259007,
-                "router_margin_mean_delta": 2.8905368462560425e-06,
-                "router_margin_median_reference": 0.006170867767470903,
-                "router_margin_median_observed": 0.006180739225395249,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 1173,
-                    "top1_flips": 6,
-                    "top1_flip_rate": 0.005115089514066497
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 443,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 346,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 86,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
+                "expert_load_reference": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
                 ],
                 "experts_touched": [
                   0,
@@ -2996,45 +1656,81 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 1173,
+                    "top1_flip_rate": 0.005115089514066497,
+                    "top1_flips": 6
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 443,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 346,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 86,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.4827844972000442,
+                "moe_input_normalized_cosine": 0.9999999606112848,
+                "moe_output_cosine": 0.9999813002301362,
+                "residual_drift_relative_norm": 0.00021537206570514935,
+                "residual_stream_cosine": 0.9999999831366344,
                 "residual_stream_in": {
                   "residual_in_cosine": 1.0,
                   "residual_in_drift_relative_norm": 0.0
-                }
+                },
+                "router_logit_cosine": 0.9999999971505857,
+                "router_margin_mean_delta": 2.8905368462560425e-06,
+                "router_margin_mean_observed": 0.03020765553259007,
+                "router_margin_mean_reference": 0.030204764995743812,
+                "router_margin_median_observed": 0.006180739225395249,
+                "router_margin_median_reference": 0.006170867767470903,
+                "router_top1_agreement": 0.9970703125,
+                "router_top2_set_agreement": 0.9990234375,
+                "router_topk_set_agreement": 0.9990234375,
+                "seconds": 21.891437768936157,
+                "selected_experts": 2
               },
-              "pilot_label": "expert_hp_ceiling"
+              "pilot_label": "expert_hp_ceiling",
+              "reference_seconds": 19.067675828933716
             },
             {
               "block": 1,
-              "reference_seconds": 20.357039213180542,
               "expert_only": {
-                "label": "expert_hp_ceiling",
-                "seconds": 26.211087226867676,
                 "attention_output_cosine": 0.9999999994946557,
                 "attention_output_cosine_per_token": 0.9999999995122413,
-                "residual_stream_cosine": 0.9999999990198687,
-                "moe_input_normalized_cosine": 0.9999999982554377,
-                "router_logit_cosine": 0.9999999998249586,
-                "moe_output_cosine": 0.9999911806399926,
+                "attn_delta_over_stream": 0.3961665999906308,
                 "block_output_cosine": 0.9999973569164325,
                 "block_output_cosine_per_token": 0.999997468422053,
-                "residual_drift_relative_norm": 4.428102064805694e-05,
                 "block_output_drift_relative_norm": 0.0022991889781694423,
-                "attn_delta_over_stream": 0.3961665999906308,
-                "moe_delta_over_stream": 0.2896296326293033,
-                "router_top1_agreement": 1.0,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.99951171875,
-                "router_top2_set_agreement": 0.99951171875,
-                "expert_load_reference": [
-                  0.1611328125,
-                  0.120361328125,
-                  0.109619140625,
-                  0.096923828125,
-                  0.117431640625,
-                  0.158203125,
-                  0.103515625,
-                  0.1328125
-                ],
+                "expert_load_js_bits": 1.476654090930979e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
                 "expert_load_observed": [
                   0.161376953125,
                   0.120361328125,
@@ -3045,51 +1741,15 @@
                   0.103515625,
                   0.132568359375
                 ],
-                "expert_load_js_bits": 1.476654090930979e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.1829495230124742,
-                "router_margin_mean_observed": 0.1829498613523623,
-                "router_margin_mean_delta": 3.383398881246126e-07,
-                "router_margin_median_reference": 0.15255130555045132,
-                "router_margin_median_observed": 0.15255614636969325,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 96,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 322,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 593,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 961,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 76,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  }
+                "expert_load_reference": [
+                  0.1611328125,
+                  0.120361328125,
+                  0.109619140625,
+                  0.096923828125,
+                  0.117431640625,
+                  0.158203125,
+                  0.103515625,
+                  0.1328125
                 ],
                 "experts_touched": [
                   0,
@@ -3101,40 +1761,76 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 96,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 322,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 593,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 961,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 76,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_hp_ceiling",
+                "moe_delta_over_stream": 0.2896296326293033,
+                "moe_input_normalized_cosine": 0.9999999982554377,
+                "moe_output_cosine": 0.9999911806399926,
+                "residual_drift_relative_norm": 4.428102064805694e-05,
+                "residual_stream_cosine": 0.9999999990198687,
                 "residual_stream_in": {
                   "residual_in_cosine": 0.9999999987176428,
                   "residual_in_drift_relative_norm": 5.0647684479044405e-05
-                }
+                },
+                "router_logit_cosine": 0.9999999998249586,
+                "router_margin_mean_delta": 3.383398881246126e-07,
+                "router_margin_mean_observed": 0.1829498613523623,
+                "router_margin_mean_reference": 0.1829495230124742,
+                "router_margin_median_observed": 0.15255614636969325,
+                "router_margin_median_reference": 0.15255130555045132,
+                "router_top1_agreement": 1.0,
+                "router_top2_set_agreement": 0.99951171875,
+                "router_topk_set_agreement": 0.99951171875,
+                "seconds": 26.211087226867676,
+                "selected_experts": 2
               },
               "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 25.633192539215088,
                 "attention_output_cosine": 0.9999955239221966,
                 "attention_output_cosine_per_token": 0.9999949975916551,
-                "residual_stream_cosine": 0.9999902372606576,
-                "moe_input_normalized_cosine": 0.9999833030380135,
-                "router_logit_cosine": 0.9999982162936379,
-                "moe_output_cosine": 0.999966460633255,
+                "attn_delta_over_stream": 0.39617942472540063,
                 "block_output_cosine": 0.9999859463229576,
                 "block_output_cosine_per_token": 0.9999851320664717,
-                "residual_drift_relative_norm": 0.004420409079612701,
                 "block_output_drift_relative_norm": 0.005302552089727011,
-                "attn_delta_over_stream": 0.39617942472540063,
-                "moe_delta_over_stream": 0.2896839036553375,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.9990234375,
-                "router_top2_set_agreement": 0.9990234375,
-                "expert_load_reference": [
-                  0.1611328125,
-                  0.120361328125,
-                  0.109619140625,
-                  0.096923828125,
-                  0.117431640625,
-                  0.158203125,
-                  0.103515625,
-                  0.1328125
-                ],
+                "expert_load_js_bits": 3.2849983466729546e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
                 "expert_load_observed": [
                   0.161376953125,
                   0.1201171875,
@@ -3145,51 +1841,15 @@
                   0.103515625,
                   0.132568359375
                 ],
-                "expert_load_js_bits": 3.2849983466729546e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.1829495230124742,
-                "router_margin_mean_observed": 0.18297782217151998,
-                "router_margin_mean_delta": 2.8299159045821673e-05,
-                "router_margin_median_reference": 0.15255130555045132,
-                "router_margin_median_observed": 0.15256852706410196,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 96,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.010416666666666666
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 322,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 593,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 961,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 76,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  }
+                "expert_load_reference": [
+                  0.1611328125,
+                  0.120361328125,
+                  0.109619140625,
+                  0.096923828125,
+                  0.117431640625,
+                  0.158203125,
+                  0.103515625,
+                  0.1328125
                 ],
                 "experts_touched": [
                   0,
@@ -3201,45 +1861,81 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 96,
+                    "top1_flip_rate": 0.010416666666666666,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 322,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 593,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 961,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 76,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.2896839036553375,
+                "moe_input_normalized_cosine": 0.9999833030380135,
+                "moe_output_cosine": 0.999966460633255,
+                "residual_drift_relative_norm": 0.004420409079612701,
+                "residual_stream_cosine": 0.9999902372606576,
                 "residual_stream_in": {
                   "residual_in_cosine": 0.9999870040322685,
                   "residual_in_drift_relative_norm": 0.005098830132430907
-                }
+                },
+                "router_logit_cosine": 0.9999982162936379,
+                "router_margin_mean_delta": 2.8299159045821673e-05,
+                "router_margin_mean_observed": 0.18297782217151998,
+                "router_margin_mean_reference": 0.1829495230124742,
+                "router_margin_median_observed": 0.15256852706410196,
+                "router_margin_median_reference": 0.15255130555045132,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.9990234375,
+                "router_topk_set_agreement": 0.9990234375,
+                "seconds": 25.633192539215088,
+                "selected_experts": 2
               },
-              "pilot_label": "expert_hp_ceiling"
+              "pilot_label": "expert_hp_ceiling",
+              "reference_seconds": 20.357039213180542
             },
             {
               "block": 2,
-              "reference_seconds": 22.211421012878418,
               "expert_only": {
-                "label": "expert_hp_ceiling",
-                "seconds": 35.33976721763611,
                 "attention_output_cosine": 0.9999992604583983,
                 "attention_output_cosine_per_token": 0.9999992162168846,
-                "residual_stream_cosine": 0.9999983536330732,
-                "moe_input_normalized_cosine": 0.9999961313227412,
-                "router_logit_cosine": 0.9999994195752296,
-                "moe_output_cosine": 0.9999935905490286,
+                "attn_delta_over_stream": 0.5848367409943813,
                 "block_output_cosine": 0.9999981084993045,
                 "block_output_cosine_per_token": 0.9999982467477101,
-                "residual_drift_relative_norm": 0.001814590431474731,
                 "block_output_drift_relative_norm": 0.001945010680576157,
-                "attn_delta_over_stream": 0.5848367409943813,
-                "moe_delta_over_stream": 0.41127854614413184,
-                "router_top1_agreement": 1.0,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 1.0,
-                "router_top2_set_agreement": 1.0,
-                "expert_load_reference": [
-                  0.047607421875,
-                  0.12646484375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.238525390625
-                ],
+                "expert_load_js_bits": 0.0,
+                "expert_load_max_abs_delta": 0.0,
                 "expert_load_observed": [
                   0.047607421875,
                   0.12646484375,
@@ -3250,51 +1946,15 @@
                   0.172607421875,
                   0.238525390625
                 ],
-                "expert_load_js_bits": 0.0,
-                "expert_load_max_abs_delta": 0.0,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.035814944739152074,
-                "router_margin_mean_observed": 0.03582018331560345,
-                "router_margin_mean_delta": 5.2385764513785335e-06,
-                "router_margin_median_reference": 0.025870433832144726,
-                "router_margin_median_observed": 0.025857554793095913,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 460,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 1055,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 513,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 20,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
+                "expert_load_reference": [
+                  0.047607421875,
+                  0.12646484375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.238525390625
                 ],
                 "experts_touched": [
                   0,
@@ -3306,40 +1966,76 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 460,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 1055,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 513,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 20,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_hp_ceiling",
+                "moe_delta_over_stream": 0.41127854614413184,
+                "moe_input_normalized_cosine": 0.9999961313227412,
+                "moe_output_cosine": 0.9999935905490286,
+                "residual_drift_relative_norm": 0.001814590431474731,
+                "residual_stream_cosine": 0.9999983536330732,
                 "residual_stream_in": {
                   "residual_in_cosine": 0.9999973569164325,
                   "residual_in_drift_relative_norm": 0.0022991889781694423
-                }
+                },
+                "router_logit_cosine": 0.9999994195752296,
+                "router_margin_mean_delta": 5.2385764513785335e-06,
+                "router_margin_mean_observed": 0.03582018331560345,
+                "router_margin_mean_reference": 0.035814944739152074,
+                "router_margin_median_observed": 0.025857554793095913,
+                "router_margin_median_reference": 0.025870433832144726,
+                "router_top1_agreement": 1.0,
+                "router_top2_set_agreement": 1.0,
+                "router_topk_set_agreement": 1.0,
+                "seconds": 35.33976721763611,
+                "selected_experts": 2
               },
               "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 28.80967140197754,
                 "attention_output_cosine": 0.9999951789248877,
                 "attention_output_cosine_per_token": 0.9999948155995892,
-                "residual_stream_cosine": 0.999991030692396,
-                "moe_input_normalized_cosine": 0.9999805357479619,
-                "router_logit_cosine": 0.9999983004394833,
-                "moe_output_cosine": 0.9998240607737604,
+                "attn_delta_over_stream": 0.5849569779392093,
                 "block_output_cosine": 0.9999682697635905,
                 "block_output_cosine_per_token": 0.9999678107431367,
-                "residual_drift_relative_norm": 0.0042354673885935425,
                 "block_output_drift_relative_norm": 0.00796618737672334,
-                "attn_delta_over_stream": 0.5849569779392093,
-                "moe_delta_over_stream": 0.4112808484149002,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.99951171875,
-                "router_top2_set_agreement": 0.99951171875,
-                "expert_load_reference": [
-                  0.047607421875,
-                  0.12646484375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.238525390625
-                ],
+                "expert_load_js_bits": 1.300004449968095e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
                 "expert_load_observed": [
                   0.047607421875,
                   0.126708984375,
@@ -3350,51 +2046,15 @@
                   0.172607421875,
                   0.23828125
                 ],
-                "expert_load_js_bits": 1.300004449968095e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.035814944739152074,
-                "router_margin_mean_observed": 0.03582240482002213,
-                "router_margin_mean_delta": 7.460080870050531e-06,
-                "router_margin_median_reference": 0.025870433832144726,
-                "router_margin_median_observed": 0.025836179844010404,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 460,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.002173913043478261
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 1055,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 513,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 20,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
+                "expert_load_reference": [
+                  0.047607421875,
+                  0.12646484375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.238525390625
                 ],
                 "experts_touched": [
                   0,
@@ -3406,45 +2066,81 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 460,
+                    "top1_flip_rate": 0.002173913043478261,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 1055,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 513,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 20,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.4112808484149002,
+                "moe_input_normalized_cosine": 0.9999805357479619,
+                "moe_output_cosine": 0.9998240607737604,
+                "residual_drift_relative_norm": 0.0042354673885935425,
+                "residual_stream_cosine": 0.999991030692396,
                 "residual_stream_in": {
                   "residual_in_cosine": 0.9999859463229576,
                   "residual_in_drift_relative_norm": 0.005302552089727011
-                }
+                },
+                "router_logit_cosine": 0.9999983004394833,
+                "router_margin_mean_delta": 7.460080870050531e-06,
+                "router_margin_mean_observed": 0.03582240482002213,
+                "router_margin_mean_reference": 0.035814944739152074,
+                "router_margin_median_observed": 0.025836179844010404,
+                "router_margin_median_reference": 0.025870433832144726,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.99951171875,
+                "router_topk_set_agreement": 0.99951171875,
+                "seconds": 28.80967140197754,
+                "selected_experts": 2
               },
-              "pilot_label": "expert_hp_ceiling"
+              "pilot_label": "expert_hp_ceiling",
+              "reference_seconds": 22.211421012878418
             },
             {
               "block": 3,
-              "reference_seconds": 24.783018827438354,
               "expert_only": {
-                "label": "expert_hp_ceiling",
-                "seconds": 37.97921562194824,
                 "attention_output_cosine": 0.9999984526093284,
                 "attention_output_cosine_per_token": 0.999998399621349,
-                "residual_stream_cosine": 0.9999987730401033,
-                "moe_input_normalized_cosine": 0.9999965061636095,
-                "router_logit_cosine": 0.9999998371455628,
-                "moe_output_cosine": 0.9999385489797917,
+                "attn_delta_over_stream": 0.5008300570103207,
                 "block_output_cosine": 0.9999838103358131,
                 "block_output_cosine_per_token": 0.9999829487004541,
-                "residual_drift_relative_norm": 0.0015665364755571474,
                 "block_output_drift_relative_norm": 0.005690267932494616,
-                "attn_delta_over_stream": 0.5008300570103207,
-                "moe_delta_over_stream": 0.3569048369424699,
-                "router_top1_agreement": 1.0,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.99951171875,
-                "router_top2_set_agreement": 0.99951171875,
-                "expert_load_reference": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.15625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.194091796875,
-                  0.084716796875
-                ],
+                "expert_load_js_bits": 1.8240947719967162e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
                 "expert_load_observed": [
                   0.0517578125,
                   0.070556640625,
@@ -3455,86 +2151,6 @@
                   0.1943359375,
                   0.08447265625
                 ],
-                "expert_load_js_bits": 1.8240947719967162e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.04406781801268037,
-                "router_margin_mean_observed": 0.044075594755017454,
-                "router_margin_mean_delta": 7.776742337081259e-06,
-                "router_margin_median_reference": 0.029539565545719543,
-                "router_margin_median_observed": 0.02952833859452031,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 421,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 988,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 568,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 71,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999981084993045,
-                  "residual_in_drift_relative_norm": 0.001945010680576157
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 26.30705761909485,
-                "attention_output_cosine": 0.9999675515960312,
-                "attention_output_cosine_per_token": 0.9999677009830585,
-                "residual_stream_cosine": 0.9999786349765859,
-                "moe_input_normalized_cosine": 0.9999317806884749,
-                "router_logit_cosine": 0.9999963366268846,
-                "moe_output_cosine": 0.9996961822039626,
-                "block_output_cosine": 0.9999195401569629,
-                "block_output_cosine_per_token": 0.9999220111693956,
-                "residual_drift_relative_norm": 0.006536818304715071,
-                "block_output_drift_relative_norm": 0.012685839893226303,
-                "attn_delta_over_stream": 0.5008011430468392,
-                "moe_delta_over_stream": 0.3568508941802894,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.998046875,
-                "router_top2_set_agreement": 0.998046875,
                 "expert_load_reference": [
                   0.0517578125,
                   0.070556640625,
@@ -3545,6 +2161,86 @@
                   0.194091796875,
                   0.084716796875
                 ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 421,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 988,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 568,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 71,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_hp_ceiling",
+                "moe_delta_over_stream": 0.3569048369424699,
+                "moe_input_normalized_cosine": 0.9999965061636095,
+                "moe_output_cosine": 0.9999385489797917,
+                "residual_drift_relative_norm": 0.0015665364755571474,
+                "residual_stream_cosine": 0.9999987730401033,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999981084993045,
+                  "residual_in_drift_relative_norm": 0.001945010680576157
+                },
+                "router_logit_cosine": 0.9999998371455628,
+                "router_margin_mean_delta": 7.776742337081259e-06,
+                "router_margin_mean_observed": 0.044075594755017454,
+                "router_margin_mean_reference": 0.04406781801268037,
+                "router_margin_median_observed": 0.02952833859452031,
+                "router_margin_median_reference": 0.029539565545719543,
+                "router_top1_agreement": 1.0,
+                "router_top2_set_agreement": 0.99951171875,
+                "router_topk_set_agreement": 0.99951171875,
+                "seconds": 37.97921562194824,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999675515960312,
+                "attention_output_cosine_per_token": 0.9999677009830585,
+                "attn_delta_over_stream": 0.5008011430468392,
+                "block_output_cosine": 0.9999195401569629,
+                "block_output_cosine_per_token": 0.9999220111693956,
+                "block_output_drift_relative_norm": 0.012685839893226303,
+                "expert_load_js_bits": 6.330749621763374e-07,
+                "expert_load_max_abs_delta": 0.00048828125,
                 "expert_load_observed": [
                   0.0517578125,
                   0.070556640625,
@@ -3555,51 +2251,15 @@
                   0.1943359375,
                   0.084228515625
                 ],
-                "expert_load_js_bits": 6.330749621763374e-07,
-                "expert_load_max_abs_delta": 0.00048828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.04406781801268037,
-                "router_margin_mean_observed": 0.04404334536098494,
-                "router_margin_mean_delta": -2.4472651695435334e-05,
-                "router_margin_median_reference": 0.029539565545719543,
-                "router_margin_median_observed": 0.02949765995199495,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 421,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.0023752969121140144
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 988,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 568,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 71,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
+                "expert_load_reference": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.15625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.194091796875,
+                  0.084716796875
                 ],
                 "experts_touched": [
                   0,
@@ -3611,66 +2271,268 @@
                   6,
                   7
                 ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 421,
+                    "top1_flip_rate": 0.0023752969121140144,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 988,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 568,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 71,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.3568508941802894,
+                "moe_input_normalized_cosine": 0.9999317806884749,
+                "moe_output_cosine": 0.9996961822039626,
+                "residual_drift_relative_norm": 0.006536818304715071,
+                "residual_stream_cosine": 0.9999786349765859,
                 "residual_stream_in": {
                   "residual_in_cosine": 0.9999682697635905,
                   "residual_in_drift_relative_norm": 0.00796618737672334
-                }
+                },
+                "router_logit_cosine": 0.9999963366268846,
+                "router_margin_mean_delta": -2.4472651695435334e-05,
+                "router_margin_mean_observed": 0.04404334536098494,
+                "router_margin_mean_reference": 0.04406781801268037,
+                "router_margin_median_observed": 0.02949765995199495,
+                "router_margin_median_reference": 0.029539565545719543,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.998046875,
+                "router_topk_set_agreement": 0.998046875,
+                "seconds": 26.30705761909485,
+                "selected_experts": 2
               },
-              "pilot_label": "expert_hp_ceiling"
+              "pilot_label": "expert_hp_ceiling",
+              "reference_seconds": 24.783018827438354
             }
+          ],
+          "pilot_labels_per_block": [
+            "expert_hp_ceiling",
+            "expert_hp_ceiling",
+            "expert_hp_ceiling",
+            "expert_hp_ceiling"
+          ],
+          "skip_fp16_control": false,
+          "ternary_blocks": [],
+          "token_id_first": 61,
+          "token_id_last": 130950,
+          "token_seed": 20260806,
+          "tokens": 2048,
+          "top_k": 2
+        },
+        "provenance": {
+          "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+          "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
+          "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+          "arm": "hp_ceiling",
+          "baseline_64": {
+            "expert_only": {
+              "block_output_cosine": 0.963572,
+              "expert_load_js_bits": 0.0,
+              "moe_output_cosine": 0.773483,
+              "residual_drift_relative_norm": 0.0,
+              "residual_stream_cosine": 1.0,
+              "router_top1_agreement": 1.0,
+              "router_top2_set_agreement": 1.0
+            },
+            "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+            "tokens": 2048
+          },
+          "baseline_72": {
+            "arm_label": "goz1_expert_ternary_only",
+            "block_output_cosine": [
+              0.963572,
+              0.945765,
+              0.884956,
+              0.839144
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.6538863846584987,
+            "decision": 3,
+            "pack_names": {
+              "0": "block_000-attention_plus_expert.goz1",
+              "1": "block_001-attention_plus_expert.goz1",
+              "2": "block_002-attention_plus_expert.goz1",
+              "3": "block_003-attention_plus_expert.goz1"
+            },
+            "pack_sha256": {
+              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+            },
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.341935,
+              0.498308
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.666504,
+              0.52832
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.548828,
+              0.289551
+            ],
+            "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "baseline_74": {
+            "arm_label": "expert_periodic_hp_n2",
+            "block_output_cosine": [
+              0.963572,
+              0.963211,
+              0.90536,
+              0.882308
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.5292121735722244,
+            "decision": 2,
+            "expert_load_js_bits": [
+              0.0,
+              0.005559,
+              0.008548,
+              0.025243
+            ],
+            "pack_names": {
+              "0": "block_000-attention_plus_expert.goz1",
+              "1": "block_001-attention_plus_expert.goz1",
+              "2": "block_002-attention_plus_expert.goz1",
+              "3": "block_003-attention_plus_expert.goz1"
+            },
+            "pack_sha256": {
+              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+            },
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.279321,
+              0.449088
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.729004,
+              0.547852
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.592773,
+              0.317383
+            ],
+            "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
+          "embedding_shard": "embedding__slot_00__token_embedding.npy",
+          "evidence_role": "secondary; no independent decision",
+          "implementation": {
+            "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
+            "dirty": false
+          },
+          "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
+          "metrics_filename": "metrics.json",
+          "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+          "model": "GPT-5.6 Sol (xhigh)",
+          "numpy": "2.4.6",
+          "python": "3.14.6",
+          "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+          "skip_fp16_control": false,
+          "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
+        }
+      },
+      "expert_periodic_hp_n2_plus_channel_alpha": {
+        "chain": {
+          "arm_label": "expert_periodic_hp_n2_plus_channel_alpha",
+          "blocks": [
+            0,
+            1,
+            2,
+            3
+          ],
+          "channel_alpha_blocks": [
+            0,
+            2
           ],
           "end_of_chain": {
             "expert_only_chain_exit": {
-              "residual_cosine": 0.9999838103358131,
-              "residual_drift_relative_norm": 0.005690267932494616,
-              "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+              "note": "post-final-block residual stream (chain exit), not last-block residual-in",
+              "residual_cosine": 0.9053794674153043,
+              "residual_drift_relative_norm": 0.454412543309536
             },
             "fp16_chain_exit": {
+              "note": "post-final-block residual stream under FP16 control",
               "residual_cosine": 0.9999195401569629,
-              "residual_drift_relative_norm": 0.012685839893226303,
-              "note": "post-final-block residual stream under FP16 control"
+              "residual_drift_relative_norm": 0.012685839893226303
             }
           },
+          "expert_mode": "periodic_hp_plus_channel_alpha",
+          "hp_blocks": [
+            1,
+            3
+          ],
+          "hp_period": 2,
+          "hp_schedule_kind": "periodic",
+          "hp_schedule_prose": "Stacked C+A label `expert_periodic_hp_n2_plus_channel_alpha`: channel-\u03b1 trits on {0,2}, HP (FP16 experts) on {1,3}.",
           "pack_provenance": [
             {
               "block": 0,
-              "pack": "block_000-attention_plus_expert.goz1",
-              "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_000-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_000.slot_01.moe_expert.down": "fp16_control",
-                "block_000.slot_00.moe_expert.gate": "fp16_control",
-                "block_000.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_000.slot_01.moe_expert.down": "pack_v2",
-                "block_000.slot_00.moe_expert.gate": "pack_v2",
-                "block_000.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_000.slot_00.moe_expert.gate": {
-                  "alpha": 0.03446429222822189,
-                  "sparsity": 0.652848777671655,
-                  "fired": 559126180,
-                  "total": 1610612736
-                },
-                "block_000.slot_01.moe_expert.down": {
-                  "alpha": 0.02270425483584404,
-                  "sparsity": 0.6372781544923782,
-                  "fired": 584204424,
-                  "total": 1610612736
-                },
-                "block_000.slot_02.moe_expert.up": {
-                  "alpha": 0.0343967042863369,
-                  "sparsity": 0.6443704627454281,
-                  "fired": 572781462,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_000.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -3701,52 +2563,52 @@
                   "threshold_abs": 0.004230931401252747
                 }
               },
+              "npy_dir": "goz68-block_000-attn",
+              "pack": "block_000-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_000.slot_00.moe_expert.gate": "pack_v2",
+                "block_000.slot_01.moe_expert.down": "pack_v2",
+                "block_000.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "scale_sources": {
+                "block_000.slot_00.moe_expert.gate": "research_per_channel_side",
+                "block_000.slot_01.moe_expert.down": "research_per_channel_side",
+                "block_000.slot_02.moe_expert.up": "research_per_channel_side"
+              },
+              "ternary_scales": {
+                "block_000.slot_00.moe_expert.gate": {
+                  "alpha": 0.03446429222822189,
+                  "fired": 559126180,
+                  "sparsity": 0.652848777671655,
+                  "total": 1610612736
+                },
+                "block_000.slot_01.moe_expert.down": {
+                  "alpha": 0.02270425483584404,
+                  "fired": 584204424,
+                  "sparsity": 0.6372781544923782,
+                  "total": 1610612736
+                },
+                "block_000.slot_02.moe_expert.up": {
+                  "alpha": 0.0343967042863369,
+                  "fired": 572781462,
+                  "sparsity": 0.6443704627454281,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 1,
-              "pack": "block_001-attention_plus_expert.goz1",
-              "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_001-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_001.slot_01.moe_expert.down": "fp16_control",
-                "block_001.slot_00.moe_expert.gate": "fp16_control",
-                "block_001.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_001.slot_01.moe_expert.down": "pack_v2",
-                "block_001.slot_00.moe_expert.gate": "pack_v2",
-                "block_001.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_001.slot_00.moe_expert.gate": {
-                  "alpha": 0.04331796243786812,
-                  "sparsity": 0.633674278234442,
-                  "fired": 590008873,
-                  "total": 1610612736
-                },
-                "block_001.slot_01.moe_expert.down": {
-                  "alpha": 0.010844916105270386,
-                  "sparsity": 0.6404839977622032,
-                  "fired": 579041052,
-                  "total": 1610612736
-                },
-                "block_001.slot_02.moe_expert.up": {
-                  "alpha": 0.04337596148252487,
-                  "sparsity": 0.6348795853555202,
-                  "fired": 588067590,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_001.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -3777,52 +2639,52 @@
                   "threshold_abs": 0.007041923236101866
                 }
               },
+              "npy_dir": "goz68-block_001-attn",
+              "pack": "block_001-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_001.slot_00.moe_expert.gate": "pack_v2",
+                "block_001.slot_01.moe_expert.down": "pack_v2",
+                "block_001.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "scale_sources": {
+                "block_001.slot_00.moe_expert.gate": "fp16_control",
+                "block_001.slot_01.moe_expert.down": "fp16_control",
+                "block_001.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_001.slot_00.moe_expert.gate": {
+                  "alpha": 0.04331796243786812,
+                  "fired": 590008873,
+                  "sparsity": 0.633674278234442,
+                  "total": 1610612736
+                },
+                "block_001.slot_01.moe_expert.down": {
+                  "alpha": 0.010844916105270386,
+                  "fired": 579041052,
+                  "sparsity": 0.6404839977622032,
+                  "total": 1610612736
+                },
+                "block_001.slot_02.moe_expert.up": {
+                  "alpha": 0.04337596148252487,
+                  "fired": 588067590,
+                  "sparsity": 0.6348795853555202,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 2,
-              "pack": "block_002-attention_plus_expert.goz1",
-              "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_002-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_002.slot_01.moe_expert.down": "fp16_control",
-                "block_002.slot_00.moe_expert.gate": "fp16_control",
-                "block_002.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_002.slot_01.moe_expert.down": "pack_v2",
-                "block_002.slot_00.moe_expert.gate": "pack_v2",
-                "block_002.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_002.slot_00.moe_expert.gate": {
-                  "alpha": 0.047630175948143005,
-                  "sparsity": 0.6356016273299854,
-                  "fired": 586904660,
-                  "total": 1610612736
-                },
-                "block_002.slot_01.moe_expert.down": {
-                  "alpha": 0.022462978959083557,
-                  "sparsity": 0.6368899804850419,
-                  "fired": 584829622,
-                  "total": 1610612736
-                },
-                "block_002.slot_02.moe_expert.up": {
-                  "alpha": 0.047669243067502975,
-                  "sparsity": 0.6359017888704936,
-                  "fired": 586421216,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_002.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -3853,52 +2715,52 @@
                   "threshold_abs": 0.01309292297810316
                 }
               },
+              "npy_dir": "goz68-block_002-attn",
+              "pack": "block_002-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_002.slot_00.moe_expert.gate": "pack_v2",
+                "block_002.slot_01.moe_expert.down": "pack_v2",
+                "block_002.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "scale_sources": {
+                "block_002.slot_00.moe_expert.gate": "research_per_channel_side",
+                "block_002.slot_01.moe_expert.down": "research_per_channel_side",
+                "block_002.slot_02.moe_expert.up": "research_per_channel_side"
+              },
+              "ternary_scales": {
+                "block_002.slot_00.moe_expert.gate": {
+                  "alpha": 0.047630175948143005,
+                  "fired": 586904660,
+                  "sparsity": 0.6356016273299854,
+                  "total": 1610612736
+                },
+                "block_002.slot_01.moe_expert.down": {
+                  "alpha": 0.022462978959083557,
+                  "fired": 584829622,
+                  "sparsity": 0.6368899804850419,
+                  "total": 1610612736
+                },
+                "block_002.slot_02.moe_expert.up": {
+                  "alpha": 0.047669243067502975,
+                  "fired": 586421216,
+                  "sparsity": 0.6359017888704936,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 3,
-              "pack": "block_003-attention_plus_expert.goz1",
-              "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_003-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_003.slot_01.moe_expert.down": "fp16_control",
-                "block_003.slot_00.moe_expert.gate": "fp16_control",
-                "block_003.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_003.slot_01.moe_expert.down": "pack_v2",
-                "block_003.slot_00.moe_expert.gate": "pack_v2",
-                "block_003.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_003.slot_00.moe_expert.gate": {
-                  "alpha": 0.03307119756937027,
-                  "sparsity": 0.6364477450648944,
-                  "fired": 585541892,
-                  "total": 1610612736
-                },
-                "block_003.slot_01.moe_expert.down": {
-                  "alpha": 0.015412655659019947,
-                  "sparsity": 0.6372132208198309,
-                  "fired": 584309007,
-                  "total": 1610612736
-                },
-                "block_003.slot_02.moe_expert.up": {
-                  "alpha": 0.033106379210948944,
-                  "sparsity": 0.6368649223198493,
-                  "fired": 584869981,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_003.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -3929,110 +2791,1033 @@
                   "threshold_abs": 0.0016606772551313043
                 }
               },
+              "npy_dir": "goz68-block_003-attn",
+              "pack": "block_003-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_003.slot_00.moe_expert.gate": "pack_v2",
+                "block_003.slot_01.moe_expert.down": "pack_v2",
+                "block_003.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+              "scale_sources": {
+                "block_003.slot_00.moe_expert.gate": "fp16_control",
+                "block_003.slot_01.moe_expert.down": "fp16_control",
+                "block_003.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_003.slot_00.moe_expert.gate": {
+                  "alpha": 0.03307119756937027,
+                  "fired": 585541892,
+                  "sparsity": 0.6364477450648944,
+                  "total": 1610612736
+                },
+                "block_003.slot_01.moe_expert.down": {
+                  "alpha": 0.015412655659019947,
+                  "fired": 584309007,
+                  "sparsity": 0.6372132208198309,
+                  "total": 1610612736
+                },
+                "block_003.slot_02.moe_expert.up": {
+                  "alpha": 0.033106379210948944,
+                  "fired": 584869981,
+                  "sparsity": 0.6368649223198493,
+                  "total": 1610612736
+                }
               }
             }
           ],
-          "skip_fp16_control": false,
-          "expert_mode": "all_hp",
-          "hp_period": null,
-          "hp_schedule_kind": "all",
-          "hp_blocks": [
-            0,
-            1,
-            2,
-            3
+          "per_block": [
+            {
+              "block": 0,
+              "expert_only": {
+                "attention_output_cosine": 1.0,
+                "attention_output_cosine_per_token": 1.0,
+                "attn_delta_over_stream": 0.876171419076819,
+                "block_output_cosine": 0.9726518417788741,
+                "block_output_cosine_per_token": 0.9711405778196809,
+                "block_output_drift_relative_norm": 0.23605953012535466,
+                "expert_load_js_bits": 0.0,
+                "expert_load_max_abs_delta": 0.0,
+                "expert_load_observed": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
+                ],
+                "expert_load_reference": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 1173,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 443,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 346,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 86,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "research_per_channel_side",
+                "moe_delta_over_stream": 0.5075108768099885,
+                "moe_input_normalized_cosine": 1.0,
+                "moe_output_cosine": 0.8575021309291444,
+                "residual_drift_relative_norm": 0.0,
+                "residual_stream_cosine": 1.0000000000000002,
+                "residual_stream_in": {
+                  "residual_in_cosine": 1.0,
+                  "residual_in_drift_relative_norm": 0.0
+                },
+                "router_logit_cosine": 1.0000000000000002,
+                "router_margin_mean_delta": 0.0,
+                "router_margin_mean_observed": 0.030204764995743812,
+                "router_margin_mean_reference": 0.030204764995743812,
+                "router_margin_median_observed": 0.006170867767470903,
+                "router_margin_median_reference": 0.006170867767470903,
+                "router_top1_agreement": 1.0,
+                "router_top2_set_agreement": 1.0,
+                "router_topk_set_agreement": 1.0,
+                "seconds": 76.4285888671875,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999999984425272,
+                "attention_output_cosine_per_token": 0.9999999986030998,
+                "attn_delta_over_stream": 0.8760054891005306,
+                "block_output_cosine": 0.9999870040322685,
+                "block_output_cosine_per_token": 0.9999880581319095,
+                "block_output_drift_relative_norm": 0.005098830132430907,
+                "expert_load_js_bits": 5.347430923457726e-07,
+                "expert_load_max_abs_delta": 0.00048828125,
+                "expert_load_observed": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.11376953125,
+                  0.127685546875,
+                  0.12841796875,
+                  0.104248046875
+                ],
+                "expert_load_reference": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 1173,
+                    "top1_flip_rate": 0.005115089514066497,
+                    "top1_flips": 6
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 443,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 346,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 86,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.4827844972000442,
+                "moe_input_normalized_cosine": 0.9999999606112848,
+                "moe_output_cosine": 0.9999813002301362,
+                "residual_drift_relative_norm": 0.00021537206570514935,
+                "residual_stream_cosine": 0.9999999831366344,
+                "residual_stream_in": {
+                  "residual_in_cosine": 1.0,
+                  "residual_in_drift_relative_norm": 0.0
+                },
+                "router_logit_cosine": 0.9999999971505857,
+                "router_margin_mean_delta": 2.8905368462560425e-06,
+                "router_margin_mean_observed": 0.03020765553259007,
+                "router_margin_mean_reference": 0.030204764995743812,
+                "router_margin_median_observed": 0.006180739225395249,
+                "router_margin_median_reference": 0.006170867767470903,
+                "router_top1_agreement": 0.9970703125,
+                "router_top2_set_agreement": 0.9990234375,
+                "router_topk_set_agreement": 0.9990234375,
+                "seconds": 28.394131422042847,
+                "selected_experts": 2
+              },
+              "pilot_label": "research_per_channel_side",
+              "reference_seconds": 27.824715614318848
+            },
+            {
+              "block": 1,
+              "expert_only": {
+                "attention_output_cosine": 0.9537457125461298,
+                "attention_output_cosine_per_token": 0.9547903696062463,
+                "attn_delta_over_stream": 0.375156781950687,
+                "block_output_cosine": 0.9711911788092129,
+                "block_output_cosine_per_token": 0.9700905664055086,
+                "block_output_drift_relative_norm": 0.2421697110066684,
+                "expert_load_js_bits": 0.004022827027534971,
+                "expert_load_max_abs_delta": 0.03173828125,
+                "expert_load_observed": [
+                  0.167724609375,
+                  0.11767578125,
+                  0.117431640625,
+                  0.065185546875,
+                  0.128173828125,
+                  0.187255859375,
+                  0.103271484375,
+                  0.11328125
+                ],
+                "expert_load_reference": [
+                  0.1611328125,
+                  0.120361328125,
+                  0.109619140625,
+                  0.096923828125,
+                  0.117431640625,
+                  0.158203125,
+                  0.103515625,
+                  0.1328125
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 96,
+                    "top1_flip_rate": 0.4895833333333333,
+                    "top1_flips": 47
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 322,
+                    "top1_flip_rate": 0.3105590062111801,
+                    "top1_flips": 100
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 593,
+                    "top1_flip_rate": 0.07419898819561552,
+                    "top1_flips": 44
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 961,
+                    "top1_flip_rate": 0.003121748178980229,
+                    "top1_flips": 3
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 76,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_periodic_hp_n2_plus_channel_alpha",
+                "moe_delta_over_stream": 0.29349700977658827,
+                "moe_input_normalized_cosine": 0.9601410662488471,
+                "moe_output_cosine": 0.9253828305545667,
+                "residual_drift_relative_norm": 0.22226741647500073,
+                "residual_stream_cosine": 0.9756508161996449,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9726518417788741,
+                  "residual_in_drift_relative_norm": 0.23605953012535466
+                },
+                "router_logit_cosine": 0.9955318341244036,
+                "router_margin_mean_delta": 0.007031242462097614,
+                "router_margin_mean_observed": 0.1899807654745718,
+                "router_margin_mean_reference": 0.1829495230124742,
+                "router_margin_median_observed": 0.15411161022976289,
+                "router_margin_median_reference": 0.15255130555045132,
+                "router_top1_agreement": 0.9052734375,
+                "router_top2_set_agreement": 0.7041015625,
+                "router_topk_set_agreement": 0.7041015625,
+                "seconds": 35.44246172904968,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999955239221966,
+                "attention_output_cosine_per_token": 0.9999949975916551,
+                "attn_delta_over_stream": 0.39617942472540063,
+                "block_output_cosine": 0.9999859463229576,
+                "block_output_cosine_per_token": 0.9999851320664717,
+                "block_output_drift_relative_norm": 0.005302552089727011,
+                "expert_load_js_bits": 3.2849983466729546e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
+                "expert_load_observed": [
+                  0.161376953125,
+                  0.1201171875,
+                  0.109619140625,
+                  0.096923828125,
+                  0.11767578125,
+                  0.158203125,
+                  0.103515625,
+                  0.132568359375
+                ],
+                "expert_load_reference": [
+                  0.1611328125,
+                  0.120361328125,
+                  0.109619140625,
+                  0.096923828125,
+                  0.117431640625,
+                  0.158203125,
+                  0.103515625,
+                  0.1328125
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 96,
+                    "top1_flip_rate": 0.010416666666666666,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 322,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 593,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 961,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 76,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.2896839036553375,
+                "moe_input_normalized_cosine": 0.9999833030380135,
+                "moe_output_cosine": 0.999966460633255,
+                "residual_drift_relative_norm": 0.004420409079612701,
+                "residual_stream_cosine": 0.9999902372606576,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999870040322685,
+                  "residual_in_drift_relative_norm": 0.005098830132430907
+                },
+                "router_logit_cosine": 0.9999982162936379,
+                "router_margin_mean_delta": 2.8299159045821673e-05,
+                "router_margin_mean_observed": 0.18297782217151998,
+                "router_margin_mean_reference": 0.1829495230124742,
+                "router_margin_median_observed": 0.15256852706410196,
+                "router_margin_median_reference": 0.15255130555045132,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.9990234375,
+                "router_topk_set_agreement": 0.9990234375,
+                "seconds": 28.875547170639038,
+                "selected_experts": 2
+              },
+              "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha",
+              "reference_seconds": 25.78087615966797
+            },
+            {
+              "block": 2,
+              "expert_only": {
+                "attention_output_cosine": 0.9363165443022808,
+                "attention_output_cosine_per_token": 0.9352787224605859,
+                "attn_delta_over_stream": 0.6152390393459595,
+                "block_output_cosine": 0.927501659519474,
+                "block_output_cosine_per_token": 0.9270459433841975,
+                "block_output_drift_relative_norm": 0.3845522132305317,
+                "expert_load_js_bits": 0.004506355398090289,
+                "expert_load_max_abs_delta": 0.0283203125,
+                "expert_load_observed": [
+                  0.055908203125,
+                  0.11083984375,
+                  0.08203125,
+                  0.258544921875,
+                  0.04638671875,
+                  0.068359375,
+                  0.144287109375,
+                  0.233642578125
+                ],
+                "expert_load_reference": [
+                  0.047607421875,
+                  0.12646484375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.238525390625
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 460,
+                    "top1_flip_rate": 0.4826086956521739,
+                    "top1_flips": 222
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 1055,
+                    "top1_flip_rate": 0.22559241706161137,
+                    "top1_flips": 238
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 513,
+                    "top1_flip_rate": 0.023391812865497075,
+                    "top1_flips": 12
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 20,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "research_per_channel_side",
+                "moe_delta_over_stream": 0.4327739826033704,
+                "moe_input_normalized_cosine": 0.9444280200483108,
+                "moe_output_cosine": 0.751475071369639,
+                "residual_drift_relative_norm": 0.23735262757428446,
+                "residual_stream_cosine": 0.9733152957026273,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9711911788092129,
+                  "residual_in_drift_relative_norm": 0.2421697110066684
+                },
+                "router_logit_cosine": 0.9908098965713827,
+                "router_margin_mean_delta": -0.0014251190605054568,
+                "router_margin_mean_observed": 0.034389825678646624,
+                "router_margin_mean_reference": 0.035814944739152074,
+                "router_margin_median_observed": 0.02456068145770847,
+                "router_margin_median_reference": 0.025870433832144726,
+                "router_top1_agreement": 0.76953125,
+                "router_top2_set_agreement": 0.654296875,
+                "router_topk_set_agreement": 0.654296875,
+                "seconds": 90.06016898155212,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999951789248877,
+                "attention_output_cosine_per_token": 0.9999948155995892,
+                "attn_delta_over_stream": 0.5849569779392093,
+                "block_output_cosine": 0.9999682697635905,
+                "block_output_cosine_per_token": 0.9999678107431367,
+                "block_output_drift_relative_norm": 0.00796618737672334,
+                "expert_load_js_bits": 1.300004449968095e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
+                "expert_load_observed": [
+                  0.047607421875,
+                  0.126708984375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.23828125
+                ],
+                "expert_load_reference": [
+                  0.047607421875,
+                  0.12646484375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.238525390625
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 460,
+                    "top1_flip_rate": 0.002173913043478261,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 1055,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 513,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 20,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.4112808484149002,
+                "moe_input_normalized_cosine": 0.9999805357479619,
+                "moe_output_cosine": 0.9998240607737604,
+                "residual_drift_relative_norm": 0.0042354673885935425,
+                "residual_stream_cosine": 0.999991030692396,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999859463229576,
+                  "residual_in_drift_relative_norm": 0.005302552089727011
+                },
+                "router_logit_cosine": 0.9999983004394833,
+                "router_margin_mean_delta": 7.460080870050531e-06,
+                "router_margin_mean_observed": 0.03582240482002213,
+                "router_margin_mean_reference": 0.035814944739152074,
+                "router_margin_median_observed": 0.025836179844010404,
+                "router_margin_median_reference": 0.025870433832144726,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.99951171875,
+                "router_topk_set_agreement": 0.99951171875,
+                "seconds": 26.93336820602417,
+                "selected_experts": 2
+              },
+              "pilot_label": "research_per_channel_side",
+              "reference_seconds": 24.830881118774414
+            },
+            {
+              "block": 3,
+              "expert_only": {
+                "attention_output_cosine": 0.8684372308517955,
+                "attention_output_cosine_per_token": 0.868727231980265,
+                "attn_delta_over_stream": 0.4979273102836338,
+                "block_output_cosine": 0.9053794674153043,
+                "block_output_cosine_per_token": 0.9056925047079109,
+                "block_output_drift_relative_norm": 0.454412543309536,
+                "expert_load_js_bits": 0.012466325561227416,
+                "expert_load_max_abs_delta": 0.06591796875,
+                "expert_load_observed": [
+                  0.0576171875,
+                  0.103759765625,
+                  0.050048828125,
+                  0.170654296875,
+                  0.346435546875,
+                  0.015869140625,
+                  0.128173828125,
+                  0.12744140625
+                ],
+                "expert_load_reference": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.15625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.194091796875,
+                  0.084716796875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 421,
+                    "top1_flip_rate": 0.6769596199524941,
+                    "top1_flips": 285
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 988,
+                    "top1_flip_rate": 0.4676113360323887,
+                    "top1_flips": 462
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 568,
+                    "top1_flip_rate": 0.15492957746478872,
+                    "top1_flips": 88
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 71,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_periodic_hp_n2_plus_channel_alpha",
+                "moe_delta_over_stream": 0.3448629974189175,
+                "moe_input_normalized_cosine": 0.8297263063959471,
+                "moe_output_cosine": 0.7915950015847938,
+                "residual_drift_relative_norm": 0.33689389427292654,
+                "residual_stream_cosine": 0.9442427287247533,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.927501659519474,
+                  "residual_in_drift_relative_norm": 0.3845522132305317
+                },
+                "router_logit_cosine": 0.9937154787260877,
+                "router_margin_mean_delta": -0.005002979629651071,
+                "router_margin_mean_observed": 0.0390648383830293,
+                "router_margin_mean_reference": 0.04406781801268037,
+                "router_margin_median_observed": 0.026195236656197385,
+                "router_margin_median_reference": 0.029539565545719543,
+                "router_top1_agreement": 0.59228515625,
+                "router_top2_set_agreement": 0.37646484375,
+                "router_topk_set_agreement": 0.37646484375,
+                "seconds": 30.9284565448761,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999675515960312,
+                "attention_output_cosine_per_token": 0.9999677009830585,
+                "attn_delta_over_stream": 0.5008011430468392,
+                "block_output_cosine": 0.9999195401569629,
+                "block_output_cosine_per_token": 0.9999220111693956,
+                "block_output_drift_relative_norm": 0.012685839893226303,
+                "expert_load_js_bits": 6.330749621763374e-07,
+                "expert_load_max_abs_delta": 0.00048828125,
+                "expert_load_observed": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.156494140625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.1943359375,
+                  0.084228515625
+                ],
+                "expert_load_reference": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.15625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.194091796875,
+                  0.084716796875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 421,
+                    "top1_flip_rate": 0.0023752969121140144,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 988,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 568,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 71,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.3568508941802894,
+                "moe_input_normalized_cosine": 0.9999317806884749,
+                "moe_output_cosine": 0.9996961822039626,
+                "residual_drift_relative_norm": 0.006536818304715071,
+                "residual_stream_cosine": 0.9999786349765859,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999682697635905,
+                  "residual_in_drift_relative_norm": 0.00796618737672334
+                },
+                "router_logit_cosine": 0.9999963366268846,
+                "router_margin_mean_delta": -2.4472651695435334e-05,
+                "router_margin_mean_observed": 0.04404334536098494,
+                "router_margin_mean_reference": 0.04406781801268037,
+                "router_margin_median_observed": 0.02949765995199495,
+                "router_margin_median_reference": 0.029539565545719543,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.998046875,
+                "router_topk_set_agreement": 0.998046875,
+                "seconds": 35.764336824417114,
+                "selected_experts": 2
+              },
+              "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha",
+              "reference_seconds": 23.51032519340515
+            }
           ],
-          "ternary_blocks": [],
-          "channel_alpha_blocks": [],
-          "hp_schedule_prose": "HP expert ceiling: FP16 experts on every measured block.",
-          "arm_label": "expert_hp_ceiling",
           "pilot_labels_per_block": [
-            "expert_hp_ceiling",
-            "expert_hp_ceiling",
-            "expert_hp_ceiling",
-            "expert_hp_ceiling"
-          ]
+            "research_per_channel_side",
+            "expert_periodic_hp_n2_plus_channel_alpha",
+            "research_per_channel_side",
+            "expert_periodic_hp_n2_plus_channel_alpha"
+          ],
+          "skip_fp16_control": false,
+          "ternary_blocks": [
+            0,
+            2
+          ],
+          "token_id_first": 61,
+          "token_id_last": 130950,
+          "token_seed": 20260806,
+          "tokens": 2048,
+          "top_k": 2
+        },
+        "provenance": {
+          "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+          "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
+          "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+          "arm": "stacked_hp_channel_alpha",
+          "baseline_64": {
+            "expert_only": {
+              "block_output_cosine": 0.963572,
+              "expert_load_js_bits": 0.0,
+              "moe_output_cosine": 0.773483,
+              "residual_drift_relative_norm": 0.0,
+              "residual_stream_cosine": 1.0,
+              "router_top1_agreement": 1.0,
+              "router_top2_set_agreement": 1.0
+            },
+            "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+            "tokens": 2048
+          },
+          "baseline_72": {
+            "arm_label": "goz1_expert_ternary_only",
+            "block_output_cosine": [
+              0.963572,
+              0.945765,
+              0.884956,
+              0.839144
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.6538863846584987,
+            "decision": 3,
+            "pack_names": {
+              "0": "block_000-attention_plus_expert.goz1",
+              "1": "block_001-attention_plus_expert.goz1",
+              "2": "block_002-attention_plus_expert.goz1",
+              "3": "block_003-attention_plus_expert.goz1"
+            },
+            "pack_sha256": {
+              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+            },
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.341935,
+              0.498308
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.666504,
+              0.52832
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.548828,
+              0.289551
+            ],
+            "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "baseline_74": {
+            "arm_label": "expert_periodic_hp_n2",
+            "block_output_cosine": [
+              0.963572,
+              0.963211,
+              0.90536,
+              0.882308
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.5292121735722244,
+            "decision": 2,
+            "expert_load_js_bits": [
+              0.0,
+              0.005559,
+              0.008548,
+              0.025243
+            ],
+            "pack_names": {
+              "0": "block_000-attention_plus_expert.goz1",
+              "1": "block_001-attention_plus_expert.goz1",
+              "2": "block_002-attention_plus_expert.goz1",
+              "3": "block_003-attention_plus_expert.goz1"
+            },
+            "pack_sha256": {
+              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+            },
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.279321,
+              0.449088
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.729004,
+              0.547852
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.592773,
+              0.317383
+            ],
+            "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
+          "embedding_shard": "embedding__slot_00__token_embedding.npy",
+          "evidence_role": "secondary; no independent decision",
+          "implementation": {
+            "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
+            "dirty": false
+          },
+          "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
+          "metrics_filename": "metrics.json",
+          "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+          "model": "GPT-5.6 Sol (xhigh)",
+          "numpy": "2.4.6",
+          "python": "3.14.6",
+          "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+          "skip_fp16_control": false,
+          "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
         }
       }
     },
     "summaries": {
-      "expert_periodic_hp_123": {
-        "arm_label": "expert_periodic_hp_123",
-        "block_output_cosine": [
-          0.9635717950590136,
-          0.9632111934148898,
-          0.9396838167556127,
-          0.9138530769863993
-        ],
-        "residual_in_drift": [
-          0.0,
-          0.27735082427370883,
-          0.27932072855348866,
-          0.3484754820003742
-        ],
-        "router_top1": [
-          1.0,
-          0.8876953125,
-          0.72900390625,
-          0.61572265625
-        ],
-        "router_top2": [
-          1.0,
-          0.6806640625,
-          0.5927734375,
-          0.40869140625
-        ],
-        "expert_load_js_bits": [
-          0.0,
-          0.005558745183592211,
-          0.008547932604502501,
-          0.0244658927183635
-        ],
-        "chain_exit_residual_drift": 0.4370545723375058,
-        "compounding": "roughly_linear",
-        "viable": false
-      },
-      "expert_periodic_hp_n2_plus_channel_alpha": {
-        "arm_label": "expert_periodic_hp_n2_plus_channel_alpha",
-        "block_output_cosine": [
-          0.9726518417788741,
-          0.9711911788092129,
-          0.927501659519474,
-          0.9053794674153043
-        ],
-        "residual_in_drift": [
-          0.0,
-          0.23605953012535466,
-          0.2421697110066684,
-          0.3845522132305317
-        ],
-        "router_top1": [
-          1.0,
-          0.9052734375,
-          0.76953125,
-          0.59228515625
-        ],
-        "router_top2": [
-          1.0,
-          0.7041015625,
-          0.654296875,
-          0.37646484375
-        ],
-        "expert_load_js_bits": [
-          0.0,
-          0.004022827027534971,
-          0.004506355398090289,
-          0.012466325561227416
-        ],
-        "chain_exit_residual_drift": 0.454412543309536,
-        "compounding": "roughly_linear",
-        "viable": false
-      },
       "expert_hp_ceiling": {
         "arm_label": "expert_hp_ceiling",
         "block_output_cosine": [
@@ -4040,6 +3825,14 @@
           0.9999973569164325,
           0.9999981084993045,
           0.9999838103358131
+        ],
+        "chain_exit_residual_drift": 0.005690267932494616,
+        "compounding": "superlinear_or_runaway",
+        "expert_load_js_bits": [
+          0.0,
+          1.476654090930979e-07,
+          0.0,
+          1.8240947719967162e-07
         ],
         "residual_in_drift": [
           0.0,
@@ -4059,20 +3852,86 @@
           1.0,
           0.99951171875
         ],
+        "viable": true
+      },
+      "expert_periodic_hp_123": {
+        "arm_label": "expert_periodic_hp_123",
+        "block_output_cosine": [
+          0.9635717950590136,
+          0.9632111934148898,
+          0.9396838167556127,
+          0.9138530769863993
+        ],
+        "chain_exit_residual_drift": 0.4370545723375058,
+        "compounding": "roughly_linear",
         "expert_load_js_bits": [
           0.0,
-          1.476654090930979e-07,
-          0.0,
-          1.8240947719967162e-07
+          0.005558745183592211,
+          0.008547932604502501,
+          0.0244658927183635
         ],
-        "chain_exit_residual_drift": 0.005690267932494616,
-        "compounding": "superlinear_or_runaway",
-        "viable": true
+        "residual_in_drift": [
+          0.0,
+          0.27735082427370883,
+          0.27932072855348866,
+          0.3484754820003742
+        ],
+        "router_top1": [
+          1.0,
+          0.8876953125,
+          0.72900390625,
+          0.61572265625
+        ],
+        "router_top2": [
+          1.0,
+          0.6806640625,
+          0.5927734375,
+          0.40869140625
+        ],
+        "viable": false
+      },
+      "expert_periodic_hp_n2_plus_channel_alpha": {
+        "arm_label": "expert_periodic_hp_n2_plus_channel_alpha",
+        "block_output_cosine": [
+          0.9726518417788741,
+          0.9711911788092129,
+          0.927501659519474,
+          0.9053794674153043
+        ],
+        "chain_exit_residual_drift": 0.454412543309536,
+        "compounding": "roughly_linear",
+        "expert_load_js_bits": [
+          0.0,
+          0.004022827027534971,
+          0.004506355398090289,
+          0.012466325561227416
+        ],
+        "residual_in_drift": [
+          0.0,
+          0.23605953012535466,
+          0.2421697110066684,
+          0.3845522132305317
+        ],
+        "router_top1": [
+          1.0,
+          0.9052734375,
+          0.76953125,
+          0.59228515625
+        ],
+        "router_top2": [
+          1.0,
+          0.7041015625,
+          0.654296875,
+          0.37646484375
+        ],
+        "viable": false
       }
     },
     "validation_errors": []
   },
   "decision": {
+    "best_remedy_arm": "expert_periodic_hp_123",
+    "compounding": "roughly_linear",
     "decision": 2,
     "decision_text": "Stronger remedies help, but full-HP experts or another correction remain required.",
     "rationale": [
@@ -4086,8 +3945,149 @@
       "hp_ceiling_viable=True",
       "any_mostly_ternary_improved_vs_74=True",
       "locked_option_2_requires_improvement_and_ceiling=True"
-    ],
-    "compounding": "roughly_linear",
-    "best_remedy_arm": "expert_periodic_hp_123"
+    ]
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "periodic_hp",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "primary; sole canonical #75 decision",
+    "implementation": {
+      "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
+      "dirty": false
+    },
+    "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+    "model": "GPT-5.6 Sol (xhigh)",
+    "numpy": "2.4.6",
+    "python": "3.14.6",
+    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v2/stacked-channel-alpha/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v2/stacked-channel-alpha/metrics.json
@@ -1,1033 +1,42 @@
 {
-  "provenance": {
-    "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
-    "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
-    "model": "GPT-5.6 Sol (xhigh)",
-    "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "implementation": {
-      "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.4.6",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-    "arm": "stacked_hp_channel_alpha",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-    "evidence_role": "secondary; no independent decision"
-  },
   "chain": {
+    "arm_label": "expert_periodic_hp_n2_plus_channel_alpha",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 27.824715614318848,
-        "expert_only": {
-          "label": "research_per_channel_side",
-          "seconds": 76.4285888671875,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0000000000000002,
-          "moe_output_cosine": 0.8575021309291444,
-          "block_output_cosine": 0.9726518417788741,
-          "block_output_cosine_per_token": 0.9711405778196809,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.23605953012535466,
-          "attn_delta_over_stream": 0.876171419076819,
-          "moe_delta_over_stream": 0.5075108768099885,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204764995743812,
-          "router_margin_mean_observed": 0.030204764995743812,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170867767470903,
-          "router_margin_median_observed": 0.006170867767470903,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 28.394131422042847,
-          "attention_output_cosine": 0.9999999984425272,
-          "attention_output_cosine_per_token": 0.9999999986030998,
-          "residual_stream_cosine": 0.9999999831366344,
-          "moe_input_normalized_cosine": 0.9999999606112848,
-          "router_logit_cosine": 0.9999999971505857,
-          "moe_output_cosine": 0.9999813002301362,
-          "block_output_cosine": 0.9999870040322685,
-          "block_output_cosine_per_token": 0.9999880581319095,
-          "residual_drift_relative_norm": 0.00021537206570514935,
-          "block_output_drift_relative_norm": 0.005098830132430907,
-          "attn_delta_over_stream": 0.8760054891005306,
-          "moe_delta_over_stream": 0.4827844972000442,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204764995743812,
-          "router_margin_mean_observed": 0.03020765553259007,
-          "router_margin_mean_delta": 2.8905368462560425e-06,
-          "router_margin_median_reference": 0.006170867767470903,
-          "router_margin_median_observed": 0.006180739225395249,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "research_per_channel_side"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 25.78087615966797,
-        "expert_only": {
-          "label": "expert_periodic_hp_n2_plus_channel_alpha",
-          "seconds": 35.44246172904968,
-          "attention_output_cosine": 0.9537457125461298,
-          "attention_output_cosine_per_token": 0.9547903696062463,
-          "residual_stream_cosine": 0.9756508161996449,
-          "moe_input_normalized_cosine": 0.9601410662488471,
-          "router_logit_cosine": 0.9955318341244036,
-          "moe_output_cosine": 0.9253828305545667,
-          "block_output_cosine": 0.9711911788092129,
-          "block_output_cosine_per_token": 0.9700905664055086,
-          "residual_drift_relative_norm": 0.22226741647500073,
-          "block_output_drift_relative_norm": 0.2421697110066684,
-          "attn_delta_over_stream": 0.375156781950687,
-          "moe_delta_over_stream": 0.29349700977658827,
-          "router_top1_agreement": 0.9052734375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.7041015625,
-          "router_top2_set_agreement": 0.7041015625,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.167724609375,
-            0.11767578125,
-            0.117431640625,
-            0.065185546875,
-            0.128173828125,
-            0.187255859375,
-            0.103271484375,
-            0.11328125
-          ],
-          "expert_load_js_bits": 0.004022827027534971,
-          "expert_load_max_abs_delta": 0.03173828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495230124742,
-          "router_margin_mean_observed": 0.1899807654745718,
-          "router_margin_mean_delta": 0.007031242462097614,
-          "router_margin_median_reference": 0.15255130555045132,
-          "router_margin_median_observed": 0.15411161022976289,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 47,
-              "top1_flip_rate": 0.4895833333333333
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 100,
-              "top1_flip_rate": 0.3105590062111801
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 44,
-              "top1_flip_rate": 0.07419898819561552
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 3,
-              "top1_flip_rate": 0.003121748178980229
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9726518417788741,
-            "residual_in_drift_relative_norm": 0.23605953012535466
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 28.875547170639038,
-          "attention_output_cosine": 0.9999955239221966,
-          "attention_output_cosine_per_token": 0.9999949975916551,
-          "residual_stream_cosine": 0.9999902372606576,
-          "moe_input_normalized_cosine": 0.9999833030380135,
-          "router_logit_cosine": 0.9999982162936379,
-          "moe_output_cosine": 0.999966460633255,
-          "block_output_cosine": 0.9999859463229576,
-          "block_output_cosine_per_token": 0.9999851320664717,
-          "residual_drift_relative_norm": 0.004420409079612701,
-          "block_output_drift_relative_norm": 0.005302552089727011,
-          "attn_delta_over_stream": 0.39617942472540063,
-          "moe_delta_over_stream": 0.2896839036553375,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495230124742,
-          "router_margin_mean_observed": 0.18297782217151998,
-          "router_margin_mean_delta": 2.8299159045821673e-05,
-          "router_margin_median_reference": 0.15255130555045132,
-          "router_margin_median_observed": 0.15256852706410196,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040322685,
-            "residual_in_drift_relative_norm": 0.005098830132430907
-          }
-        },
-        "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 24.830881118774414,
-        "expert_only": {
-          "label": "research_per_channel_side",
-          "seconds": 90.06016898155212,
-          "attention_output_cosine": 0.9363165443022808,
-          "attention_output_cosine_per_token": 0.9352787224605859,
-          "residual_stream_cosine": 0.9733152957026273,
-          "moe_input_normalized_cosine": 0.9444280200483108,
-          "router_logit_cosine": 0.9908098965713827,
-          "moe_output_cosine": 0.751475071369639,
-          "block_output_cosine": 0.927501659519474,
-          "block_output_cosine_per_token": 0.9270459433841975,
-          "residual_drift_relative_norm": 0.23735262757428446,
-          "block_output_drift_relative_norm": 0.3845522132305317,
-          "attn_delta_over_stream": 0.6152390393459595,
-          "moe_delta_over_stream": 0.4327739826033704,
-          "router_top1_agreement": 0.76953125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.654296875,
-          "router_top2_set_agreement": 0.654296875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.055908203125,
-            0.11083984375,
-            0.08203125,
-            0.258544921875,
-            0.04638671875,
-            0.068359375,
-            0.144287109375,
-            0.233642578125
-          ],
-          "expert_load_js_bits": 0.004506355398090289,
-          "expert_load_max_abs_delta": 0.0283203125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814944739152074,
-          "router_margin_mean_observed": 0.034389825678646624,
-          "router_margin_mean_delta": -0.0014251190605054568,
-          "router_margin_median_reference": 0.025870433832144726,
-          "router_margin_median_observed": 0.02456068145770847,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 222,
-              "top1_flip_rate": 0.4826086956521739
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 238,
-              "top1_flip_rate": 0.22559241706161137
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 12,
-              "top1_flip_rate": 0.023391812865497075
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9711911788092129,
-            "residual_in_drift_relative_norm": 0.2421697110066684
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 26.93336820602417,
-          "attention_output_cosine": 0.9999951789248877,
-          "attention_output_cosine_per_token": 0.9999948155995892,
-          "residual_stream_cosine": 0.999991030692396,
-          "moe_input_normalized_cosine": 0.9999805357479619,
-          "router_logit_cosine": 0.9999983004394833,
-          "moe_output_cosine": 0.9998240607737604,
-          "block_output_cosine": 0.9999682697635905,
-          "block_output_cosine_per_token": 0.9999678107431367,
-          "residual_drift_relative_norm": 0.0042354673885935425,
-          "block_output_drift_relative_norm": 0.00796618737672334,
-          "attn_delta_over_stream": 0.5849569779392093,
-          "moe_delta_over_stream": 0.4112808484149002,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814944739152074,
-          "router_margin_mean_observed": 0.03582240482002213,
-          "router_margin_mean_delta": 7.460080870050531e-06,
-          "router_margin_median_reference": 0.025870433832144726,
-          "router_margin_median_observed": 0.025836179844010404,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463229576,
-            "residual_in_drift_relative_norm": 0.005302552089727011
-          }
-        },
-        "pilot_label": "research_per_channel_side"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 23.51032519340515,
-        "expert_only": {
-          "label": "expert_periodic_hp_n2_plus_channel_alpha",
-          "seconds": 30.9284565448761,
-          "attention_output_cosine": 0.8684372308517955,
-          "attention_output_cosine_per_token": 0.868727231980265,
-          "residual_stream_cosine": 0.9442427287247533,
-          "moe_input_normalized_cosine": 0.8297263063959471,
-          "router_logit_cosine": 0.9937154787260877,
-          "moe_output_cosine": 0.7915950015847938,
-          "block_output_cosine": 0.9053794674153043,
-          "block_output_cosine_per_token": 0.9056925047079109,
-          "residual_drift_relative_norm": 0.33689389427292654,
-          "block_output_drift_relative_norm": 0.454412543309536,
-          "attn_delta_over_stream": 0.4979273102836338,
-          "moe_delta_over_stream": 0.3448629974189175,
-          "router_top1_agreement": 0.59228515625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.37646484375,
-          "router_top2_set_agreement": 0.37646484375,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0576171875,
-            0.103759765625,
-            0.050048828125,
-            0.170654296875,
-            0.346435546875,
-            0.015869140625,
-            0.128173828125,
-            0.12744140625
-          ],
-          "expert_load_js_bits": 0.012466325561227416,
-          "expert_load_max_abs_delta": 0.06591796875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.04406781801268037,
-          "router_margin_mean_observed": 0.0390648383830293,
-          "router_margin_mean_delta": -0.005002979629651071,
-          "router_margin_median_reference": 0.029539565545719543,
-          "router_margin_median_observed": 0.026195236656197385,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 285,
-              "top1_flip_rate": 0.6769596199524941
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 462,
-              "top1_flip_rate": 0.4676113360323887
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 88,
-              "top1_flip_rate": 0.15492957746478872
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.927501659519474,
-            "residual_in_drift_relative_norm": 0.3845522132305317
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 35.764336824417114,
-          "attention_output_cosine": 0.9999675515960312,
-          "attention_output_cosine_per_token": 0.9999677009830585,
-          "residual_stream_cosine": 0.9999786349765859,
-          "moe_input_normalized_cosine": 0.9999317806884749,
-          "router_logit_cosine": 0.9999963366268846,
-          "moe_output_cosine": 0.9996961822039626,
-          "block_output_cosine": 0.9999195401569629,
-          "block_output_cosine_per_token": 0.9999220111693956,
-          "residual_drift_relative_norm": 0.006536818304715071,
-          "block_output_drift_relative_norm": 0.012685839893226303,
-          "attn_delta_over_stream": 0.5008011430468392,
-          "moe_delta_over_stream": 0.3568508941802894,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.04406781801268037,
-          "router_margin_mean_observed": 0.04404334536098494,
-          "router_margin_mean_delta": -2.4472651695435334e-05,
-          "router_margin_median_reference": 0.029539565545719543,
-          "router_margin_median_observed": 0.02949765995199495,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697635905,
-            "residual_in_drift_relative_norm": 0.00796618737672334
-          }
-        },
-        "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha"
-      }
+    "channel_alpha_blocks": [
+      0,
+      2
     ],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.9053794674153043,
-        "residual_drift_relative_norm": 0.454412543309536,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.454412543309536
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401569629,
-        "residual_drift_relative_norm": 0.012685839893226303,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685839893226303
       }
     },
+    "expert_mode": "periodic_hp_plus_channel_alpha",
+    "hp_blocks": [
+      1,
+      3
+    ],
+    "hp_period": 2,
+    "hp_schedule_kind": "periodic",
+    "hp_schedule_prose": "Stacked C+A label `expert_periodic_hp_n2_plus_channel_alpha`: channel-\u03b1 trits on {0,2}, HP (FP16 experts) on {1,3}.",
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "research_per_channel_side",
-          "block_000.slot_00.moe_expert.gate": "research_per_channel_side",
-          "block_000.slot_02.moe_expert.up": "research_per_channel_side"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1058,52 +67,52 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "research_per_channel_side",
+          "block_000.slot_01.moe_expert.down": "research_per_channel_side",
+          "block_000.slot_02.moe_expert.up": "research_per_channel_side"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "fp16_control",
-          "block_001.slot_00.moe_expert.gate": "fp16_control",
-          "block_001.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1134,52 +143,52 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "fp16_control",
+          "block_001.slot_01.moe_expert.down": "fp16_control",
+          "block_001.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "research_per_channel_side",
-          "block_002.slot_00.moe_expert.gate": "research_per_channel_side",
-          "block_002.slot_02.moe_expert.up": "research_per_channel_side"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1210,52 +219,52 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "research_per_channel_side",
+          "block_002.slot_01.moe_expert.down": "research_per_channel_side",
+          "block_002.slot_02.moe_expert.up": "research_per_channel_side"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "fp16_control",
-          "block_003.slot_00.moe_expert.gate": "fp16_control",
-          "block_003.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1286,37 +295,1028 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "fp16_control",
+          "block_003.slot_01.moe_expert.down": "fp16_control",
+          "block_003.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "periodic_hp_plus_channel_alpha",
-    "hp_period": 2,
-    "hp_schedule_kind": "periodic",
-    "hp_blocks": [
-      1,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171419076819,
+          "block_output_cosine": 0.9726518417788741,
+          "block_output_cosine_per_token": 0.9711405778196809,
+          "block_output_drift_relative_norm": 0.23605953012535466,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_per_channel_side",
+          "moe_delta_over_stream": 0.5075108768099885,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.8575021309291444,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0000000000000002,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204764995743812,
+          "router_margin_mean_reference": 0.030204764995743812,
+          "router_margin_median_observed": 0.006170867767470903,
+          "router_margin_median_reference": 0.006170867767470903,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 76.4285888671875,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984425272,
+          "attention_output_cosine_per_token": 0.9999999986030998,
+          "attn_delta_over_stream": 0.8760054891005306,
+          "block_output_cosine": 0.9999870040322685,
+          "block_output_cosine_per_token": 0.9999880581319095,
+          "block_output_drift_relative_norm": 0.005098830132430907,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4827844972000442,
+          "moe_input_normalized_cosine": 0.9999999606112848,
+          "moe_output_cosine": 0.9999813002301362,
+          "residual_drift_relative_norm": 0.00021537206570514935,
+          "residual_stream_cosine": 0.9999999831366344,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971505857,
+          "router_margin_mean_delta": 2.8905368462560425e-06,
+          "router_margin_mean_observed": 0.03020765553259007,
+          "router_margin_mean_reference": 0.030204764995743812,
+          "router_margin_median_observed": 0.006180739225395249,
+          "router_margin_median_reference": 0.006170867767470903,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 28.394131422042847,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_per_channel_side",
+        "reference_seconds": 27.824715614318848
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9537457125461298,
+          "attention_output_cosine_per_token": 0.9547903696062463,
+          "attn_delta_over_stream": 0.375156781950687,
+          "block_output_cosine": 0.9711911788092129,
+          "block_output_cosine_per_token": 0.9700905664055086,
+          "block_output_drift_relative_norm": 0.2421697110066684,
+          "expert_load_js_bits": 0.004022827027534971,
+          "expert_load_max_abs_delta": 0.03173828125,
+          "expert_load_observed": [
+            0.167724609375,
+            0.11767578125,
+            0.117431640625,
+            0.065185546875,
+            0.128173828125,
+            0.187255859375,
+            0.103271484375,
+            0.11328125
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.4895833333333333,
+              "top1_flips": 47
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.3105590062111801,
+              "top1_flips": 100
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.07419898819561552,
+              "top1_flips": 44
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.003121748178980229,
+              "top1_flips": 3
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_n2_plus_channel_alpha",
+          "moe_delta_over_stream": 0.29349700977658827,
+          "moe_input_normalized_cosine": 0.9601410662488471,
+          "moe_output_cosine": 0.9253828305545667,
+          "residual_drift_relative_norm": 0.22226741647500073,
+          "residual_stream_cosine": 0.9756508161996449,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9726518417788741,
+            "residual_in_drift_relative_norm": 0.23605953012535466
+          },
+          "router_logit_cosine": 0.9955318341244036,
+          "router_margin_mean_delta": 0.007031242462097614,
+          "router_margin_mean_observed": 0.1899807654745718,
+          "router_margin_mean_reference": 0.1829495230124742,
+          "router_margin_median_observed": 0.15411161022976289,
+          "router_margin_median_reference": 0.15255130555045132,
+          "router_top1_agreement": 0.9052734375,
+          "router_top2_set_agreement": 0.7041015625,
+          "router_topk_set_agreement": 0.7041015625,
+          "seconds": 35.44246172904968,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239221966,
+          "attention_output_cosine_per_token": 0.9999949975916551,
+          "attn_delta_over_stream": 0.39617942472540063,
+          "block_output_cosine": 0.9999859463229576,
+          "block_output_cosine_per_token": 0.9999851320664717,
+          "block_output_drift_relative_norm": 0.005302552089727011,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839036553375,
+          "moe_input_normalized_cosine": 0.9999833030380135,
+          "moe_output_cosine": 0.999966460633255,
+          "residual_drift_relative_norm": 0.004420409079612701,
+          "residual_stream_cosine": 0.9999902372606576,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040322685,
+            "residual_in_drift_relative_norm": 0.005098830132430907
+          },
+          "router_logit_cosine": 0.9999982162936379,
+          "router_margin_mean_delta": 2.8299159045821673e-05,
+          "router_margin_mean_observed": 0.18297782217151998,
+          "router_margin_mean_reference": 0.1829495230124742,
+          "router_margin_median_observed": 0.15256852706410196,
+          "router_margin_median_reference": 0.15255130555045132,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 28.875547170639038,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha",
+        "reference_seconds": 25.78087615966797
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.9363165443022808,
+          "attention_output_cosine_per_token": 0.9352787224605859,
+          "attn_delta_over_stream": 0.6152390393459595,
+          "block_output_cosine": 0.927501659519474,
+          "block_output_cosine_per_token": 0.9270459433841975,
+          "block_output_drift_relative_norm": 0.3845522132305317,
+          "expert_load_js_bits": 0.004506355398090289,
+          "expert_load_max_abs_delta": 0.0283203125,
+          "expert_load_observed": [
+            0.055908203125,
+            0.11083984375,
+            0.08203125,
+            0.258544921875,
+            0.04638671875,
+            0.068359375,
+            0.144287109375,
+            0.233642578125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.4826086956521739,
+              "top1_flips": 222
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.22559241706161137,
+              "top1_flips": 238
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.023391812865497075,
+              "top1_flips": 12
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_per_channel_side",
+          "moe_delta_over_stream": 0.4327739826033704,
+          "moe_input_normalized_cosine": 0.9444280200483108,
+          "moe_output_cosine": 0.751475071369639,
+          "residual_drift_relative_norm": 0.23735262757428446,
+          "residual_stream_cosine": 0.9733152957026273,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9711911788092129,
+            "residual_in_drift_relative_norm": 0.2421697110066684
+          },
+          "router_logit_cosine": 0.9908098965713827,
+          "router_margin_mean_delta": -0.0014251190605054568,
+          "router_margin_mean_observed": 0.034389825678646624,
+          "router_margin_mean_reference": 0.035814944739152074,
+          "router_margin_median_observed": 0.02456068145770847,
+          "router_margin_median_reference": 0.025870433832144726,
+          "router_top1_agreement": 0.76953125,
+          "router_top2_set_agreement": 0.654296875,
+          "router_topk_set_agreement": 0.654296875,
+          "seconds": 90.06016898155212,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789248877,
+          "attention_output_cosine_per_token": 0.9999948155995892,
+          "attn_delta_over_stream": 0.5849569779392093,
+          "block_output_cosine": 0.9999682697635905,
+          "block_output_cosine_per_token": 0.9999678107431367,
+          "block_output_drift_relative_norm": 0.00796618737672334,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808484149002,
+          "moe_input_normalized_cosine": 0.9999805357479619,
+          "moe_output_cosine": 0.9998240607737604,
+          "residual_drift_relative_norm": 0.0042354673885935425,
+          "residual_stream_cosine": 0.999991030692396,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463229576,
+            "residual_in_drift_relative_norm": 0.005302552089727011
+          },
+          "router_logit_cosine": 0.9999983004394833,
+          "router_margin_mean_delta": 7.460080870050531e-06,
+          "router_margin_mean_observed": 0.03582240482002213,
+          "router_margin_mean_reference": 0.035814944739152074,
+          "router_margin_median_observed": 0.025836179844010404,
+          "router_margin_median_reference": 0.025870433832144726,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 26.93336820602417,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_per_channel_side",
+        "reference_seconds": 24.830881118774414
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.8684372308517955,
+          "attention_output_cosine_per_token": 0.868727231980265,
+          "attn_delta_over_stream": 0.4979273102836338,
+          "block_output_cosine": 0.9053794674153043,
+          "block_output_cosine_per_token": 0.9056925047079109,
+          "block_output_drift_relative_norm": 0.454412543309536,
+          "expert_load_js_bits": 0.012466325561227416,
+          "expert_load_max_abs_delta": 0.06591796875,
+          "expert_load_observed": [
+            0.0576171875,
+            0.103759765625,
+            0.050048828125,
+            0.170654296875,
+            0.346435546875,
+            0.015869140625,
+            0.128173828125,
+            0.12744140625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.6769596199524941,
+              "top1_flips": 285
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.4676113360323887,
+              "top1_flips": 462
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.15492957746478872,
+              "top1_flips": 88
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_n2_plus_channel_alpha",
+          "moe_delta_over_stream": 0.3448629974189175,
+          "moe_input_normalized_cosine": 0.8297263063959471,
+          "moe_output_cosine": 0.7915950015847938,
+          "residual_drift_relative_norm": 0.33689389427292654,
+          "residual_stream_cosine": 0.9442427287247533,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.927501659519474,
+            "residual_in_drift_relative_norm": 0.3845522132305317
+          },
+          "router_logit_cosine": 0.9937154787260877,
+          "router_margin_mean_delta": -0.005002979629651071,
+          "router_margin_mean_observed": 0.0390648383830293,
+          "router_margin_mean_reference": 0.04406781801268037,
+          "router_margin_median_observed": 0.026195236656197385,
+          "router_margin_median_reference": 0.029539565545719543,
+          "router_top1_agreement": 0.59228515625,
+          "router_top2_set_agreement": 0.37646484375,
+          "router_topk_set_agreement": 0.37646484375,
+          "seconds": 30.9284565448761,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999675515960312,
+          "attention_output_cosine_per_token": 0.9999677009830585,
+          "attn_delta_over_stream": 0.5008011430468392,
+          "block_output_cosine": 0.9999195401569629,
+          "block_output_cosine_per_token": 0.9999220111693956,
+          "block_output_drift_relative_norm": 0.012685839893226303,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.3568508941802894,
+          "moe_input_normalized_cosine": 0.9999317806884749,
+          "moe_output_cosine": 0.9996961822039626,
+          "residual_drift_relative_norm": 0.006536818304715071,
+          "residual_stream_cosine": 0.9999786349765859,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697635905,
+            "residual_in_drift_relative_norm": 0.00796618737672334
+          },
+          "router_logit_cosine": 0.9999963366268846,
+          "router_margin_mean_delta": -2.4472651695435334e-05,
+          "router_margin_mean_observed": 0.04404334536098494,
+          "router_margin_mean_reference": 0.04406781801268037,
+          "router_margin_median_observed": 0.02949765995199495,
+          "router_margin_median_reference": 0.029539565545719543,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 35.764336824417114,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_n2_plus_channel_alpha",
+        "reference_seconds": 23.51032519340515
+      }
     ],
-    "ternary_blocks": [
-      0,
-      2
-    ],
-    "channel_alpha_blocks": [
-      0,
-      2
-    ],
-    "hp_schedule_prose": "Stacked C+A label `expert_periodic_hp_n2_plus_channel_alpha`: channel-\u03b1 trits on {0,2}, HP (FP16 experts) on {1,3}.",
-    "arm_label": "expert_periodic_hp_n2_plus_channel_alpha",
     "pilot_labels_per_block": [
       "research_per_channel_side",
       "expert_periodic_hp_n2_plus_channel_alpha",
       "research_per_channel_side",
       "expert_periodic_hp_n2_plus_channel_alpha"
-    ]
+    ],
+    "skip_fp16_control": false,
+    "ternary_blocks": [
+      0,
+      2
+    ],
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "OpenAI Codex: GPT-5.6 Sol (xhigh) \u00b7 Issue: #75 / Linear RM-462 \u00b7 beads goz-rvk",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "stacked_hp_channel_alpha",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "design": "Codex design lock: C denser, N=2+C+A, and HP expert ceiling",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "secondary; no independent decision",
+    "implementation": {
+      "commit": "07f0a697dc04002f78b222362149ff9a2a7c7892",
+      "dirty": false
+    },
+    "issue": "GH #75 / Linear RM-462 / beads goz-rvk",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+    "model": "GPT-5.6 Sol (xhigh)",
+    "numpy": "2.4.6",
+    "python": "3.14.6",
+    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v3/int4-plus-hp123/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v3/int4-plus-hp123/metrics.json
@@ -1,1099 +1,43 @@
 {
-  "provenance": {
-    "issue": "GH #80 / Linear RM-468 / beads goz-d603r4",
-    "agent": "Grok Build: Grok 4.5 (high) (xAI) \u00b7 Issue: #80 / Linear RM-468 \u00b7 beads goz-d603r4",
-    "model": "Grok-4.5 (high)",
-    "design": "Grok Build design lock: INT4 research side-table middle-ground (P0 all-blocks + P1 denser HP); cite #76 denser/ceiling",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_76_denser": {
-      "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.939684,
-        0.913853
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.348475
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.615723
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.408691
-      ],
-      "chain_exit_residual_drift": 0.4370545723375058,
-      "arm_label": "expert_periodic_hp_123"
-    },
-    "baseline_76_ceiling": {
-      "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "block_output_cosine": [
-        1.0,
-        0.999997,
-        0.999998,
-        0.999984
-      ],
-      "router_top1": [
-        1.0,
-        1.0,
-        1.0,
-        1.0
-      ],
-      "chain_exit_residual_drift": 0.005690267932494616,
-      "arm_label": "expert_hp_ceiling",
-      "viable": true
-    },
-    "implementation": {
-      "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
-      "dirty": true
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "research_int4_side per-output-channel absmax on INT4 path; GOZ1 v3 pack-only on ternary cite path; abort on legacy_oracle",
-    "arm": "int4",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-    "evidence_role": "secondary; no independent decision"
-  },
   "chain": {
+    "arm_label": "expert_int4_123",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 25.066315174102783,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 44.15513730049133,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.994302110178458,
-          "block_output_cosine": 0.9986151821027426,
-          "block_output_cosine_per_token": 0.9986060303095572,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.05288061497549421,
-          "attn_delta_over_stream": 0.876171414302045,
-          "moe_delta_over_stream": 0.48116209785584313,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030204767217204893,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.006170911132304002,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 37.03864359855652,
-          "attention_output_cosine": 0.9999999984424572,
-          "attention_output_cosine_per_token": 0.9999999986030829,
-          "residual_stream_cosine": 0.9999999831365632,
-          "moe_input_normalized_cosine": 0.9999999606124855,
-          "router_logit_cosine": 0.9999999971511485,
-          "moe_output_cosine": 0.9999813002410165,
-          "block_output_cosine": 0.9999870040318545,
-          "block_output_cosine_per_token": 0.9999880581321908,
-          "residual_drift_relative_norm": 0.00021537234101925558,
-          "block_output_drift_relative_norm": 0.005098830221729304,
-          "attn_delta_over_stream": 0.8760054853350859,
-          "moe_delta_over_stream": 0.482784499720899,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030207654444896787,
-          "router_margin_mean_delta": 2.8872276918900968e-06,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.0061808020273402264,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 21.432623624801636,
-        "expert_only": {
-          "label": "expert_int4_123",
-          "seconds": 38.77097153663635,
-          "attention_output_cosine": 0.9994805824645078,
-          "attention_output_cosine_per_token": 0.9994966546188022,
-          "residual_stream_cosine": 0.998956811213174,
-          "moe_input_normalized_cosine": 0.9983623750311726,
-          "router_logit_cosine": 0.999822663993783,
-          "moe_output_cosine": 0.9960516073713731,
-          "block_output_cosine": 0.9984733954000422,
-          "block_output_cosine_per_token": 0.9984467147346038,
-          "residual_drift_relative_norm": 0.045856788607629415,
-          "block_output_drift_relative_norm": 0.055352064339083296,
-          "attn_delta_over_stream": 0.3935783059266308,
-          "moe_delta_over_stream": 0.28870008648630724,
-          "router_top1_agreement": 0.98193359375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.93359375,
-          "router_top2_set_agreement": 0.93359375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161865234375,
-            0.118896484375,
-            0.110107421875,
-            0.095703125,
-            0.119140625,
-            0.155029296875,
-            0.104736328125,
-            0.134521484375
-          ],
-          "expert_load_js_bits": 2.958814470063395e-05,
-          "expert_load_max_abs_delta": 0.003173828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18275724966811674,
-          "router_margin_mean_delta": -0.00019227171288197753,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15099636260196336,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 32,
-              "top1_flip_rate": 0.3333333333333333
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 5,
-              "top1_flip_rate": 0.015527950310559006
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9986151821027426,
-            "residual_in_drift_relative_norm": 0.05288061497549421
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 39.304056882858276,
-          "attention_output_cosine": 0.9999955239311591,
-          "attention_output_cosine_per_token": 0.9999949975985942,
-          "residual_stream_cosine": 0.9999902372591066,
-          "moe_input_normalized_cosine": 0.9999833030390249,
-          "router_logit_cosine": 0.9999982162936869,
-          "moe_output_cosine": 0.9999664606659787,
-          "block_output_cosine": 0.9999859463222839,
-          "block_output_cosine_per_token": 0.9999851320664912,
-          "residual_drift_relative_norm": 0.0044204095195649025,
-          "block_output_drift_relative_norm": 0.005302552236880725,
-          "attn_delta_over_stream": 0.3961794228342294,
-          "moe_delta_over_stream": 0.2896839054949744,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18297782060234993,
-          "router_margin_mean_delta": 2.8299221351235133e-05,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15256866411484876,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040318545,
-            "residual_in_drift_relative_norm": 0.005098830221729304
-          }
-        },
-        "pilot_label": "expert_int4_123"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 18.46852445602417,
-        "expert_only": {
-          "label": "expert_int4_123",
-          "seconds": 37.270052671432495,
-          "attention_output_cosine": 0.997791168879033,
-          "attention_output_cosine_per_token": 0.9978028331224871,
-          "residual_stream_cosine": 0.9987241913633482,
-          "moe_input_normalized_cosine": 0.9973407139931779,
-          "router_logit_cosine": 0.999727058195182,
-          "moe_output_cosine": 0.9861352778082605,
-          "block_output_cosine": 0.9956197704253421,
-          "block_output_cosine_per_token": 0.9955563252939656,
-          "residual_drift_relative_norm": 0.05065577079655575,
-          "block_output_drift_relative_norm": 0.0935215641530563,
-          "attn_delta_over_stream": 0.5833000319768352,
-          "moe_delta_over_stream": 0.40577715858960955,
-          "router_top1_agreement": 0.953125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.919921875,
-          "router_top2_set_agreement": 0.919921875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.13427734375,
-            0.06103515625,
-            0.243896484375,
-            0.02880859375,
-            0.07177734375,
-            0.178466796875,
-            0.234130859375
-          ],
-          "expert_load_js_bits": 0.0002489326034859664,
-          "expert_load_max_abs_delta": 0.01171875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.035266875542993154,
-          "router_margin_mean_delta": -0.0005480700240302096,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.02550062808475105,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 86,
-              "top1_flip_rate": 0.18695652173913044
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 10,
-              "top1_flip_rate": 0.009478672985781991
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9984733954000422,
-            "residual_in_drift_relative_norm": 0.055352064339083296
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 39.70007848739624,
-          "attention_output_cosine": 0.9999951789408488,
-          "attention_output_cosine_per_token": 0.9999948156177104,
-          "residual_stream_cosine": 0.999991030697749,
-          "moe_input_normalized_cosine": 0.9999805357628218,
-          "router_logit_cosine": 0.99999830045166,
-          "moe_output_cosine": 0.9998240608794524,
-          "block_output_cosine": 0.9999682697724989,
-          "block_output_cosine_per_token": 0.9999678107548897,
-          "residual_drift_relative_norm": 0.004235465975258782,
-          "block_output_drift_relative_norm": 0.007966186310686194,
-          "attn_delta_over_stream": 0.584956965059082,
-          "moe_delta_over_stream": 0.4112808355956077,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03582240155308043,
-          "router_margin_mean_delta": 7.4559860570678075e-06,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025836218008428474,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463222839,
-            "residual_in_drift_relative_norm": 0.005302552236880725
-          }
-        },
-        "pilot_label": "expert_int4_123"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 20.111958265304565,
-        "expert_only": {
-          "label": "expert_int4_123",
-          "seconds": 44.01105546951294,
-          "attention_output_cosine": 0.9933526611621083,
-          "attention_output_cosine_per_token": 0.9933280158751556,
-          "residual_stream_cosine": 0.9968655131007353,
-          "moe_input_normalized_cosine": 0.9901588534262185,
-          "router_logit_cosine": 0.9995724067351002,
-          "moe_output_cosine": 0.9774093487202452,
-          "block_output_cosine": 0.9915226862504408,
-          "block_output_cosine_per_token": 0.9913832419923976,
-          "residual_drift_relative_norm": 0.07912630612051204,
-          "block_output_drift_relative_norm": 0.1302129056031902,
-          "attn_delta_over_stream": 0.4985185792142929,
-          "moe_delta_over_stream": 0.35593962253825956,
-          "router_top1_agreement": 0.92529296875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.861328125,
-          "router_top2_set_agreement": 0.861328125,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.054931640625,
-            0.07080078125,
-            0.038818359375,
-            0.1591796875,
-            0.381103515625,
-            0.0224609375,
-            0.19482421875,
-            0.077880859375
-          ],
-          "expert_load_js_bits": 0.00016866846773804433,
-          "expert_load_max_abs_delta": 0.0068359375,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.0437278129058025,
-          "router_margin_mean_delta": -0.000340000059432497,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.02952331167047509,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 103,
-              "top1_flip_rate": 0.24465558194774348
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 45,
-              "top1_flip_rate": 0.04554655870445344
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 5,
-              "top1_flip_rate": 0.008802816901408451
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9956197704253421,
-            "residual_in_drift_relative_norm": 0.0935215641530563
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 41.16312384605408,
-          "attention_output_cosine": 0.999967551568842,
-          "attention_output_cosine_per_token": 0.9999677009593164,
-          "residual_stream_cosine": 0.9999786349806121,
-          "moe_input_normalized_cosine": 0.9999317807120685,
-          "router_logit_cosine": 0.9999963366294831,
-          "moe_output_cosine": 0.9996961823732479,
-          "block_output_cosine": 0.9999195401900538,
-          "block_output_cosine_per_token": 0.9999220112059125,
-          "residual_drift_relative_norm": 0.006536817583550683,
-          "block_output_drift_relative_norm": 0.012685837908964355,
-          "attn_delta_over_stream": 0.5008011118859926,
-          "moe_delta_over_stream": 0.35685089524601604,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.04404335021260723,
-          "router_margin_mean_delta": -2.446275262776493e-05,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.029497699031347163,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697724989,
-            "residual_in_drift_relative_norm": 0.007966186310686194
-          }
-        },
-        "pilot_label": "expert_int4_123"
-      }
-    ],
+    "channel_alpha_blocks": [],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.9915226862504408,
-        "residual_drift_relative_norm": 0.1302129056031902,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.1302129056031902
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401900538,
-        "residual_drift_relative_norm": 0.012685837908964355,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685837908964355
       }
     },
+    "expert_mode": "int4",
+    "hp_blocks": [
+      1,
+      2,
+      3
+    ],
+    "hp_period": null,
+    "hp_schedule_kind": "explicit",
+    "hp_schedule_prose": "INT4 middle-ground label `expert_int4_123`: research INT4 experts on {0}, HP (FP16 experts) on {1,2,3}.",
+    "int4_blocks": [
+      0
+    ],
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "research_int4_side",
-          "block_000.slot_00.moe_expert.gate": "research_int4_side",
-          "block_000.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1124,52 +68,52 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "research_int4_side",
+          "block_000.slot_01.moe_expert.down": "research_int4_side",
+          "block_000.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "fp16_control",
-          "block_001.slot_00.moe_expert.gate": "fp16_control",
-          "block_001.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1200,52 +144,52 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "fp16_control",
+          "block_001.slot_01.moe_expert.down": "fp16_control",
+          "block_001.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "fp16_control",
-          "block_002.slot_00.moe_expert.gate": "fp16_control",
-          "block_002.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1276,52 +220,52 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "fp16_control",
+          "block_002.slot_01.moe_expert.down": "fp16_control",
+          "block_002.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "fp16_control",
-          "block_003.slot_00.moe_expert.gate": "fp16_control",
-          "block_003.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1352,35 +296,1091 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "fp16_control",
+          "block_003.slot_01.moe_expert.down": "fp16_control",
+          "block_003.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "int4",
-    "hp_period": null,
-    "hp_schedule_kind": "explicit",
-    "hp_blocks": [
-      1,
-      2,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171414302045,
+          "block_output_cosine": 0.9986151821027426,
+          "block_output_cosine_per_token": 0.9986060303095572,
+          "block_output_drift_relative_norm": 0.05288061497549421,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.48116209785584313,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.994302110178458,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204767217204893,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.006170911132304002,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 44.15513730049133,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984424572,
+          "attention_output_cosine_per_token": 0.9999999986030829,
+          "attn_delta_over_stream": 0.8760054853350859,
+          "block_output_cosine": 0.9999870040318545,
+          "block_output_cosine_per_token": 0.9999880581321908,
+          "block_output_drift_relative_norm": 0.005098830221729304,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.482784499720899,
+          "moe_input_normalized_cosine": 0.9999999606124855,
+          "moe_output_cosine": 0.9999813002410165,
+          "residual_drift_relative_norm": 0.00021537234101925558,
+          "residual_stream_cosine": 0.9999999831365632,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971511485,
+          "router_margin_mean_delta": 2.8872276918900968e-06,
+          "router_margin_mean_observed": 0.030207654444896787,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.0061808020273402264,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 37.03864359855652,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 25.066315174102783
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9994805824645078,
+          "attention_output_cosine_per_token": 0.9994966546188022,
+          "attn_delta_over_stream": 0.3935783059266308,
+          "block_output_cosine": 0.9984733954000422,
+          "block_output_cosine_per_token": 0.9984467147346038,
+          "block_output_drift_relative_norm": 0.055352064339083296,
+          "expert_load_js_bits": 2.958814470063395e-05,
+          "expert_load_max_abs_delta": 0.003173828125,
+          "expert_load_observed": [
+            0.161865234375,
+            0.118896484375,
+            0.110107421875,
+            0.095703125,
+            0.119140625,
+            0.155029296875,
+            0.104736328125,
+            0.134521484375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.3333333333333333,
+              "top1_flips": 32
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.015527950310559006,
+              "top1_flips": 5
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_int4_123",
+          "moe_delta_over_stream": 0.28870008648630724,
+          "moe_input_normalized_cosine": 0.9983623750311726,
+          "moe_output_cosine": 0.9960516073713731,
+          "residual_drift_relative_norm": 0.045856788607629415,
+          "residual_stream_cosine": 0.998956811213174,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9986151821027426,
+            "residual_in_drift_relative_norm": 0.05288061497549421
+          },
+          "router_logit_cosine": 0.999822663993783,
+          "router_margin_mean_delta": -0.00019227171288197753,
+          "router_margin_mean_observed": 0.18275724966811674,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15099636260196336,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.98193359375,
+          "router_top2_set_agreement": 0.93359375,
+          "router_topk_set_agreement": 0.93359375,
+          "seconds": 38.77097153663635,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239311591,
+          "attention_output_cosine_per_token": 0.9999949975985942,
+          "attn_delta_over_stream": 0.3961794228342294,
+          "block_output_cosine": 0.9999859463222839,
+          "block_output_cosine_per_token": 0.9999851320664912,
+          "block_output_drift_relative_norm": 0.005302552236880725,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839054949744,
+          "moe_input_normalized_cosine": 0.9999833030390249,
+          "moe_output_cosine": 0.9999664606659787,
+          "residual_drift_relative_norm": 0.0044204095195649025,
+          "residual_stream_cosine": 0.9999902372591066,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040318545,
+            "residual_in_drift_relative_norm": 0.005098830221729304
+          },
+          "router_logit_cosine": 0.9999982162936869,
+          "router_margin_mean_delta": 2.8299221351235133e-05,
+          "router_margin_mean_observed": 0.18297782060234993,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15256866411484876,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 39.304056882858276,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_int4_123",
+        "reference_seconds": 21.432623624801636
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.997791168879033,
+          "attention_output_cosine_per_token": 0.9978028331224871,
+          "attn_delta_over_stream": 0.5833000319768352,
+          "block_output_cosine": 0.9956197704253421,
+          "block_output_cosine_per_token": 0.9955563252939656,
+          "block_output_drift_relative_norm": 0.0935215641530563,
+          "expert_load_js_bits": 0.0002489326034859664,
+          "expert_load_max_abs_delta": 0.01171875,
+          "expert_load_observed": [
+            0.047607421875,
+            0.13427734375,
+            0.06103515625,
+            0.243896484375,
+            0.02880859375,
+            0.07177734375,
+            0.178466796875,
+            0.234130859375
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.18695652173913044,
+              "top1_flips": 86
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.009478672985781991,
+              "top1_flips": 10
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_int4_123",
+          "moe_delta_over_stream": 0.40577715858960955,
+          "moe_input_normalized_cosine": 0.9973407139931779,
+          "moe_output_cosine": 0.9861352778082605,
+          "residual_drift_relative_norm": 0.05065577079655575,
+          "residual_stream_cosine": 0.9987241913633482,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9984733954000422,
+            "residual_in_drift_relative_norm": 0.055352064339083296
+          },
+          "router_logit_cosine": 0.999727058195182,
+          "router_margin_mean_delta": -0.0005480700240302096,
+          "router_margin_mean_observed": 0.035266875542993154,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.02550062808475105,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.953125,
+          "router_top2_set_agreement": 0.919921875,
+          "router_topk_set_agreement": 0.919921875,
+          "seconds": 37.270052671432495,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789408488,
+          "attention_output_cosine_per_token": 0.9999948156177104,
+          "attn_delta_over_stream": 0.584956965059082,
+          "block_output_cosine": 0.9999682697724989,
+          "block_output_cosine_per_token": 0.9999678107548897,
+          "block_output_drift_relative_norm": 0.007966186310686194,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808355956077,
+          "moe_input_normalized_cosine": 0.9999805357628218,
+          "moe_output_cosine": 0.9998240608794524,
+          "residual_drift_relative_norm": 0.004235465975258782,
+          "residual_stream_cosine": 0.999991030697749,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463222839,
+            "residual_in_drift_relative_norm": 0.005302552236880725
+          },
+          "router_logit_cosine": 0.99999830045166,
+          "router_margin_mean_delta": 7.4559860570678075e-06,
+          "router_margin_mean_observed": 0.03582240155308043,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025836218008428474,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 39.70007848739624,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_int4_123",
+        "reference_seconds": 18.46852445602417
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.9933526611621083,
+          "attention_output_cosine_per_token": 0.9933280158751556,
+          "attn_delta_over_stream": 0.4985185792142929,
+          "block_output_cosine": 0.9915226862504408,
+          "block_output_cosine_per_token": 0.9913832419923976,
+          "block_output_drift_relative_norm": 0.1302129056031902,
+          "expert_load_js_bits": 0.00016866846773804433,
+          "expert_load_max_abs_delta": 0.0068359375,
+          "expert_load_observed": [
+            0.054931640625,
+            0.07080078125,
+            0.038818359375,
+            0.1591796875,
+            0.381103515625,
+            0.0224609375,
+            0.19482421875,
+            0.077880859375
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.24465558194774348,
+              "top1_flips": 103
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.04554655870445344,
+              "top1_flips": 45
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.008802816901408451,
+              "top1_flips": 5
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_int4_123",
+          "moe_delta_over_stream": 0.35593962253825956,
+          "moe_input_normalized_cosine": 0.9901588534262185,
+          "moe_output_cosine": 0.9774093487202452,
+          "residual_drift_relative_norm": 0.07912630612051204,
+          "residual_stream_cosine": 0.9968655131007353,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9956197704253421,
+            "residual_in_drift_relative_norm": 0.0935215641530563
+          },
+          "router_logit_cosine": 0.9995724067351002,
+          "router_margin_mean_delta": -0.000340000059432497,
+          "router_margin_mean_observed": 0.0437278129058025,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.02952331167047509,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.92529296875,
+          "router_top2_set_agreement": 0.861328125,
+          "router_topk_set_agreement": 0.861328125,
+          "seconds": 44.01105546951294,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.999967551568842,
+          "attention_output_cosine_per_token": 0.9999677009593164,
+          "attn_delta_over_stream": 0.5008011118859926,
+          "block_output_cosine": 0.9999195401900538,
+          "block_output_cosine_per_token": 0.9999220112059125,
+          "block_output_drift_relative_norm": 0.012685837908964355,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.35685089524601604,
+          "moe_input_normalized_cosine": 0.9999317807120685,
+          "moe_output_cosine": 0.9996961823732479,
+          "residual_drift_relative_norm": 0.006536817583550683,
+          "residual_stream_cosine": 0.9999786349806121,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697724989,
+            "residual_in_drift_relative_norm": 0.007966186310686194
+          },
+          "router_logit_cosine": 0.9999963366294831,
+          "router_margin_mean_delta": -2.446275262776493e-05,
+          "router_margin_mean_observed": 0.04404335021260723,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.029497699031347163,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 41.16312384605408,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_int4_123",
+        "reference_seconds": 20.111958265304565
+      }
     ],
-    "ternary_blocks": [],
-    "channel_alpha_blocks": [],
-    "hp_schedule_prose": "INT4 middle-ground label `expert_int4_123`: research INT4 experts on {0}, HP (FP16 experts) on {1,2,3}.",
-    "arm_label": "expert_int4_123",
     "pilot_labels_per_block": [
       "research_int4_side",
       "expert_int4_123",
       "expert_int4_123",
       "expert_int4_123"
     ],
-    "int4_blocks": [
-      0
-    ]
+    "skip_fp16_control": false,
+    "ternary_blocks": [],
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Grok Build: Grok 4.5 (high) (xAI) \u00b7 Issue: #80 / Linear RM-468 \u00b7 beads goz-d603r4",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "int4",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_76_ceiling": {
+      "arm_label": "expert_hp_ceiling",
+      "block_output_cosine": [
+        1.0,
+        0.999997,
+        0.999998,
+        0.999984
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.005690267932494616,
+      "router_top1": [
+        1.0,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2,
+      "viable": true
+    },
+    "baseline_76_denser": {
+      "arm_label": "expert_periodic_hp_123",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.939684,
+        0.913853
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.4370545723375058,
+      "decision": 2,
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.348475
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.615723
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.408691
+      ],
+      "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "design": "Grok Build design lock: INT4 research side-table middle-ground (P0 all-blocks + P1 denser HP); cite #76 denser/ceiling",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "secondary; no independent decision",
+    "implementation": {
+      "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
+      "dirty": true
+    },
+    "issue": "GH #80 / Linear RM-468 / beads goz-d603r4",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+    "model": "Grok-4.5 (high)",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "research_int4_side per-output-channel absmax on INT4 path; GOZ1 v3 pack-only on ternary cite path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v3/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v3/metrics.json
@@ -1,1099 +1,42 @@
 {
-  "provenance": {
-    "issue": "GH #80 / Linear RM-468 / beads goz-d603r4",
-    "agent": "Grok Build: Grok 4.5 (high) (xAI) \u00b7 Issue: #80 / Linear RM-468 \u00b7 beads goz-d603r4",
-    "model": "Grok-4.5 (high)",
-    "design": "Grok Build design lock: INT4 research side-table middle-ground (P0 all-blocks + P1 denser HP); cite #76 denser/ceiling",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_76_denser": {
-      "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.939684,
-        0.913853
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.348475
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.615723
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.408691
-      ],
-      "chain_exit_residual_drift": 0.4370545723375058,
-      "arm_label": "expert_periodic_hp_123"
-    },
-    "baseline_76_ceiling": {
-      "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "block_output_cosine": [
-        1.0,
-        0.999997,
-        0.999998,
-        0.999984
-      ],
-      "router_top1": [
-        1.0,
-        1.0,
-        1.0,
-        1.0
-      ],
-      "chain_exit_residual_drift": 0.005690267932494616,
-      "arm_label": "expert_hp_ceiling",
-      "viable": true
-    },
-    "implementation": {
-      "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
-      "dirty": true
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "research_int4_side per-output-channel absmax on INT4 path; GOZ1 v3 pack-only on ternary cite path; abort on legacy_oracle",
-    "arm": "int4",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-    "evidence_role": "primary; sole canonical #80 decision"
-  },
   "chain": {
+    "arm_label": "expert_int4",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 24.408310174942017,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 38.5462327003479,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.994302110178458,
-          "block_output_cosine": 0.9986151821027426,
-          "block_output_cosine_per_token": 0.9986060303095572,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.05288061497549421,
-          "attn_delta_over_stream": 0.876171414302045,
-          "moe_delta_over_stream": 0.48116209785584313,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030204767217204893,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.006170911132304002,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 36.55275535583496,
-          "attention_output_cosine": 0.9999999984424572,
-          "attention_output_cosine_per_token": 0.9999999986030829,
-          "residual_stream_cosine": 0.9999999831365632,
-          "moe_input_normalized_cosine": 0.9999999606124855,
-          "router_logit_cosine": 0.9999999971511485,
-          "moe_output_cosine": 0.9999813002410165,
-          "block_output_cosine": 0.9999870040318545,
-          "block_output_cosine_per_token": 0.9999880581321908,
-          "residual_drift_relative_norm": 0.00021537234101925558,
-          "block_output_drift_relative_norm": 0.005098830221729304,
-          "attn_delta_over_stream": 0.8760054853350859,
-          "moe_delta_over_stream": 0.482784499720899,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030207654444896787,
-          "router_margin_mean_delta": 2.8872276918900968e-06,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.0061808020273402264,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 23.774211406707764,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 41.66035032272339,
-          "attention_output_cosine": 0.9994805824645078,
-          "attention_output_cosine_per_token": 0.9994966546188022,
-          "residual_stream_cosine": 0.998956811213174,
-          "moe_input_normalized_cosine": 0.9983623750311726,
-          "router_logit_cosine": 0.999822663993783,
-          "moe_output_cosine": 0.9857559288035102,
-          "block_output_cosine": 0.9971471520590423,
-          "block_output_cosine_per_token": 0.9970905266773447,
-          "residual_drift_relative_norm": 0.045856788607629415,
-          "block_output_drift_relative_norm": 0.07569161411436817,
-          "attn_delta_over_stream": 0.3935783059266308,
-          "moe_delta_over_stream": 0.29111029714087594,
-          "router_top1_agreement": 0.98193359375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.93359375,
-          "router_top2_set_agreement": 0.93359375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161865234375,
-            0.118896484375,
-            0.110107421875,
-            0.095703125,
-            0.119140625,
-            0.155029296875,
-            0.104736328125,
-            0.134521484375
-          ],
-          "expert_load_js_bits": 2.958814470063395e-05,
-          "expert_load_max_abs_delta": 0.003173828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18275724966811674,
-          "router_margin_mean_delta": -0.00019227171288197753,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15099636260196336,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 32,
-              "top1_flip_rate": 0.3333333333333333
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 5,
-              "top1_flip_rate": 0.015527950310559006
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9986151821027426,
-            "residual_in_drift_relative_norm": 0.05288061497549421
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 41.31385898590088,
-          "attention_output_cosine": 0.9999955239311591,
-          "attention_output_cosine_per_token": 0.9999949975985942,
-          "residual_stream_cosine": 0.9999902372591066,
-          "moe_input_normalized_cosine": 0.9999833030390249,
-          "router_logit_cosine": 0.9999982162936869,
-          "moe_output_cosine": 0.9999664606659787,
-          "block_output_cosine": 0.9999859463222839,
-          "block_output_cosine_per_token": 0.9999851320664912,
-          "residual_drift_relative_norm": 0.0044204095195649025,
-          "block_output_drift_relative_norm": 0.005302552236880725,
-          "attn_delta_over_stream": 0.3961794228342294,
-          "moe_delta_over_stream": 0.2896839054949744,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18297782060234993,
-          "router_margin_mean_delta": 2.8299221351235133e-05,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15256866411484876,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040318545,
-            "residual_in_drift_relative_norm": 0.005098830221729304
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 19.392960786819458,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 39.04044795036316,
-          "attention_output_cosine": 0.9957266490516082,
-          "attention_output_cosine_per_token": 0.9957554549513418,
-          "residual_stream_cosine": 0.9976207484527081,
-          "moe_input_normalized_cosine": 0.994552254159909,
-          "router_logit_cosine": 0.9994599137990562,
-          "moe_output_cosine": 0.9618261787700041,
-          "block_output_cosine": 0.9890487155967639,
-          "block_output_cosine_per_token": 0.9890252274680347,
-          "residual_drift_relative_norm": 0.06927014578723611,
-          "block_output_drift_relative_norm": 0.1476628678040506,
-          "attn_delta_over_stream": 0.5851800210454654,
-          "moe_delta_over_stream": 0.4147013947095636,
-          "router_top1_agreement": 0.9296875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.8857421875,
-          "router_top2_set_agreement": 0.8857421875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.046142578125,
-            0.1396484375,
-            0.0634765625,
-            0.239013671875,
-            0.02734375,
-            0.072265625,
-            0.17626953125,
-            0.23583984375
-          ],
-          "expert_load_js_bits": 0.0004889610222175079,
-          "expert_load_max_abs_delta": 0.0166015625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.035544684367637844,
-          "router_margin_mean_delta": -0.0002702611993855275,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025838411492324673,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 125,
-              "top1_flip_rate": 0.2717391304347826
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 19,
-              "top1_flip_rate": 0.01800947867298578
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9971471520590423,
-            "residual_in_drift_relative_norm": 0.07569161411436817
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 35.82634878158569,
-          "attention_output_cosine": 0.9999951789408488,
-          "attention_output_cosine_per_token": 0.9999948156177104,
-          "residual_stream_cosine": 0.999991030697749,
-          "moe_input_normalized_cosine": 0.9999805357628218,
-          "router_logit_cosine": 0.99999830045166,
-          "moe_output_cosine": 0.9998240608794524,
-          "block_output_cosine": 0.9999682697724989,
-          "block_output_cosine_per_token": 0.9999678107548897,
-          "residual_drift_relative_norm": 0.004235465975258782,
-          "block_output_drift_relative_norm": 0.007966186310686194,
-          "attn_delta_over_stream": 0.584956965059082,
-          "moe_delta_over_stream": 0.4112808355956077,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03582240155308043,
-          "router_margin_mean_delta": 7.4559860570678075e-06,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025836218008428474,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463222839,
-            "residual_in_drift_relative_norm": 0.005302552236880725
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 18.21269941329956,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 37.13821029663086,
-          "attention_output_cosine": 0.9832817632218565,
-          "attention_output_cosine_per_token": 0.9833122663348932,
-          "residual_stream_cosine": 0.9922650383454483,
-          "moe_input_normalized_cosine": 0.9753827288362507,
-          "router_logit_cosine": 0.9990586278991375,
-          "moe_output_cosine": 0.9390849421214712,
-          "block_output_cosine": 0.978044237973187,
-          "block_output_cosine_per_token": 0.9779229033641172,
-          "residual_drift_relative_norm": 0.12471952208409154,
-          "block_output_drift_relative_norm": 0.21106381790108242,
-          "attn_delta_over_stream": 0.5161723492735949,
-          "moe_delta_over_stream": 0.35835629804422037,
-          "router_top1_agreement": 0.8505859375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.7294921875,
-          "router_top2_set_agreement": 0.7294921875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0537109375,
-            0.0654296875,
-            0.043212890625,
-            0.1552734375,
-            0.36767578125,
-            0.0234375,
-            0.205810546875,
-            0.08544921875
-          ],
-          "expert_load_js_bits": 0.0005153232062816999,
-          "expert_load_max_abs_delta": 0.015625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.04226899943680299,
-          "router_margin_mean_delta": -0.0017988135284320067,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.02834222640361289,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 176,
-              "top1_flip_rate": 0.4180522565320665
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 119,
-              "top1_flip_rate": 0.12044534412955465
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 11,
-              "top1_flip_rate": 0.01936619718309859
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9890487155967639,
-            "residual_in_drift_relative_norm": 0.1476628678040506
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 33.867552757263184,
-          "attention_output_cosine": 0.999967551568842,
-          "attention_output_cosine_per_token": 0.9999677009593164,
-          "residual_stream_cosine": 0.9999786349806121,
-          "moe_input_normalized_cosine": 0.9999317807120685,
-          "router_logit_cosine": 0.9999963366294831,
-          "moe_output_cosine": 0.9996961823732479,
-          "block_output_cosine": 0.9999195401900538,
-          "block_output_cosine_per_token": 0.9999220112059125,
-          "residual_drift_relative_norm": 0.006536817583550683,
-          "block_output_drift_relative_norm": 0.012685837908964355,
-          "attn_delta_over_stream": 0.5008011118859926,
-          "moe_delta_over_stream": 0.35685089524601604,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.04404335021260723,
-          "router_margin_mean_delta": -2.446275262776493e-05,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.029497699031347163,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697724989,
-            "residual_in_drift_relative_norm": 0.007966186310686194
-          }
-        },
-        "pilot_label": "research_int4_side"
-      }
-    ],
+    "channel_alpha_blocks": [],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.978044237973187,
-        "residual_drift_relative_norm": 0.21106381790108242,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.21106381790108242
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401900538,
-        "residual_drift_relative_norm": 0.012685837908964355,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685837908964355
       }
     },
+    "expert_mode": "int4",
+    "hp_blocks": [],
+    "hp_period": null,
+    "hp_schedule_kind": "none",
+    "hp_schedule_prose": "INT4 experts (research_int4_side) on all chain blocks.",
+    "int4_blocks": [
+      0,
+      1,
+      2,
+      3
+    ],
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "research_int4_side",
-          "block_000.slot_00.moe_expert.gate": "research_int4_side",
-          "block_000.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1124,52 +67,52 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "research_int4_side",
+          "block_000.slot_01.moe_expert.down": "research_int4_side",
+          "block_000.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "research_int4_side",
-          "block_001.slot_00.moe_expert.gate": "research_int4_side",
-          "block_001.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1200,52 +143,52 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "research_int4_side",
+          "block_001.slot_01.moe_expert.down": "research_int4_side",
+          "block_001.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "research_int4_side",
-          "block_002.slot_00.moe_expert.gate": "research_int4_side",
-          "block_002.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1276,52 +219,52 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "research_int4_side",
+          "block_002.slot_01.moe_expert.down": "research_int4_side",
+          "block_002.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "research_int4_side",
-          "block_003.slot_00.moe_expert.gate": "research_int4_side",
-          "block_003.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1352,1135 +295,1109 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "research_int4_side",
+          "block_003.slot_01.moe_expert.down": "research_int4_side",
+          "block_003.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "int4",
-    "hp_period": null,
-    "hp_schedule_kind": "none",
-    "hp_blocks": [],
-    "ternary_blocks": [],
-    "channel_alpha_blocks": [],
-    "hp_schedule_prose": "INT4 experts (research_int4_side) on all chain blocks.",
-    "arm_label": "expert_int4",
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171414302045,
+          "block_output_cosine": 0.9986151821027426,
+          "block_output_cosine_per_token": 0.9986060303095572,
+          "block_output_drift_relative_norm": 0.05288061497549421,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.48116209785584313,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.994302110178458,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204767217204893,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.006170911132304002,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 38.5462327003479,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984424572,
+          "attention_output_cosine_per_token": 0.9999999986030829,
+          "attn_delta_over_stream": 0.8760054853350859,
+          "block_output_cosine": 0.9999870040318545,
+          "block_output_cosine_per_token": 0.9999880581321908,
+          "block_output_drift_relative_norm": 0.005098830221729304,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.482784499720899,
+          "moe_input_normalized_cosine": 0.9999999606124855,
+          "moe_output_cosine": 0.9999813002410165,
+          "residual_drift_relative_norm": 0.00021537234101925558,
+          "residual_stream_cosine": 0.9999999831365632,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971511485,
+          "router_margin_mean_delta": 2.8872276918900968e-06,
+          "router_margin_mean_observed": 0.030207654444896787,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.0061808020273402264,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 36.55275535583496,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 24.408310174942017
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9994805824645078,
+          "attention_output_cosine_per_token": 0.9994966546188022,
+          "attn_delta_over_stream": 0.3935783059266308,
+          "block_output_cosine": 0.9971471520590423,
+          "block_output_cosine_per_token": 0.9970905266773447,
+          "block_output_drift_relative_norm": 0.07569161411436817,
+          "expert_load_js_bits": 2.958814470063395e-05,
+          "expert_load_max_abs_delta": 0.003173828125,
+          "expert_load_observed": [
+            0.161865234375,
+            0.118896484375,
+            0.110107421875,
+            0.095703125,
+            0.119140625,
+            0.155029296875,
+            0.104736328125,
+            0.134521484375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.3333333333333333,
+              "top1_flips": 32
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.015527950310559006,
+              "top1_flips": 5
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.29111029714087594,
+          "moe_input_normalized_cosine": 0.9983623750311726,
+          "moe_output_cosine": 0.9857559288035102,
+          "residual_drift_relative_norm": 0.045856788607629415,
+          "residual_stream_cosine": 0.998956811213174,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9986151821027426,
+            "residual_in_drift_relative_norm": 0.05288061497549421
+          },
+          "router_logit_cosine": 0.999822663993783,
+          "router_margin_mean_delta": -0.00019227171288197753,
+          "router_margin_mean_observed": 0.18275724966811674,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15099636260196336,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.98193359375,
+          "router_top2_set_agreement": 0.93359375,
+          "router_topk_set_agreement": 0.93359375,
+          "seconds": 41.66035032272339,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239311591,
+          "attention_output_cosine_per_token": 0.9999949975985942,
+          "attn_delta_over_stream": 0.3961794228342294,
+          "block_output_cosine": 0.9999859463222839,
+          "block_output_cosine_per_token": 0.9999851320664912,
+          "block_output_drift_relative_norm": 0.005302552236880725,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839054949744,
+          "moe_input_normalized_cosine": 0.9999833030390249,
+          "moe_output_cosine": 0.9999664606659787,
+          "residual_drift_relative_norm": 0.0044204095195649025,
+          "residual_stream_cosine": 0.9999902372591066,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040318545,
+            "residual_in_drift_relative_norm": 0.005098830221729304
+          },
+          "router_logit_cosine": 0.9999982162936869,
+          "router_margin_mean_delta": 2.8299221351235133e-05,
+          "router_margin_mean_observed": 0.18297782060234993,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15256866411484876,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 41.31385898590088,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 23.774211406707764
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.9957266490516082,
+          "attention_output_cosine_per_token": 0.9957554549513418,
+          "attn_delta_over_stream": 0.5851800210454654,
+          "block_output_cosine": 0.9890487155967639,
+          "block_output_cosine_per_token": 0.9890252274680347,
+          "block_output_drift_relative_norm": 0.1476628678040506,
+          "expert_load_js_bits": 0.0004889610222175079,
+          "expert_load_max_abs_delta": 0.0166015625,
+          "expert_load_observed": [
+            0.046142578125,
+            0.1396484375,
+            0.0634765625,
+            0.239013671875,
+            0.02734375,
+            0.072265625,
+            0.17626953125,
+            0.23583984375
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.2717391304347826,
+              "top1_flips": 125
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.01800947867298578,
+              "top1_flips": 19
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.4147013947095636,
+          "moe_input_normalized_cosine": 0.994552254159909,
+          "moe_output_cosine": 0.9618261787700041,
+          "residual_drift_relative_norm": 0.06927014578723611,
+          "residual_stream_cosine": 0.9976207484527081,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9971471520590423,
+            "residual_in_drift_relative_norm": 0.07569161411436817
+          },
+          "router_logit_cosine": 0.9994599137990562,
+          "router_margin_mean_delta": -0.0002702611993855275,
+          "router_margin_mean_observed": 0.035544684367637844,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025838411492324673,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.9296875,
+          "router_top2_set_agreement": 0.8857421875,
+          "router_topk_set_agreement": 0.8857421875,
+          "seconds": 39.04044795036316,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789408488,
+          "attention_output_cosine_per_token": 0.9999948156177104,
+          "attn_delta_over_stream": 0.584956965059082,
+          "block_output_cosine": 0.9999682697724989,
+          "block_output_cosine_per_token": 0.9999678107548897,
+          "block_output_drift_relative_norm": 0.007966186310686194,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808355956077,
+          "moe_input_normalized_cosine": 0.9999805357628218,
+          "moe_output_cosine": 0.9998240608794524,
+          "residual_drift_relative_norm": 0.004235465975258782,
+          "residual_stream_cosine": 0.999991030697749,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463222839,
+            "residual_in_drift_relative_norm": 0.005302552236880725
+          },
+          "router_logit_cosine": 0.99999830045166,
+          "router_margin_mean_delta": 7.4559860570678075e-06,
+          "router_margin_mean_observed": 0.03582240155308043,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025836218008428474,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 35.82634878158569,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 19.392960786819458
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.9832817632218565,
+          "attention_output_cosine_per_token": 0.9833122663348932,
+          "attn_delta_over_stream": 0.5161723492735949,
+          "block_output_cosine": 0.978044237973187,
+          "block_output_cosine_per_token": 0.9779229033641172,
+          "block_output_drift_relative_norm": 0.21106381790108242,
+          "expert_load_js_bits": 0.0005153232062816999,
+          "expert_load_max_abs_delta": 0.015625,
+          "expert_load_observed": [
+            0.0537109375,
+            0.0654296875,
+            0.043212890625,
+            0.1552734375,
+            0.36767578125,
+            0.0234375,
+            0.205810546875,
+            0.08544921875
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.4180522565320665,
+              "top1_flips": 176
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.12044534412955465,
+              "top1_flips": 119
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.01936619718309859,
+              "top1_flips": 11
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.35835629804422037,
+          "moe_input_normalized_cosine": 0.9753827288362507,
+          "moe_output_cosine": 0.9390849421214712,
+          "residual_drift_relative_norm": 0.12471952208409154,
+          "residual_stream_cosine": 0.9922650383454483,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9890487155967639,
+            "residual_in_drift_relative_norm": 0.1476628678040506
+          },
+          "router_logit_cosine": 0.9990586278991375,
+          "router_margin_mean_delta": -0.0017988135284320067,
+          "router_margin_mean_observed": 0.04226899943680299,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.02834222640361289,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.8505859375,
+          "router_top2_set_agreement": 0.7294921875,
+          "router_topk_set_agreement": 0.7294921875,
+          "seconds": 37.13821029663086,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.999967551568842,
+          "attention_output_cosine_per_token": 0.9999677009593164,
+          "attn_delta_over_stream": 0.5008011118859926,
+          "block_output_cosine": 0.9999195401900538,
+          "block_output_cosine_per_token": 0.9999220112059125,
+          "block_output_drift_relative_norm": 0.012685837908964355,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.35685089524601604,
+          "moe_input_normalized_cosine": 0.9999317807120685,
+          "moe_output_cosine": 0.9996961823732479,
+          "residual_drift_relative_norm": 0.006536817583550683,
+          "residual_stream_cosine": 0.9999786349806121,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697724989,
+            "residual_in_drift_relative_norm": 0.007966186310686194
+          },
+          "router_logit_cosine": 0.9999963366294831,
+          "router_margin_mean_delta": -2.446275262776493e-05,
+          "router_margin_mean_observed": 0.04404335021260723,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.029497699031347163,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 33.867552757263184,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 18.21269941329956
+      }
+    ],
     "pilot_labels_per_block": [
       "research_int4_side",
       "research_int4_side",
       "research_int4_side",
       "research_int4_side"
     ],
-    "int4_blocks": [
-      0,
-      1,
-      2,
-      3
-    ]
+    "skip_fp16_control": false,
+    "ternary_blocks": [],
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
   },
   "comparison": {
+    "baselines_cited": {
+      "baseline_72": {
+        "arm_label": "goz1_expert_ternary_only",
+        "block_output_cosine": [
+          0.963572,
+          0.945765,
+          0.884956,
+          0.839144
+        ],
+        "blocks": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "chain_exit_residual_drift": 0.6538863846584987,
+        "decision": 3,
+        "pack_names": {
+          "0": "block_000-attention_plus_expert.goz1",
+          "1": "block_001-attention_plus_expert.goz1",
+          "2": "block_002-attention_plus_expert.goz1",
+          "3": "block_003-attention_plus_expert.goz1"
+        },
+        "pack_sha256": {
+          "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+          "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+          "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+          "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+        },
+        "residual_in_drift": [
+          0.0,
+          0.277351,
+          0.341935,
+          0.498308
+        ],
+        "router_top1": [
+          1.0,
+          0.887695,
+          0.666504,
+          0.52832
+        ],
+        "router_top2": [
+          1.0,
+          0.680664,
+          0.548828,
+          0.289551
+        ],
+        "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+        "token_seed": 20260806,
+        "tokens": 2048,
+        "top_k": 2
+      },
+      "baseline_74": {
+        "arm_label": "expert_periodic_hp_n2",
+        "block_output_cosine": [
+          0.963572,
+          0.963211,
+          0.90536,
+          0.882308
+        ],
+        "blocks": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "chain_exit_residual_drift": 0.5292121735722244,
+        "decision": 2,
+        "expert_load_js_bits": [
+          0.0,
+          0.005559,
+          0.008548,
+          0.025243
+        ],
+        "pack_names": {
+          "0": "block_000-attention_plus_expert.goz1",
+          "1": "block_001-attention_plus_expert.goz1",
+          "2": "block_002-attention_plus_expert.goz1",
+          "3": "block_003-attention_plus_expert.goz1"
+        },
+        "pack_sha256": {
+          "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+          "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+          "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+          "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+        },
+        "residual_in_drift": [
+          0.0,
+          0.277351,
+          0.279321,
+          0.449088
+        ],
+        "router_top1": [
+          1.0,
+          0.887695,
+          0.729004,
+          0.547852
+        ],
+        "router_top2": [
+          1.0,
+          0.680664,
+          0.592773,
+          0.317383
+        ],
+        "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+        "token_seed": 20260806,
+        "tokens": 2048,
+        "top_k": 2
+      },
+      "ceiling": {
+        "arm_label": "expert_hp_ceiling",
+        "block_output_cosine": [
+          1.0,
+          0.999997,
+          0.999998,
+          0.999984
+        ],
+        "blocks": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "chain_exit_residual_drift": 0.005690267932494616,
+        "router_top1": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
+        "token_seed": 20260806,
+        "tokens": 2048,
+        "top_k": 2,
+        "viable": true
+      },
+      "denser": {
+        "arm_label": "expert_periodic_hp_123",
+        "block_output_cosine": [
+          0.963572,
+          0.963211,
+          0.939684,
+          0.913853
+        ],
+        "blocks": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "chain_exit_residual_drift": 0.4370545723375058,
+        "decision": 2,
+        "residual_in_drift": [
+          0.0,
+          0.277351,
+          0.279321,
+          0.348475
+        ],
+        "router_top1": [
+          1.0,
+          0.887695,
+          0.729004,
+          0.615723
+        ],
+        "router_top2": [
+          1.0,
+          0.680664,
+          0.592773,
+          0.408691
+        ],
+        "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
+        "token_seed": 20260806,
+        "tokens": 2048,
+        "top_k": 2
+      }
+    },
     "primary_arm": "expert_int4",
+    "primary_provenance": {
+      "implementation": {
+        "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
+        "dirty": true
+      }
+    },
     "secondary_arms": {
       "expert_int4_123": {
-        "provenance": {
-          "issue": "GH #80 / Linear RM-468 / beads goz-d603r4",
-          "agent": "Grok Build: Grok 4.5 (high) (xAI) \u00b7 Issue: #80 / Linear RM-468 \u00b7 beads goz-d603r4",
-          "model": "Grok-4.5 (high)",
-          "design": "Grok Build design lock: INT4 research side-table middle-ground (P0 all-blocks + P1 denser HP); cite #76 denser/ceiling",
-          "baseline_64": {
-            "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-            "tokens": 2048,
-            "expert_only": {
-              "block_output_cosine": 0.963572,
-              "residual_stream_cosine": 1.0,
-              "residual_drift_relative_norm": 0.0,
-              "router_top1_agreement": 1.0,
-              "router_top2_set_agreement": 1.0,
-              "expert_load_js_bits": 0.0,
-              "moe_output_cosine": 0.773483
-            }
-          },
-          "baseline_72": {
-            "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 3,
-            "block_output_cosine": [
-              0.963572,
-              0.945765,
-              0.884956,
-              0.839144
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.341935,
-              0.498308
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.666504,
-              0.52832
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.548828,
-              0.289551
-            ],
-            "chain_exit_residual_drift": 0.6538863846584987,
-            "arm_label": "goz1_expert_ternary_only",
-            "pack_sha256": {
-              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-            },
-            "pack_names": {
-              "0": "block_000-attention_plus_expert.goz1",
-              "1": "block_001-attention_plus_expert.goz1",
-              "2": "block_002-attention_plus_expert.goz1",
-              "3": "block_003-attention_plus_expert.goz1"
-            }
-          },
-          "baseline_74": {
-            "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 2,
-            "block_output_cosine": [
-              0.963572,
-              0.963211,
-              0.90536,
-              0.882308
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.279321,
-              0.449088
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.729004,
-              0.547852
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.592773,
-              0.317383
-            ],
-            "expert_load_js_bits": [
-              0.0,
-              0.005559,
-              0.008548,
-              0.025243
-            ],
-            "chain_exit_residual_drift": 0.5292121735722244,
-            "arm_label": "expert_periodic_hp_n2",
-            "pack_sha256": {
-              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-            },
-            "pack_names": {
-              "0": "block_000-attention_plus_expert.goz1",
-              "1": "block_001-attention_plus_expert.goz1",
-              "2": "block_002-attention_plus_expert.goz1",
-              "3": "block_003-attention_plus_expert.goz1"
-            }
-          },
-          "baseline_76_denser": {
-            "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "decision": 2,
-            "block_output_cosine": [
-              0.963572,
-              0.963211,
-              0.939684,
-              0.913853
-            ],
-            "residual_in_drift": [
-              0.0,
-              0.277351,
-              0.279321,
-              0.348475
-            ],
-            "router_top1": [
-              1.0,
-              0.887695,
-              0.729004,
-              0.615723
-            ],
-            "router_top2": [
-              1.0,
-              0.680664,
-              0.592773,
-              0.408691
-            ],
-            "chain_exit_residual_drift": 0.4370545723375058,
-            "arm_label": "expert_periodic_hp_123"
-          },
-          "baseline_76_ceiling": {
-            "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
-            "tokens": 2048,
-            "token_seed": 20260806,
-            "blocks": [
-              0,
-              1,
-              2,
-              3
-            ],
-            "top_k": 2,
-            "block_output_cosine": [
-              1.0,
-              0.999997,
-              0.999998,
-              0.999984
-            ],
-            "router_top1": [
-              1.0,
-              1.0,
-              1.0,
-              1.0
-            ],
-            "chain_exit_residual_drift": 0.005690267932494616,
-            "arm_label": "expert_hp_ceiling",
-            "viable": true
-          },
-          "implementation": {
-            "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
-            "dirty": true
-          },
-          "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-          "numpy": "2.5.1",
-          "python": "3.14.6",
-          "embedding_shard": "embedding__slot_00__token_embedding.npy",
-          "skip_fp16_control": false,
-          "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-          "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-          "scale_policy": "research_int4_side per-output-channel absmax on INT4 path; GOZ1 v3 pack-only on ternary cite path; abort on legacy_oracle",
-          "arm": "int4",
-          "metrics_filename": "metrics.json",
-          "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
-          "evidence_role": "secondary; no independent decision"
-        },
         "chain": {
+          "arm_label": "expert_int4_123",
           "blocks": [
             0,
             1,
             2,
             3
           ],
-          "tokens": 2048,
-          "token_seed": 20260806,
-          "token_id_first": 61,
-          "token_id_last": 130950,
-          "top_k": 2,
-          "per_block": [
-            {
-              "block": 0,
-              "reference_seconds": 25.066315174102783,
-              "expert_only": {
-                "label": "research_int4_side",
-                "seconds": 44.15513730049133,
-                "attention_output_cosine": 1.0,
-                "attention_output_cosine_per_token": 1.0,
-                "residual_stream_cosine": 1.0000000000000002,
-                "moe_input_normalized_cosine": 1.0,
-                "router_logit_cosine": 1.0,
-                "moe_output_cosine": 0.994302110178458,
-                "block_output_cosine": 0.9986151821027426,
-                "block_output_cosine_per_token": 0.9986060303095572,
-                "residual_drift_relative_norm": 0.0,
-                "block_output_drift_relative_norm": 0.05288061497549421,
-                "attn_delta_over_stream": 0.876171414302045,
-                "moe_delta_over_stream": 0.48116209785584313,
-                "router_top1_agreement": 1.0,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 1.0,
-                "router_top2_set_agreement": 1.0,
-                "expert_load_reference": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
-                "expert_load_observed": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
-                "expert_load_js_bits": 0.0,
-                "expert_load_max_abs_delta": 0.0,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.030204767217204893,
-                "router_margin_mean_observed": 0.030204767217204893,
-                "router_margin_mean_delta": 0.0,
-                "router_margin_median_reference": 0.006170911132304002,
-                "router_margin_median_observed": 0.006170911132304002,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 1173,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 443,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 346,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 86,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 1.0,
-                  "residual_in_drift_relative_norm": 0.0
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 37.03864359855652,
-                "attention_output_cosine": 0.9999999984424572,
-                "attention_output_cosine_per_token": 0.9999999986030829,
-                "residual_stream_cosine": 0.9999999831365632,
-                "moe_input_normalized_cosine": 0.9999999606124855,
-                "router_logit_cosine": 0.9999999971511485,
-                "moe_output_cosine": 0.9999813002410165,
-                "block_output_cosine": 0.9999870040318545,
-                "block_output_cosine_per_token": 0.9999880581321908,
-                "residual_drift_relative_norm": 0.00021537234101925558,
-                "block_output_drift_relative_norm": 0.005098830221729304,
-                "attn_delta_over_stream": 0.8760054853350859,
-                "moe_delta_over_stream": 0.482784499720899,
-                "router_top1_agreement": 0.9970703125,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.9990234375,
-                "router_top2_set_agreement": 0.9990234375,
-                "expert_load_reference": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.114013671875,
-                  0.127197265625,
-                  0.12841796875,
-                  0.1044921875
-                ],
-                "expert_load_observed": [
-                  0.131591796875,
-                  0.102294921875,
-                  0.166259765625,
-                  0.125732421875,
-                  0.11376953125,
-                  0.127685546875,
-                  0.12841796875,
-                  0.104248046875
-                ],
-                "expert_load_js_bits": 5.347430923457726e-07,
-                "expert_load_max_abs_delta": 0.00048828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.030204767217204893,
-                "router_margin_mean_observed": 0.030207654444896787,
-                "router_margin_mean_delta": 2.8872276918900968e-06,
-                "router_margin_median_reference": 0.006170911132304002,
-                "router_margin_median_observed": 0.0061808020273402264,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 1173,
-                    "top1_flips": 6,
-                    "top1_flip_rate": 0.005115089514066497
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 443,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 346,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 86,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 1.0,
-                  "residual_in_drift_relative_norm": 0.0
-                }
-              },
-              "pilot_label": "research_int4_side"
-            },
-            {
-              "block": 1,
-              "reference_seconds": 21.432623624801636,
-              "expert_only": {
-                "label": "expert_int4_123",
-                "seconds": 38.77097153663635,
-                "attention_output_cosine": 0.9994805824645078,
-                "attention_output_cosine_per_token": 0.9994966546188022,
-                "residual_stream_cosine": 0.998956811213174,
-                "moe_input_normalized_cosine": 0.9983623750311726,
-                "router_logit_cosine": 0.999822663993783,
-                "moe_output_cosine": 0.9960516073713731,
-                "block_output_cosine": 0.9984733954000422,
-                "block_output_cosine_per_token": 0.9984467147346038,
-                "residual_drift_relative_norm": 0.045856788607629415,
-                "block_output_drift_relative_norm": 0.055352064339083296,
-                "attn_delta_over_stream": 0.3935783059266308,
-                "moe_delta_over_stream": 0.28870008648630724,
-                "router_top1_agreement": 0.98193359375,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.93359375,
-                "router_top2_set_agreement": 0.93359375,
-                "expert_load_reference": [
-                  0.1611328125,
-                  0.120361328125,
-                  0.109619140625,
-                  0.096923828125,
-                  0.117431640625,
-                  0.158203125,
-                  0.103515625,
-                  0.1328125
-                ],
-                "expert_load_observed": [
-                  0.161865234375,
-                  0.118896484375,
-                  0.110107421875,
-                  0.095703125,
-                  0.119140625,
-                  0.155029296875,
-                  0.104736328125,
-                  0.134521484375
-                ],
-                "expert_load_js_bits": 2.958814470063395e-05,
-                "expert_load_max_abs_delta": 0.003173828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.1829495213809987,
-                "router_margin_mean_observed": 0.18275724966811674,
-                "router_margin_mean_delta": -0.00019227171288197753,
-                "router_margin_median_reference": 0.15255148410556432,
-                "router_margin_median_observed": 0.15099636260196336,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 96,
-                    "top1_flips": 32,
-                    "top1_flip_rate": 0.3333333333333333
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 322,
-                    "top1_flips": 5,
-                    "top1_flip_rate": 0.015527950310559006
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 593,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 961,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 76,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9986151821027426,
-                  "residual_in_drift_relative_norm": 0.05288061497549421
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 39.304056882858276,
-                "attention_output_cosine": 0.9999955239311591,
-                "attention_output_cosine_per_token": 0.9999949975985942,
-                "residual_stream_cosine": 0.9999902372591066,
-                "moe_input_normalized_cosine": 0.9999833030390249,
-                "router_logit_cosine": 0.9999982162936869,
-                "moe_output_cosine": 0.9999664606659787,
-                "block_output_cosine": 0.9999859463222839,
-                "block_output_cosine_per_token": 0.9999851320664912,
-                "residual_drift_relative_norm": 0.0044204095195649025,
-                "block_output_drift_relative_norm": 0.005302552236880725,
-                "attn_delta_over_stream": 0.3961794228342294,
-                "moe_delta_over_stream": 0.2896839054949744,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.9990234375,
-                "router_top2_set_agreement": 0.9990234375,
-                "expert_load_reference": [
-                  0.1611328125,
-                  0.120361328125,
-                  0.109619140625,
-                  0.096923828125,
-                  0.117431640625,
-                  0.158203125,
-                  0.103515625,
-                  0.1328125
-                ],
-                "expert_load_observed": [
-                  0.161376953125,
-                  0.1201171875,
-                  0.109619140625,
-                  0.096923828125,
-                  0.11767578125,
-                  0.158203125,
-                  0.103515625,
-                  0.132568359375
-                ],
-                "expert_load_js_bits": 3.2849983466729546e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.1829495213809987,
-                "router_margin_mean_observed": 0.18297782060234993,
-                "router_margin_mean_delta": 2.8299221351235133e-05,
-                "router_margin_median_reference": 0.15255148410556432,
-                "router_margin_median_observed": 0.15256866411484876,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 96,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.010416666666666666
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 322,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 593,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 961,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 76,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999870040318545,
-                  "residual_in_drift_relative_norm": 0.005098830221729304
-                }
-              },
-              "pilot_label": "expert_int4_123"
-            },
-            {
-              "block": 2,
-              "reference_seconds": 18.46852445602417,
-              "expert_only": {
-                "label": "expert_int4_123",
-                "seconds": 37.270052671432495,
-                "attention_output_cosine": 0.997791168879033,
-                "attention_output_cosine_per_token": 0.9978028331224871,
-                "residual_stream_cosine": 0.9987241913633482,
-                "moe_input_normalized_cosine": 0.9973407139931779,
-                "router_logit_cosine": 0.999727058195182,
-                "moe_output_cosine": 0.9861352778082605,
-                "block_output_cosine": 0.9956197704253421,
-                "block_output_cosine_per_token": 0.9955563252939656,
-                "residual_drift_relative_norm": 0.05065577079655575,
-                "block_output_drift_relative_norm": 0.0935215641530563,
-                "attn_delta_over_stream": 0.5833000319768352,
-                "moe_delta_over_stream": 0.40577715858960955,
-                "router_top1_agreement": 0.953125,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.919921875,
-                "router_top2_set_agreement": 0.919921875,
-                "expert_load_reference": [
-                  0.047607421875,
-                  0.12646484375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.238525390625
-                ],
-                "expert_load_observed": [
-                  0.047607421875,
-                  0.13427734375,
-                  0.06103515625,
-                  0.243896484375,
-                  0.02880859375,
-                  0.07177734375,
-                  0.178466796875,
-                  0.234130859375
-                ],
-                "expert_load_js_bits": 0.0002489326034859664,
-                "expert_load_max_abs_delta": 0.01171875,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.035814945567023374,
-                "router_margin_mean_observed": 0.035266875542993154,
-                "router_margin_mean_delta": -0.0005480700240302096,
-                "router_margin_median_reference": 0.025870355622028635,
-                "router_margin_median_observed": 0.02550062808475105,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 460,
-                    "top1_flips": 86,
-                    "top1_flip_rate": 0.18695652173913044
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 1055,
-                    "top1_flips": 10,
-                    "top1_flip_rate": 0.009478672985781991
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 513,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 20,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9984733954000422,
-                  "residual_in_drift_relative_norm": 0.055352064339083296
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 39.70007848739624,
-                "attention_output_cosine": 0.9999951789408488,
-                "attention_output_cosine_per_token": 0.9999948156177104,
-                "residual_stream_cosine": 0.999991030697749,
-                "moe_input_normalized_cosine": 0.9999805357628218,
-                "router_logit_cosine": 0.99999830045166,
-                "moe_output_cosine": 0.9998240608794524,
-                "block_output_cosine": 0.9999682697724989,
-                "block_output_cosine_per_token": 0.9999678107548897,
-                "residual_drift_relative_norm": 0.004235465975258782,
-                "block_output_drift_relative_norm": 0.007966186310686194,
-                "attn_delta_over_stream": 0.584956965059082,
-                "moe_delta_over_stream": 0.4112808355956077,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.99951171875,
-                "router_top2_set_agreement": 0.99951171875,
-                "expert_load_reference": [
-                  0.047607421875,
-                  0.12646484375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.238525390625
-                ],
-                "expert_load_observed": [
-                  0.047607421875,
-                  0.126708984375,
-                  0.060791015625,
-                  0.255615234375,
-                  0.02734375,
-                  0.071044921875,
-                  0.172607421875,
-                  0.23828125
-                ],
-                "expert_load_js_bits": 1.300004449968095e-07,
-                "expert_load_max_abs_delta": 0.000244140625,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.035814945567023374,
-                "router_margin_mean_observed": 0.03582240155308043,
-                "router_margin_mean_delta": 7.4559860570678075e-06,
-                "router_margin_median_reference": 0.025870355622028635,
-                "router_margin_median_observed": 0.025836218008428474,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 460,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.002173913043478261
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 1055,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 513,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 20,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999859463222839,
-                  "residual_in_drift_relative_norm": 0.005302552236880725
-                }
-              },
-              "pilot_label": "expert_int4_123"
-            },
-            {
-              "block": 3,
-              "reference_seconds": 20.111958265304565,
-              "expert_only": {
-                "label": "expert_int4_123",
-                "seconds": 44.01105546951294,
-                "attention_output_cosine": 0.9933526611621083,
-                "attention_output_cosine_per_token": 0.9933280158751556,
-                "residual_stream_cosine": 0.9968655131007353,
-                "moe_input_normalized_cosine": 0.9901588534262185,
-                "router_logit_cosine": 0.9995724067351002,
-                "moe_output_cosine": 0.9774093487202452,
-                "block_output_cosine": 0.9915226862504408,
-                "block_output_cosine_per_token": 0.9913832419923976,
-                "residual_drift_relative_norm": 0.07912630612051204,
-                "block_output_drift_relative_norm": 0.1302129056031902,
-                "attn_delta_over_stream": 0.4985185792142929,
-                "moe_delta_over_stream": 0.35593962253825956,
-                "router_top1_agreement": 0.92529296875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.861328125,
-                "router_top2_set_agreement": 0.861328125,
-                "expert_load_reference": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.15625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.194091796875,
-                  0.084716796875
-                ],
-                "expert_load_observed": [
-                  0.054931640625,
-                  0.07080078125,
-                  0.038818359375,
-                  0.1591796875,
-                  0.381103515625,
-                  0.0224609375,
-                  0.19482421875,
-                  0.077880859375
-                ],
-                "expert_load_js_bits": 0.00016866846773804433,
-                "expert_load_max_abs_delta": 0.0068359375,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.044067812965235,
-                "router_margin_mean_observed": 0.0437278129058025,
-                "router_margin_mean_delta": -0.000340000059432497,
-                "router_margin_median_reference": 0.0295396135928446,
-                "router_margin_median_observed": 0.02952331167047509,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 421,
-                    "top1_flips": 103,
-                    "top1_flip_rate": 0.24465558194774348
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 988,
-                    "top1_flips": 45,
-                    "top1_flip_rate": 0.04554655870445344
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 568,
-                    "top1_flips": 5,
-                    "top1_flip_rate": 0.008802816901408451
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 71,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9956197704253421,
-                  "residual_in_drift_relative_norm": 0.0935215641530563
-                }
-              },
-              "fp16_control": {
-                "label": "fp16_roundtrip",
-                "seconds": 41.16312384605408,
-                "attention_output_cosine": 0.999967551568842,
-                "attention_output_cosine_per_token": 0.9999677009593164,
-                "residual_stream_cosine": 0.9999786349806121,
-                "moe_input_normalized_cosine": 0.9999317807120685,
-                "router_logit_cosine": 0.9999963366294831,
-                "moe_output_cosine": 0.9996961823732479,
-                "block_output_cosine": 0.9999195401900538,
-                "block_output_cosine_per_token": 0.9999220112059125,
-                "residual_drift_relative_norm": 0.006536817583550683,
-                "block_output_drift_relative_norm": 0.012685837908964355,
-                "attn_delta_over_stream": 0.5008011118859926,
-                "moe_delta_over_stream": 0.35685089524601604,
-                "router_top1_agreement": 0.99951171875,
-                "selected_experts": 2,
-                "router_topk_set_agreement": 0.998046875,
-                "router_top2_set_agreement": 0.998046875,
-                "expert_load_reference": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.15625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.194091796875,
-                  0.084716796875
-                ],
-                "expert_load_observed": [
-                  0.0517578125,
-                  0.070556640625,
-                  0.036865234375,
-                  0.156494140625,
-                  0.38330078125,
-                  0.0224609375,
-                  0.1943359375,
-                  0.084228515625
-                ],
-                "expert_load_js_bits": 6.330749621763374e-07,
-                "expert_load_max_abs_delta": 0.00048828125,
-                "experts_unused_reference": 0,
-                "experts_unused_observed": 0,
-                "router_margin_mean_reference": 0.044067812965235,
-                "router_margin_mean_observed": 0.04404335021260723,
-                "router_margin_mean_delta": -2.446275262776493e-05,
-                "router_margin_median_reference": 0.0295396135928446,
-                "router_margin_median_observed": 0.029497699031347163,
-                "flip_stratification_by_reference_margin": [
-                  {
-                    "margin_low": 0.0,
-                    "margin_high": 0.01,
-                    "tokens": 421,
-                    "top1_flips": 1,
-                    "top1_flip_rate": 0.0023752969121140144
-                  },
-                  {
-                    "margin_low": 0.01,
-                    "margin_high": 0.05,
-                    "tokens": 988,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.05,
-                    "margin_high": 0.15,
-                    "tokens": 568,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.15,
-                    "margin_high": 0.5,
-                    "tokens": 71,
-                    "top1_flips": 0,
-                    "top1_flip_rate": 0.0
-                  },
-                  {
-                    "margin_low": 0.5,
-                    "margin_high": 1.01,
-                    "tokens": 0,
-                    "top1_flips": 0,
-                    "top1_flip_rate": null
-                  }
-                ],
-                "experts_touched": [
-                  0,
-                  1,
-                  2,
-                  3,
-                  4,
-                  5,
-                  6,
-                  7
-                ],
-                "residual_stream_in": {
-                  "residual_in_cosine": 0.9999682697724989,
-                  "residual_in_drift_relative_norm": 0.007966186310686194
-                }
-              },
-              "pilot_label": "expert_int4_123"
-            }
-          ],
+          "channel_alpha_blocks": [],
           "end_of_chain": {
             "expert_only_chain_exit": {
+              "note": "post-final-block residual stream (chain exit), not last-block residual-in",
               "residual_cosine": 0.9915226862504408,
-              "residual_drift_relative_norm": 0.1302129056031902,
-              "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+              "residual_drift_relative_norm": 0.1302129056031902
             },
             "fp16_chain_exit": {
+              "note": "post-final-block residual stream under FP16 control",
               "residual_cosine": 0.9999195401900538,
-              "residual_drift_relative_norm": 0.012685837908964355,
-              "note": "post-final-block residual stream under FP16 control"
+              "residual_drift_relative_norm": 0.012685837908964355
             }
           },
+          "expert_mode": "int4",
+          "hp_blocks": [
+            1,
+            2,
+            3
+          ],
+          "hp_period": null,
+          "hp_schedule_kind": "explicit",
+          "hp_schedule_prose": "INT4 middle-ground label `expert_int4_123`: research INT4 experts on {0}, HP (FP16 experts) on {1,2,3}.",
+          "int4_blocks": [
+            0
+          ],
           "pack_provenance": [
             {
               "block": 0,
-              "pack": "block_000-attention_plus_expert.goz1",
-              "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_000-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_000.slot_01.moe_expert.down": "research_int4_side",
-                "block_000.slot_00.moe_expert.gate": "research_int4_side",
-                "block_000.slot_02.moe_expert.up": "research_int4_side"
-              },
-              "pack_scale_sources": {
-                "block_000.slot_01.moe_expert.down": "pack_v2",
-                "block_000.slot_00.moe_expert.gate": "pack_v2",
-                "block_000.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_000.slot_00.moe_expert.gate": {
-                  "alpha": 0.03446429222822189,
-                  "sparsity": 0.652848777671655,
-                  "fired": 559126180,
-                  "total": 1610612736
-                },
-                "block_000.slot_01.moe_expert.down": {
-                  "alpha": 0.02270425483584404,
-                  "sparsity": 0.6372781544923782,
-                  "fired": 584204424,
-                  "total": 1610612736
-                },
-                "block_000.slot_02.moe_expert.up": {
-                  "alpha": 0.0343967042863369,
-                  "sparsity": 0.6443704627454281,
-                  "fired": 572781462,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_000.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2511,52 +1428,52 @@
                   "threshold_abs": 0.004230931401252747
                 }
               },
+              "npy_dir": "goz68-block_000-attn",
+              "pack": "block_000-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_000.slot_00.moe_expert.gate": "pack_v2",
+                "block_000.slot_01.moe_expert.down": "pack_v2",
+                "block_000.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "scale_sources": {
+                "block_000.slot_00.moe_expert.gate": "research_int4_side",
+                "block_000.slot_01.moe_expert.down": "research_int4_side",
+                "block_000.slot_02.moe_expert.up": "research_int4_side"
+              },
+              "ternary_scales": {
+                "block_000.slot_00.moe_expert.gate": {
+                  "alpha": 0.03446429222822189,
+                  "fired": 559126180,
+                  "sparsity": 0.652848777671655,
+                  "total": 1610612736
+                },
+                "block_000.slot_01.moe_expert.down": {
+                  "alpha": 0.02270425483584404,
+                  "fired": 584204424,
+                  "sparsity": 0.6372781544923782,
+                  "total": 1610612736
+                },
+                "block_000.slot_02.moe_expert.up": {
+                  "alpha": 0.0343967042863369,
+                  "fired": 572781462,
+                  "sparsity": 0.6443704627454281,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 1,
-              "pack": "block_001-attention_plus_expert.goz1",
-              "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_001-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_001.slot_01.moe_expert.down": "fp16_control",
-                "block_001.slot_00.moe_expert.gate": "fp16_control",
-                "block_001.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_001.slot_01.moe_expert.down": "pack_v2",
-                "block_001.slot_00.moe_expert.gate": "pack_v2",
-                "block_001.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_001.slot_00.moe_expert.gate": {
-                  "alpha": 0.04331796243786812,
-                  "sparsity": 0.633674278234442,
-                  "fired": 590008873,
-                  "total": 1610612736
-                },
-                "block_001.slot_01.moe_expert.down": {
-                  "alpha": 0.010844916105270386,
-                  "sparsity": 0.6404839977622032,
-                  "fired": 579041052,
-                  "total": 1610612736
-                },
-                "block_001.slot_02.moe_expert.up": {
-                  "alpha": 0.04337596148252487,
-                  "sparsity": 0.6348795853555202,
-                  "fired": 588067590,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_001.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2587,52 +1504,52 @@
                   "threshold_abs": 0.007041923236101866
                 }
               },
+              "npy_dir": "goz68-block_001-attn",
+              "pack": "block_001-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_001.slot_00.moe_expert.gate": "pack_v2",
+                "block_001.slot_01.moe_expert.down": "pack_v2",
+                "block_001.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "scale_sources": {
+                "block_001.slot_00.moe_expert.gate": "fp16_control",
+                "block_001.slot_01.moe_expert.down": "fp16_control",
+                "block_001.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_001.slot_00.moe_expert.gate": {
+                  "alpha": 0.04331796243786812,
+                  "fired": 590008873,
+                  "sparsity": 0.633674278234442,
+                  "total": 1610612736
+                },
+                "block_001.slot_01.moe_expert.down": {
+                  "alpha": 0.010844916105270386,
+                  "fired": 579041052,
+                  "sparsity": 0.6404839977622032,
+                  "total": 1610612736
+                },
+                "block_001.slot_02.moe_expert.up": {
+                  "alpha": 0.04337596148252487,
+                  "fired": 588067590,
+                  "sparsity": 0.6348795853555202,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 2,
-              "pack": "block_002-attention_plus_expert.goz1",
-              "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_002-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_002.slot_01.moe_expert.down": "fp16_control",
-                "block_002.slot_00.moe_expert.gate": "fp16_control",
-                "block_002.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_002.slot_01.moe_expert.down": "pack_v2",
-                "block_002.slot_00.moe_expert.gate": "pack_v2",
-                "block_002.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_002.slot_00.moe_expert.gate": {
-                  "alpha": 0.047630175948143005,
-                  "sparsity": 0.6356016273299854,
-                  "fired": 586904660,
-                  "total": 1610612736
-                },
-                "block_002.slot_01.moe_expert.down": {
-                  "alpha": 0.022462978959083557,
-                  "sparsity": 0.6368899804850419,
-                  "fired": 584829622,
-                  "total": 1610612736
-                },
-                "block_002.slot_02.moe_expert.up": {
-                  "alpha": 0.047669243067502975,
-                  "sparsity": 0.6359017888704936,
-                  "fired": 586421216,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_002.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2663,52 +1580,52 @@
                   "threshold_abs": 0.01309292297810316
                 }
               },
+              "npy_dir": "goz68-block_002-attn",
+              "pack": "block_002-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_002.slot_00.moe_expert.gate": "pack_v2",
+                "block_002.slot_01.moe_expert.down": "pack_v2",
+                "block_002.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "scale_sources": {
+                "block_002.slot_00.moe_expert.gate": "fp16_control",
+                "block_002.slot_01.moe_expert.down": "fp16_control",
+                "block_002.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_002.slot_00.moe_expert.gate": {
+                  "alpha": 0.047630175948143005,
+                  "fired": 586904660,
+                  "sparsity": 0.6356016273299854,
+                  "total": 1610612736
+                },
+                "block_002.slot_01.moe_expert.down": {
+                  "alpha": 0.022462978959083557,
+                  "fired": 584829622,
+                  "sparsity": 0.6368899804850419,
+                  "total": 1610612736
+                },
+                "block_002.slot_02.moe_expert.up": {
+                  "alpha": 0.047669243067502975,
+                  "fired": 586421216,
+                  "sparsity": 0.6359017888704936,
+                  "total": 1610612736
+                }
               }
             },
             {
               "block": 3,
-              "pack": "block_003-attention_plus_expert.goz1",
-              "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-              "pack_bytes": 1230128768,
-              "npy_dir": "goz68-block_003-attn",
               "container_versions": [
                 3
               ],
-              "scale_sources": {
-                "block_003.slot_01.moe_expert.down": "fp16_control",
-                "block_003.slot_00.moe_expert.gate": "fp16_control",
-                "block_003.slot_02.moe_expert.up": "fp16_control"
-              },
-              "pack_scale_sources": {
-                "block_003.slot_01.moe_expert.down": "pack_v2",
-                "block_003.slot_00.moe_expert.gate": "pack_v2",
-                "block_003.slot_02.moe_expert.up": "pack_v2"
-              },
-              "ternary_scales": {
-                "block_003.slot_00.moe_expert.gate": {
-                  "alpha": 0.03307119756937027,
-                  "sparsity": 0.6364477450648944,
-                  "fired": 585541892,
-                  "total": 1610612736
-                },
-                "block_003.slot_01.moe_expert.down": {
-                  "alpha": 0.015412655659019947,
-                  "sparsity": 0.6372132208198309,
-                  "fired": 584309007,
-                  "total": 1610612736
-                },
-                "block_003.slot_02.moe_expert.up": {
-                  "alpha": 0.033106379210948944,
-                  "sparsity": 0.6368649223198493,
-                  "fired": 584869981,
-                  "total": 1610612736
-                }
-              },
               "gif_thresholds": {
                 "block_003.slot_00.moe_expert.gate": {
                   "gif_threshold": 0.8999999761581421,
@@ -2739,40 +1656,1146 @@
                   "threshold_abs": 0.0016606772551313043
                 }
               },
+              "npy_dir": "goz68-block_003-attn",
+              "pack": "block_003-attention_plus_expert.goz1",
+              "pack_bytes": 1230128768,
               "pack_metadata": {
-                "oz.quantization_version": 3,
                 "oz.gif_threshold": "0.05",
                 "oz.gif_threshold_authority": "tensor_row",
-                "oz.gif_threshold_scope": "baseline_only_not_applied"
+                "oz.gif_threshold_scope": "baseline_only_not_applied",
+                "oz.quantization_version": 3
+              },
+              "pack_scale_sources": {
+                "block_003.slot_00.moe_expert.gate": "pack_v2",
+                "block_003.slot_01.moe_expert.down": "pack_v2",
+                "block_003.slot_02.moe_expert.up": "pack_v2"
+              },
+              "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+              "scale_sources": {
+                "block_003.slot_00.moe_expert.gate": "fp16_control",
+                "block_003.slot_01.moe_expert.down": "fp16_control",
+                "block_003.slot_02.moe_expert.up": "fp16_control"
+              },
+              "ternary_scales": {
+                "block_003.slot_00.moe_expert.gate": {
+                  "alpha": 0.03307119756937027,
+                  "fired": 585541892,
+                  "sparsity": 0.6364477450648944,
+                  "total": 1610612736
+                },
+                "block_003.slot_01.moe_expert.down": {
+                  "alpha": 0.015412655659019947,
+                  "fired": 584309007,
+                  "sparsity": 0.6372132208198309,
+                  "total": 1610612736
+                },
+                "block_003.slot_02.moe_expert.up": {
+                  "alpha": 0.033106379210948944,
+                  "fired": 584869981,
+                  "sparsity": 0.6368649223198493,
+                  "total": 1610612736
+                }
               }
             }
           ],
-          "skip_fp16_control": false,
-          "expert_mode": "int4",
-          "hp_period": null,
-          "hp_schedule_kind": "explicit",
-          "hp_blocks": [
-            1,
-            2,
-            3
+          "per_block": [
+            {
+              "block": 0,
+              "expert_only": {
+                "attention_output_cosine": 1.0,
+                "attention_output_cosine_per_token": 1.0,
+                "attn_delta_over_stream": 0.876171414302045,
+                "block_output_cosine": 0.9986151821027426,
+                "block_output_cosine_per_token": 0.9986060303095572,
+                "block_output_drift_relative_norm": 0.05288061497549421,
+                "expert_load_js_bits": 0.0,
+                "expert_load_max_abs_delta": 0.0,
+                "expert_load_observed": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
+                ],
+                "expert_load_reference": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 1173,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 443,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 346,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 86,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "research_int4_side",
+                "moe_delta_over_stream": 0.48116209785584313,
+                "moe_input_normalized_cosine": 1.0,
+                "moe_output_cosine": 0.994302110178458,
+                "residual_drift_relative_norm": 0.0,
+                "residual_stream_cosine": 1.0000000000000002,
+                "residual_stream_in": {
+                  "residual_in_cosine": 1.0,
+                  "residual_in_drift_relative_norm": 0.0
+                },
+                "router_logit_cosine": 1.0,
+                "router_margin_mean_delta": 0.0,
+                "router_margin_mean_observed": 0.030204767217204893,
+                "router_margin_mean_reference": 0.030204767217204893,
+                "router_margin_median_observed": 0.006170911132304002,
+                "router_margin_median_reference": 0.006170911132304002,
+                "router_top1_agreement": 1.0,
+                "router_top2_set_agreement": 1.0,
+                "router_topk_set_agreement": 1.0,
+                "seconds": 44.15513730049133,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999999984424572,
+                "attention_output_cosine_per_token": 0.9999999986030829,
+                "attn_delta_over_stream": 0.8760054853350859,
+                "block_output_cosine": 0.9999870040318545,
+                "block_output_cosine_per_token": 0.9999880581321908,
+                "block_output_drift_relative_norm": 0.005098830221729304,
+                "expert_load_js_bits": 5.347430923457726e-07,
+                "expert_load_max_abs_delta": 0.00048828125,
+                "expert_load_observed": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.11376953125,
+                  0.127685546875,
+                  0.12841796875,
+                  0.104248046875
+                ],
+                "expert_load_reference": [
+                  0.131591796875,
+                  0.102294921875,
+                  0.166259765625,
+                  0.125732421875,
+                  0.114013671875,
+                  0.127197265625,
+                  0.12841796875,
+                  0.1044921875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 1173,
+                    "top1_flip_rate": 0.005115089514066497,
+                    "top1_flips": 6
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 443,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 346,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 86,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.482784499720899,
+                "moe_input_normalized_cosine": 0.9999999606124855,
+                "moe_output_cosine": 0.9999813002410165,
+                "residual_drift_relative_norm": 0.00021537234101925558,
+                "residual_stream_cosine": 0.9999999831365632,
+                "residual_stream_in": {
+                  "residual_in_cosine": 1.0,
+                  "residual_in_drift_relative_norm": 0.0
+                },
+                "router_logit_cosine": 0.9999999971511485,
+                "router_margin_mean_delta": 2.8872276918900968e-06,
+                "router_margin_mean_observed": 0.030207654444896787,
+                "router_margin_mean_reference": 0.030204767217204893,
+                "router_margin_median_observed": 0.0061808020273402264,
+                "router_margin_median_reference": 0.006170911132304002,
+                "router_top1_agreement": 0.9970703125,
+                "router_top2_set_agreement": 0.9990234375,
+                "router_topk_set_agreement": 0.9990234375,
+                "seconds": 37.03864359855652,
+                "selected_experts": 2
+              },
+              "pilot_label": "research_int4_side",
+              "reference_seconds": 25.066315174102783
+            },
+            {
+              "block": 1,
+              "expert_only": {
+                "attention_output_cosine": 0.9994805824645078,
+                "attention_output_cosine_per_token": 0.9994966546188022,
+                "attn_delta_over_stream": 0.3935783059266308,
+                "block_output_cosine": 0.9984733954000422,
+                "block_output_cosine_per_token": 0.9984467147346038,
+                "block_output_drift_relative_norm": 0.055352064339083296,
+                "expert_load_js_bits": 2.958814470063395e-05,
+                "expert_load_max_abs_delta": 0.003173828125,
+                "expert_load_observed": [
+                  0.161865234375,
+                  0.118896484375,
+                  0.110107421875,
+                  0.095703125,
+                  0.119140625,
+                  0.155029296875,
+                  0.104736328125,
+                  0.134521484375
+                ],
+                "expert_load_reference": [
+                  0.1611328125,
+                  0.120361328125,
+                  0.109619140625,
+                  0.096923828125,
+                  0.117431640625,
+                  0.158203125,
+                  0.103515625,
+                  0.1328125
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 96,
+                    "top1_flip_rate": 0.3333333333333333,
+                    "top1_flips": 32
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 322,
+                    "top1_flip_rate": 0.015527950310559006,
+                    "top1_flips": 5
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 593,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 961,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 76,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_int4_123",
+                "moe_delta_over_stream": 0.28870008648630724,
+                "moe_input_normalized_cosine": 0.9983623750311726,
+                "moe_output_cosine": 0.9960516073713731,
+                "residual_drift_relative_norm": 0.045856788607629415,
+                "residual_stream_cosine": 0.998956811213174,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9986151821027426,
+                  "residual_in_drift_relative_norm": 0.05288061497549421
+                },
+                "router_logit_cosine": 0.999822663993783,
+                "router_margin_mean_delta": -0.00019227171288197753,
+                "router_margin_mean_observed": 0.18275724966811674,
+                "router_margin_mean_reference": 0.1829495213809987,
+                "router_margin_median_observed": 0.15099636260196336,
+                "router_margin_median_reference": 0.15255148410556432,
+                "router_top1_agreement": 0.98193359375,
+                "router_top2_set_agreement": 0.93359375,
+                "router_topk_set_agreement": 0.93359375,
+                "seconds": 38.77097153663635,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999955239311591,
+                "attention_output_cosine_per_token": 0.9999949975985942,
+                "attn_delta_over_stream": 0.3961794228342294,
+                "block_output_cosine": 0.9999859463222839,
+                "block_output_cosine_per_token": 0.9999851320664912,
+                "block_output_drift_relative_norm": 0.005302552236880725,
+                "expert_load_js_bits": 3.2849983466729546e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
+                "expert_load_observed": [
+                  0.161376953125,
+                  0.1201171875,
+                  0.109619140625,
+                  0.096923828125,
+                  0.11767578125,
+                  0.158203125,
+                  0.103515625,
+                  0.132568359375
+                ],
+                "expert_load_reference": [
+                  0.1611328125,
+                  0.120361328125,
+                  0.109619140625,
+                  0.096923828125,
+                  0.117431640625,
+                  0.158203125,
+                  0.103515625,
+                  0.1328125
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 96,
+                    "top1_flip_rate": 0.010416666666666666,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 322,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 593,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 961,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 76,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.2896839054949744,
+                "moe_input_normalized_cosine": 0.9999833030390249,
+                "moe_output_cosine": 0.9999664606659787,
+                "residual_drift_relative_norm": 0.0044204095195649025,
+                "residual_stream_cosine": 0.9999902372591066,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999870040318545,
+                  "residual_in_drift_relative_norm": 0.005098830221729304
+                },
+                "router_logit_cosine": 0.9999982162936869,
+                "router_margin_mean_delta": 2.8299221351235133e-05,
+                "router_margin_mean_observed": 0.18297782060234993,
+                "router_margin_mean_reference": 0.1829495213809987,
+                "router_margin_median_observed": 0.15256866411484876,
+                "router_margin_median_reference": 0.15255148410556432,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.9990234375,
+                "router_topk_set_agreement": 0.9990234375,
+                "seconds": 39.304056882858276,
+                "selected_experts": 2
+              },
+              "pilot_label": "expert_int4_123",
+              "reference_seconds": 21.432623624801636
+            },
+            {
+              "block": 2,
+              "expert_only": {
+                "attention_output_cosine": 0.997791168879033,
+                "attention_output_cosine_per_token": 0.9978028331224871,
+                "attn_delta_over_stream": 0.5833000319768352,
+                "block_output_cosine": 0.9956197704253421,
+                "block_output_cosine_per_token": 0.9955563252939656,
+                "block_output_drift_relative_norm": 0.0935215641530563,
+                "expert_load_js_bits": 0.0002489326034859664,
+                "expert_load_max_abs_delta": 0.01171875,
+                "expert_load_observed": [
+                  0.047607421875,
+                  0.13427734375,
+                  0.06103515625,
+                  0.243896484375,
+                  0.02880859375,
+                  0.07177734375,
+                  0.178466796875,
+                  0.234130859375
+                ],
+                "expert_load_reference": [
+                  0.047607421875,
+                  0.12646484375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.238525390625
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 460,
+                    "top1_flip_rate": 0.18695652173913044,
+                    "top1_flips": 86
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 1055,
+                    "top1_flip_rate": 0.009478672985781991,
+                    "top1_flips": 10
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 513,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 20,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_int4_123",
+                "moe_delta_over_stream": 0.40577715858960955,
+                "moe_input_normalized_cosine": 0.9973407139931779,
+                "moe_output_cosine": 0.9861352778082605,
+                "residual_drift_relative_norm": 0.05065577079655575,
+                "residual_stream_cosine": 0.9987241913633482,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9984733954000422,
+                  "residual_in_drift_relative_norm": 0.055352064339083296
+                },
+                "router_logit_cosine": 0.999727058195182,
+                "router_margin_mean_delta": -0.0005480700240302096,
+                "router_margin_mean_observed": 0.035266875542993154,
+                "router_margin_mean_reference": 0.035814945567023374,
+                "router_margin_median_observed": 0.02550062808475105,
+                "router_margin_median_reference": 0.025870355622028635,
+                "router_top1_agreement": 0.953125,
+                "router_top2_set_agreement": 0.919921875,
+                "router_topk_set_agreement": 0.919921875,
+                "seconds": 37.270052671432495,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.9999951789408488,
+                "attention_output_cosine_per_token": 0.9999948156177104,
+                "attn_delta_over_stream": 0.584956965059082,
+                "block_output_cosine": 0.9999682697724989,
+                "block_output_cosine_per_token": 0.9999678107548897,
+                "block_output_drift_relative_norm": 0.007966186310686194,
+                "expert_load_js_bits": 1.300004449968095e-07,
+                "expert_load_max_abs_delta": 0.000244140625,
+                "expert_load_observed": [
+                  0.047607421875,
+                  0.126708984375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.23828125
+                ],
+                "expert_load_reference": [
+                  0.047607421875,
+                  0.12646484375,
+                  0.060791015625,
+                  0.255615234375,
+                  0.02734375,
+                  0.071044921875,
+                  0.172607421875,
+                  0.238525390625
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 460,
+                    "top1_flip_rate": 0.002173913043478261,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 1055,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 513,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 20,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.4112808355956077,
+                "moe_input_normalized_cosine": 0.9999805357628218,
+                "moe_output_cosine": 0.9998240608794524,
+                "residual_drift_relative_norm": 0.004235465975258782,
+                "residual_stream_cosine": 0.999991030697749,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999859463222839,
+                  "residual_in_drift_relative_norm": 0.005302552236880725
+                },
+                "router_logit_cosine": 0.99999830045166,
+                "router_margin_mean_delta": 7.4559860570678075e-06,
+                "router_margin_mean_observed": 0.03582240155308043,
+                "router_margin_mean_reference": 0.035814945567023374,
+                "router_margin_median_observed": 0.025836218008428474,
+                "router_margin_median_reference": 0.025870355622028635,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.99951171875,
+                "router_topk_set_agreement": 0.99951171875,
+                "seconds": 39.70007848739624,
+                "selected_experts": 2
+              },
+              "pilot_label": "expert_int4_123",
+              "reference_seconds": 18.46852445602417
+            },
+            {
+              "block": 3,
+              "expert_only": {
+                "attention_output_cosine": 0.9933526611621083,
+                "attention_output_cosine_per_token": 0.9933280158751556,
+                "attn_delta_over_stream": 0.4985185792142929,
+                "block_output_cosine": 0.9915226862504408,
+                "block_output_cosine_per_token": 0.9913832419923976,
+                "block_output_drift_relative_norm": 0.1302129056031902,
+                "expert_load_js_bits": 0.00016866846773804433,
+                "expert_load_max_abs_delta": 0.0068359375,
+                "expert_load_observed": [
+                  0.054931640625,
+                  0.07080078125,
+                  0.038818359375,
+                  0.1591796875,
+                  0.381103515625,
+                  0.0224609375,
+                  0.19482421875,
+                  0.077880859375
+                ],
+                "expert_load_reference": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.15625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.194091796875,
+                  0.084716796875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 421,
+                    "top1_flip_rate": 0.24465558194774348,
+                    "top1_flips": 103
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 988,
+                    "top1_flip_rate": 0.04554655870445344,
+                    "top1_flips": 45
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 568,
+                    "top1_flip_rate": 0.008802816901408451,
+                    "top1_flips": 5
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 71,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "expert_int4_123",
+                "moe_delta_over_stream": 0.35593962253825956,
+                "moe_input_normalized_cosine": 0.9901588534262185,
+                "moe_output_cosine": 0.9774093487202452,
+                "residual_drift_relative_norm": 0.07912630612051204,
+                "residual_stream_cosine": 0.9968655131007353,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9956197704253421,
+                  "residual_in_drift_relative_norm": 0.0935215641530563
+                },
+                "router_logit_cosine": 0.9995724067351002,
+                "router_margin_mean_delta": -0.000340000059432497,
+                "router_margin_mean_observed": 0.0437278129058025,
+                "router_margin_mean_reference": 0.044067812965235,
+                "router_margin_median_observed": 0.02952331167047509,
+                "router_margin_median_reference": 0.0295396135928446,
+                "router_top1_agreement": 0.92529296875,
+                "router_top2_set_agreement": 0.861328125,
+                "router_topk_set_agreement": 0.861328125,
+                "seconds": 44.01105546951294,
+                "selected_experts": 2
+              },
+              "fp16_control": {
+                "attention_output_cosine": 0.999967551568842,
+                "attention_output_cosine_per_token": 0.9999677009593164,
+                "attn_delta_over_stream": 0.5008011118859926,
+                "block_output_cosine": 0.9999195401900538,
+                "block_output_cosine_per_token": 0.9999220112059125,
+                "block_output_drift_relative_norm": 0.012685837908964355,
+                "expert_load_js_bits": 6.330749621763374e-07,
+                "expert_load_max_abs_delta": 0.00048828125,
+                "expert_load_observed": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.156494140625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.1943359375,
+                  0.084228515625
+                ],
+                "expert_load_reference": [
+                  0.0517578125,
+                  0.070556640625,
+                  0.036865234375,
+                  0.15625,
+                  0.38330078125,
+                  0.0224609375,
+                  0.194091796875,
+                  0.084716796875
+                ],
+                "experts_touched": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7
+                ],
+                "experts_unused_observed": 0,
+                "experts_unused_reference": 0,
+                "flip_stratification_by_reference_margin": [
+                  {
+                    "margin_high": 0.01,
+                    "margin_low": 0.0,
+                    "tokens": 421,
+                    "top1_flip_rate": 0.0023752969121140144,
+                    "top1_flips": 1
+                  },
+                  {
+                    "margin_high": 0.05,
+                    "margin_low": 0.01,
+                    "tokens": 988,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.15,
+                    "margin_low": 0.05,
+                    "tokens": 568,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 0.5,
+                    "margin_low": 0.15,
+                    "tokens": 71,
+                    "top1_flip_rate": 0.0,
+                    "top1_flips": 0
+                  },
+                  {
+                    "margin_high": 1.01,
+                    "margin_low": 0.5,
+                    "tokens": 0,
+                    "top1_flip_rate": null,
+                    "top1_flips": 0
+                  }
+                ],
+                "label": "fp16_roundtrip",
+                "moe_delta_over_stream": 0.35685089524601604,
+                "moe_input_normalized_cosine": 0.9999317807120685,
+                "moe_output_cosine": 0.9996961823732479,
+                "residual_drift_relative_norm": 0.006536817583550683,
+                "residual_stream_cosine": 0.9999786349806121,
+                "residual_stream_in": {
+                  "residual_in_cosine": 0.9999682697724989,
+                  "residual_in_drift_relative_norm": 0.007966186310686194
+                },
+                "router_logit_cosine": 0.9999963366294831,
+                "router_margin_mean_delta": -2.446275262776493e-05,
+                "router_margin_mean_observed": 0.04404335021260723,
+                "router_margin_mean_reference": 0.044067812965235,
+                "router_margin_median_observed": 0.029497699031347163,
+                "router_margin_median_reference": 0.0295396135928446,
+                "router_top1_agreement": 0.99951171875,
+                "router_top2_set_agreement": 0.998046875,
+                "router_topk_set_agreement": 0.998046875,
+                "seconds": 41.16312384605408,
+                "selected_experts": 2
+              },
+              "pilot_label": "expert_int4_123",
+              "reference_seconds": 20.111958265304565
+            }
           ],
-          "ternary_blocks": [],
-          "channel_alpha_blocks": [],
-          "hp_schedule_prose": "INT4 middle-ground label `expert_int4_123`: research INT4 experts on {0}, HP (FP16 experts) on {1,2,3}.",
-          "arm_label": "expert_int4_123",
           "pilot_labels_per_block": [
             "research_int4_side",
             "expert_int4_123",
             "expert_int4_123",
             "expert_int4_123"
           ],
-          "int4_blocks": [
-            0
-          ]
+          "skip_fp16_control": false,
+          "ternary_blocks": [],
+          "token_id_first": 61,
+          "token_id_last": 130950,
+          "token_seed": 20260806,
+          "tokens": 2048,
+          "top_k": 2
+        },
+        "provenance": {
+          "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+          "agent": "Grok Build: Grok 4.5 (high) (xAI) \u00b7 Issue: #80 / Linear RM-468 \u00b7 beads goz-d603r4",
+          "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+          "arm": "int4",
+          "baseline_64": {
+            "expert_only": {
+              "block_output_cosine": 0.963572,
+              "expert_load_js_bits": 0.0,
+              "moe_output_cosine": 0.773483,
+              "residual_drift_relative_norm": 0.0,
+              "residual_stream_cosine": 1.0,
+              "router_top1_agreement": 1.0,
+              "router_top2_set_agreement": 1.0
+            },
+            "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+            "tokens": 2048
+          },
+          "baseline_72": {
+            "arm_label": "goz1_expert_ternary_only",
+            "block_output_cosine": [
+              0.963572,
+              0.945765,
+              0.884956,
+              0.839144
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.6538863846584987,
+            "decision": 3,
+            "pack_names": {
+              "0": "block_000-attention_plus_expert.goz1",
+              "1": "block_001-attention_plus_expert.goz1",
+              "2": "block_002-attention_plus_expert.goz1",
+              "3": "block_003-attention_plus_expert.goz1"
+            },
+            "pack_sha256": {
+              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+            },
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.341935,
+              0.498308
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.666504,
+              0.52832
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.548828,
+              0.289551
+            ],
+            "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "baseline_74": {
+            "arm_label": "expert_periodic_hp_n2",
+            "block_output_cosine": [
+              0.963572,
+              0.963211,
+              0.90536,
+              0.882308
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.5292121735722244,
+            "decision": 2,
+            "expert_load_js_bits": [
+              0.0,
+              0.005559,
+              0.008548,
+              0.025243
+            ],
+            "pack_names": {
+              "0": "block_000-attention_plus_expert.goz1",
+              "1": "block_001-attention_plus_expert.goz1",
+              "2": "block_002-attention_plus_expert.goz1",
+              "3": "block_003-attention_plus_expert.goz1"
+            },
+            "pack_sha256": {
+              "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+              "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+              "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+              "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+            },
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.279321,
+              0.449088
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.729004,
+              0.547852
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.592773,
+              0.317383
+            ],
+            "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "baseline_76_ceiling": {
+            "arm_label": "expert_hp_ceiling",
+            "block_output_cosine": [
+              1.0,
+              0.999997,
+              0.999998,
+              0.999984
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.005690267932494616,
+            "router_top1": [
+              1.0,
+              1.0,
+              1.0,
+              1.0
+            ],
+            "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2,
+            "viable": true
+          },
+          "baseline_76_denser": {
+            "arm_label": "expert_periodic_hp_123",
+            "block_output_cosine": [
+              0.963572,
+              0.963211,
+              0.939684,
+              0.913853
+            ],
+            "blocks": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "chain_exit_residual_drift": 0.4370545723375058,
+            "decision": 2,
+            "residual_in_drift": [
+              0.0,
+              0.277351,
+              0.279321,
+              0.348475
+            ],
+            "router_top1": [
+              1.0,
+              0.887695,
+              0.729004,
+              0.615723
+            ],
+            "router_top2": [
+              1.0,
+              0.680664,
+              0.592773,
+              0.408691
+            ],
+            "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
+            "token_seed": 20260806,
+            "tokens": 2048,
+            "top_k": 2
+          },
+          "design": "Grok Build design lock: INT4 research side-table middle-ground (P0 all-blocks + P1 denser HP); cite #76 denser/ceiling",
+          "embedding_shard": "embedding__slot_00__token_embedding.npy",
+          "evidence_role": "secondary; no independent decision",
+          "implementation": {
+            "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
+            "dirty": true
+          },
+          "issue": "GH #80 / Linear RM-468 / beads goz-d603r4",
+          "metrics_filename": "metrics.json",
+          "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+          "model": "Grok-4.5 (high)",
+          "numpy": "2.5.1",
+          "python": "3.14.6",
+          "scale_policy": "research_int4_side per-output-channel absmax on INT4 path; GOZ1 v3 pack-only on ternary cite path; abort on legacy_oracle",
+          "skip_fp16_control": false,
+          "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
         }
       }
     },
     "summaries": {
+      "cited_ceiling_76": {
+        "arm_label": "expert_hp_ceiling",
+        "block_output_cosine": [
+          1.0,
+          0.999997,
+          0.999998,
+          0.999984
+        ],
+        "chain_exit_residual_drift": 0.005690267932494616,
+        "cited": true,
+        "compounding": "cited",
+        "router_top1": [
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "viable": true
+      },
+      "cited_denser_76": {
+        "arm_label": "expert_periodic_hp_123",
+        "block_output_cosine": [
+          0.963572,
+          0.963211,
+          0.939684,
+          0.913853
+        ],
+        "chain_exit_residual_drift": 0.4370545723375058,
+        "cited": true,
+        "compounding": "cited",
+        "residual_in_drift": [
+          0.0,
+          0.277351,
+          0.279321,
+          0.348475
+        ],
+        "router_top1": [
+          1.0,
+          0.887695,
+          0.729004,
+          0.615723
+        ],
+        "router_top2": [
+          1.0,
+          0.680664,
+          0.592773,
+          0.408691
+        ],
+        "viable": false
+      },
       "expert_int4": {
         "arm_label": "expert_int4",
         "block_output_cosine": [
@@ -2780,6 +2803,14 @@
           0.9971471520590423,
           0.9890487155967639,
           0.978044237973187
+        ],
+        "chain_exit_residual_drift": 0.21106381790108242,
+        "compounding": "superlinear_or_runaway",
+        "expert_load_js_bits": [
+          0.0,
+          2.958814470063395e-05,
+          0.0004889610222175079,
+          0.0005153232062816999
         ],
         "residual_in_drift": [
           0.0,
@@ -2799,65 +2830,7 @@
           0.8857421875,
           0.7294921875
         ],
-        "expert_load_js_bits": [
-          0.0,
-          2.958814470063395e-05,
-          0.0004889610222175079,
-          0.0005153232062816999
-        ],
-        "chain_exit_residual_drift": 0.21106381790108242,
-        "compounding": "superlinear_or_runaway",
         "viable": false
-      },
-      "cited_denser_76": {
-        "arm_label": "expert_periodic_hp_123",
-        "block_output_cosine": [
-          0.963572,
-          0.963211,
-          0.939684,
-          0.913853
-        ],
-        "residual_in_drift": [
-          0.0,
-          0.277351,
-          0.279321,
-          0.348475
-        ],
-        "router_top1": [
-          1.0,
-          0.887695,
-          0.729004,
-          0.615723
-        ],
-        "router_top2": [
-          1.0,
-          0.680664,
-          0.592773,
-          0.408691
-        ],
-        "chain_exit_residual_drift": 0.4370545723375058,
-        "compounding": "cited",
-        "viable": false,
-        "cited": true
-      },
-      "cited_ceiling_76": {
-        "arm_label": "expert_hp_ceiling",
-        "block_output_cosine": [
-          1.0,
-          0.999997,
-          0.999998,
-          0.999984
-        ],
-        "router_top1": [
-          1.0,
-          1.0,
-          1.0,
-          1.0
-        ],
-        "chain_exit_residual_drift": 0.005690267932494616,
-        "compounding": "cited",
-        "viable": true,
-        "cited": true
       },
       "expert_int4_123": {
         "arm_label": "expert_int4_123",
@@ -2866,6 +2839,14 @@
           0.9984733954000422,
           0.9956197704253421,
           0.9915226862504408
+        ],
+        "chain_exit_residual_drift": 0.1302129056031902,
+        "compounding": "roughly_linear",
+        "expert_load_js_bits": [
+          0.0,
+          2.958814470063395e-05,
+          0.0002489326034859664,
+          0.00016866846773804433
         ],
         "residual_in_drift": [
           0.0,
@@ -2885,202 +2866,14 @@
           0.919921875,
           0.861328125
         ],
-        "expert_load_js_bits": [
-          0.0,
-          2.958814470063395e-05,
-          0.0002489326034859664,
-          0.00016866846773804433
-        ],
-        "chain_exit_residual_drift": 0.1302129056031902,
-        "compounding": "roughly_linear",
         "viable": false
       }
     },
-    "validation_errors": [],
-    "baselines_cited": {
-      "denser": {
-        "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
-        "tokens": 2048,
-        "token_seed": 20260806,
-        "blocks": [
-          0,
-          1,
-          2,
-          3
-        ],
-        "top_k": 2,
-        "decision": 2,
-        "block_output_cosine": [
-          0.963572,
-          0.963211,
-          0.939684,
-          0.913853
-        ],
-        "residual_in_drift": [
-          0.0,
-          0.277351,
-          0.279321,
-          0.348475
-        ],
-        "router_top1": [
-          1.0,
-          0.887695,
-          0.729004,
-          0.615723
-        ],
-        "router_top2": [
-          1.0,
-          0.680664,
-          0.592773,
-          0.408691
-        ],
-        "chain_exit_residual_drift": 0.4370545723375058,
-        "arm_label": "expert_periodic_hp_123"
-      },
-      "ceiling": {
-        "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
-        "tokens": 2048,
-        "token_seed": 20260806,
-        "blocks": [
-          0,
-          1,
-          2,
-          3
-        ],
-        "top_k": 2,
-        "block_output_cosine": [
-          1.0,
-          0.999997,
-          0.999998,
-          0.999984
-        ],
-        "router_top1": [
-          1.0,
-          1.0,
-          1.0,
-          1.0
-        ],
-        "chain_exit_residual_drift": 0.005690267932494616,
-        "arm_label": "expert_hp_ceiling",
-        "viable": true
-      },
-      "baseline_74": {
-        "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-        "tokens": 2048,
-        "token_seed": 20260806,
-        "blocks": [
-          0,
-          1,
-          2,
-          3
-        ],
-        "top_k": 2,
-        "decision": 2,
-        "block_output_cosine": [
-          0.963572,
-          0.963211,
-          0.90536,
-          0.882308
-        ],
-        "residual_in_drift": [
-          0.0,
-          0.277351,
-          0.279321,
-          0.449088
-        ],
-        "router_top1": [
-          1.0,
-          0.887695,
-          0.729004,
-          0.547852
-        ],
-        "router_top2": [
-          1.0,
-          0.680664,
-          0.592773,
-          0.317383
-        ],
-        "expert_load_js_bits": [
-          0.0,
-          0.005559,
-          0.008548,
-          0.025243
-        ],
-        "chain_exit_residual_drift": 0.5292121735722244,
-        "arm_label": "expert_periodic_hp_n2",
-        "pack_sha256": {
-          "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-          "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-          "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-          "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-        },
-        "pack_names": {
-          "0": "block_000-attention_plus_expert.goz1",
-          "1": "block_001-attention_plus_expert.goz1",
-          "2": "block_002-attention_plus_expert.goz1",
-          "3": "block_003-attention_plus_expert.goz1"
-        }
-      },
-      "baseline_72": {
-        "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-        "tokens": 2048,
-        "token_seed": 20260806,
-        "blocks": [
-          0,
-          1,
-          2,
-          3
-        ],
-        "top_k": 2,
-        "decision": 3,
-        "block_output_cosine": [
-          0.963572,
-          0.945765,
-          0.884956,
-          0.839144
-        ],
-        "residual_in_drift": [
-          0.0,
-          0.277351,
-          0.341935,
-          0.498308
-        ],
-        "router_top1": [
-          1.0,
-          0.887695,
-          0.666504,
-          0.52832
-        ],
-        "router_top2": [
-          1.0,
-          0.680664,
-          0.548828,
-          0.289551
-        ],
-        "chain_exit_residual_drift": 0.6538863846584987,
-        "arm_label": "goz1_expert_ternary_only",
-        "pack_sha256": {
-          "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-          "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-          "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-          "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-        },
-        "pack_names": {
-          "0": "block_000-attention_plus_expert.goz1",
-          "1": "block_001-attention_plus_expert.goz1",
-          "2": "block_002-attention_plus_expert.goz1",
-          "3": "block_003-attention_plus_expert.goz1"
-        }
-      }
-    },
-    "primary_provenance": {
-      "implementation": {
-        "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
-        "dirty": true
-      }
-    }
+    "validation_errors": []
   },
   "decision": {
+    "best_remedy_arm": "expert_int4_123",
+    "compounding": "roughly_linear",
     "decision": 2,
     "decision_text": "INT4 middle-ground helps vs denser ternary, but full-HP experts or another correction remain required.",
     "rationale": [
@@ -3094,8 +2887,215 @@
       "#76_ceiling_viable=True (cited)",
       "any_middle_ground_improved_vs_denser=True",
       "codec=research_int4_side per-output-channel absmax qmax=7"
-    ],
-    "compounding": "roughly_linear",
-    "best_remedy_arm": "expert_int4_123"
+    ]
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Grok Build: Grok 4.5 (high) (xAI) \u00b7 Issue: #80 / Linear RM-468 \u00b7 beads goz-d603r4",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "int4",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_76_ceiling": {
+      "arm_label": "expert_hp_ceiling",
+      "block_output_cosine": [
+        1.0,
+        0.999997,
+        0.999998,
+        0.999984
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.005690267932494616,
+      "router_top1": [
+        1.0,
+        1.0,
+        1.0,
+        1.0
+      ],
+      "source": "reports/grok-1-expert-precision-remedy-v2/hp-ceiling/ (PR #76)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2,
+      "viable": true
+    },
+    "baseline_76_denser": {
+      "arm_label": "expert_periodic_hp_123",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.939684,
+        0.913853
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.4370545723375058,
+      "decision": 2,
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.348475
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.615723
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.408691
+      ],
+      "source": "reports/grok-1-expert-precision-remedy-v2/ (PR #76 / #75 / RM-462)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "design": "Grok Build design lock: INT4 research side-table middle-ground (P0 all-blocks + P1 denser HP); cite #76 denser/ceiling",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "primary; sole canonical #80 decision",
+    "implementation": {
+      "commit": "7cf99b2901b5929e3d1d35130e4f009c1f51acc4",
+      "dirty": true
+    },
+    "issue": "GH #80 / Linear RM-468 / beads goz-d603r4",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (matching seed/tokens/blocks/top_k; pack SHA when recorded).",
+    "model": "Grok-4.5 (high)",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "research_int4_side per-output-channel absmax on INT4 path; GOZ1 v3 pack-only on ternary cite path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v4/host-at-launch.txt
+++ b/reports/grok-1-expert-precision-remedy-v4/host-at-launch.txt
@@ -1,0 +1,8 @@
+== #85 run launch ==
+2026-08-15T06:25:24-05:00
+031bb44
+?? reports/grok-1-expert-precision-remedy-v4/
+               total        used        free      shared  buff/cache   available
+Mem:            60Gi        45Gi       1.0Gi        11Gi        24Gi        15Gi
+Swap:          8.0Gi       8.0Gi          0B
+/dev/nvme1n1p3  1.9T  1.7T   91G  96% /home

--- a/reports/grok-1-expert-precision-remedy-v4/int4-baseline/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v4/int4-baseline/metrics.json
@@ -1,1050 +1,42 @@
 {
-  "provenance": {
-    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
-    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
-    "model": "OpenAI Codex",
-    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_76_denser": null,
-    "baseline_76_ceiling": null,
-    "baseline_85": {
-      "source": "GH #85 / RM-608 \u2014 protocol lock (Grok-1 max context sequence)",
-      "tokens": 8192,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "tokens_note": "8192 = Grok-1 published max context (causal sequence). Vocab size 131072 is the sampler ceiling only \u2014 not a valid T for dense attention in this harness."
-    },
-    "implementation": {
-      "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle",
-    "arm": "int4",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#85 protocol (Grok-1 max context tokens=8192). #72/#80 2048-token figures are historical cites only; not same-budget and not a validation failure.",
-    "evidence_role": "secondary; no independent decision"
-  },
   "chain": {
+    "arm_label": "expert_int4",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 8192,
-    "token_seed": 20260806,
-    "token_id_first": 37,
-    "token_id_last": 131061,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 266.6767609119415,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 355.4767093658447,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0000000000000002,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.9942099657787136,
-          "block_output_cosine": 0.998636599415437,
-          "block_output_cosine_per_token": 0.9986353002909485,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.052476083867624736,
-          "attn_delta_over_stream": 0.9033581150208522,
-          "moe_delta_over_stream": 0.49148734495865865,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.15130615234375,
-            0.111328125,
-            0.15545654296875,
-            0.13671875,
-            0.10418701171875,
-            0.1141357421875,
-            0.11602783203125,
-            0.11083984375
-          ],
-          "expert_load_observed": [
-            0.15130615234375,
-            0.111328125,
-            0.15545654296875,
-            0.13671875,
-            0.10418701171875,
-            0.1141357421875,
-            0.11602783203125,
-            0.11083984375
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.0346857385962856,
-          "router_margin_mean_observed": 0.0346857385962856,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.008471452573598867,
-          "router_margin_median_observed": 0.008471452573598867,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 4299,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1846,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1700,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 1,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 320.2840836048126,
-          "attention_output_cosine": 0.9999999985728412,
-          "attention_output_cosine_per_token": 0.9999999986361572,
-          "residual_stream_cosine": 0.9999999819762834,
-          "moe_input_normalized_cosine": 0.999999958445224,
-          "router_logit_cosine": 0.9999999972602787,
-          "moe_output_cosine": 0.9998959798468963,
-          "block_output_cosine": 0.9999662344185568,
-          "block_output_cosine_per_token": 0.9999632230144466,
-          "residual_drift_relative_norm": 0.00022418911406672668,
-          "block_output_drift_relative_norm": 0.008217809632556623,
-          "attn_delta_over_stream": 0.9031929817106404,
-          "moe_delta_over_stream": 0.4934264147307654,
-          "router_top1_agreement": 0.9991455078125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99658203125,
-          "router_top2_set_agreement": 0.99658203125,
-          "expert_load_reference": [
-            0.15130615234375,
-            0.111328125,
-            0.15545654296875,
-            0.13671875,
-            0.10418701171875,
-            0.1141357421875,
-            0.11602783203125,
-            0.11083984375
-          ],
-          "expert_load_observed": [
-            0.1513671875,
-            0.11181640625,
-            0.15570068359375,
-            0.13677978515625,
-            0.10382080078125,
-            0.11431884765625,
-            0.11578369140625,
-            0.11041259765625
-          ],
-          "expert_load_js_bits": 1.1395797616989257e-06,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.0346857385962856,
-          "router_margin_mean_observed": 0.034688792519098996,
-          "router_margin_mean_delta": 3.053922813402341e-06,
-          "router_margin_median_reference": 0.008471452573598867,
-          "router_margin_median_observed": 0.008459846907189983,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 4299,
-              "top1_flips": 7,
-              "top1_flip_rate": 0.0016282856478250756
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1846,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1700,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 1,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 193.54124808311462,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 325.74283051490784,
-          "attention_output_cosine": 0.9994921977874481,
-          "attention_output_cosine_per_token": 0.9994901484606165,
-          "residual_stream_cosine": 0.9990365860991692,
-          "moe_input_normalized_cosine": 0.9984100924448689,
-          "router_logit_cosine": 0.9998245027993015,
-          "moe_output_cosine": 0.9880094626292876,
-          "block_output_cosine": 0.9975672646063307,
-          "block_output_cosine_per_token": 0.9975523585688557,
-          "residual_drift_relative_norm": 0.044067242430541415,
-          "block_output_drift_relative_norm": 0.0698795479982047,
-          "attn_delta_over_stream": 0.42559126102455946,
-          "moe_delta_over_stream": 0.27485205570786986,
-          "router_top1_agreement": 0.9822998046875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9385986328125,
-          "router_top2_set_agreement": 0.9385986328125,
-          "expert_load_reference": [
-            0.1622314453125,
-            0.1270751953125,
-            0.10992431640625,
-            0.10797119140625,
-            0.1124267578125,
-            0.145263671875,
-            0.11138916015625,
-            0.12371826171875
-          ],
-          "expert_load_observed": [
-            0.16143798828125,
-            0.12744140625,
-            0.1083984375,
-            0.10687255859375,
-            0.11212158203125,
-            0.14471435546875,
-            0.112548828125,
-            0.12646484375
-          ],
-          "expert_load_js_bits": 2.033074208447681e-05,
-          "expert_load_max_abs_delta": 0.00274658203125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1768117849176516,
-          "router_margin_mean_observed": 0.17680783921605497,
-          "router_margin_mean_delta": -3.945701596603477e-06,
-          "router_margin_median_reference": 0.14185318157435073,
-          "router_margin_median_observed": 0.14095126307344535,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 122,
-              "top1_flip_rate": 0.28978622327790976
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1368,
-              "top1_flips": 23,
-              "top1_flip_rate": 0.016812865497076022
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 2479,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 3608,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 316,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.998636599415437,
-            "residual_in_drift_relative_norm": 0.052476083867624736
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 311.47637486457825,
-          "attention_output_cosine": 0.9999844464986306,
-          "attention_output_cosine_per_token": 0.9999843032690912,
-          "residual_stream_cosine": 0.9999756963861242,
-          "moe_input_normalized_cosine": 0.9999509294401662,
-          "router_logit_cosine": 0.9999932806125511,
-          "moe_output_cosine": 0.9999010859004773,
-          "block_output_cosine": 0.999965929851699,
-          "block_output_cosine_per_token": 0.9999644733042241,
-          "residual_drift_relative_norm": 0.006972312249031641,
-          "block_output_drift_relative_norm": 0.008254778779977658,
-          "attn_delta_over_stream": 0.4284735778277611,
-          "moe_delta_over_stream": 0.27375707876517935,
-          "router_top1_agreement": 0.9996337890625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9981689453125,
-          "router_top2_set_agreement": 0.9981689453125,
-          "expert_load_reference": [
-            0.1622314453125,
-            0.1270751953125,
-            0.10992431640625,
-            0.10797119140625,
-            0.1124267578125,
-            0.145263671875,
-            0.11138916015625,
-            0.12371826171875
-          ],
-          "expert_load_observed": [
-            0.1624755859375,
-            0.1270751953125,
-            0.10992431640625,
-            0.10791015625,
-            0.11224365234375,
-            0.1453857421875,
-            0.111328125,
-            0.1236572265625
-          ],
-          "expert_load_js_bits": 1.5620965325225452e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1768117849176516,
-          "router_margin_mean_observed": 0.1769348817503377,
-          "router_margin_mean_delta": 0.00012309683268611266,
-          "router_margin_median_reference": 0.14185318157435073,
-          "router_margin_median_observed": 0.14202488915802522,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 3,
-              "top1_flip_rate": 0.007125890736342043
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1368,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 2479,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 3608,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 316,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999662344185568,
-            "residual_in_drift_relative_norm": 0.008217809632556623
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 242.07538318634033,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 345.4744019508362,
-          "attention_output_cosine": 0.9965665106057541,
-          "attention_output_cosine_per_token": 0.9966740867903803,
-          "residual_stream_cosine": 0.9980410644324349,
-          "moe_input_normalized_cosine": 0.9955594058712655,
-          "router_logit_cosine": 0.9996287541956903,
-          "moe_output_cosine": 0.9612818348279588,
-          "block_output_cosine": 0.9886573865540497,
-          "block_output_cosine_per_token": 0.9886610677209071,
-          "residual_drift_relative_norm": 0.06273540273174869,
-          "block_output_drift_relative_norm": 0.1504987802639529,
-          "attn_delta_over_stream": 0.6084507931815782,
-          "moe_delta_over_stream": 0.4341807436222842,
-          "router_top1_agreement": 0.92626953125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.8861083984375,
-          "router_top2_set_agreement": 0.8861083984375,
-          "expert_load_reference": [
-            0.04443359375,
-            0.1650390625,
-            0.09173583984375,
-            0.29046630859375,
-            0.069580078125,
-            0.0606689453125,
-            0.148193359375,
-            0.1298828125
-          ],
-          "expert_load_observed": [
-            0.04437255859375,
-            0.17437744140625,
-            0.0950927734375,
-            0.281005859375,
-            0.06939697265625,
-            0.060791015625,
-            0.14910888671875,
-            0.1258544921875
-          ],
-          "expert_load_js_bits": 0.00019497360882110354,
-          "expert_load_max_abs_delta": 0.00946044921875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.03315020039085974,
-          "router_margin_mean_observed": 0.033071704304925925,
-          "router_margin_mean_delta": -7.849608593381847e-05,
-          "router_margin_median_reference": 0.024014774987458368,
-          "router_margin_median_observed": 0.023938491704430215,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2019,
-              "top1_flips": 544,
-              "top1_flip_rate": 0.2694403169886082
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4362,
-              "top1_flips": 60,
-              "top1_flip_rate": 0.013755158184319119
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1752,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 59,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9975672646063307,
-            "residual_in_drift_relative_norm": 0.0698795479982047
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 316.63707876205444,
-          "attention_output_cosine": 0.9999716287912973,
-          "attention_output_cosine_per_token": 0.9999694231843663,
-          "residual_stream_cosine": 0.9999749873089938,
-          "moe_input_normalized_cosine": 0.9999439196166795,
-          "router_logit_cosine": 0.9999958994382009,
-          "moe_output_cosine": 0.9991185860861073,
-          "block_output_cosine": 0.9997649252084471,
-          "block_output_cosine_per_token": 0.9997605920963788,
-          "residual_drift_relative_norm": 0.0070732812585666514,
-          "block_output_drift_relative_norm": 0.021683098492711318,
-          "attn_delta_over_stream": 0.6092783179867541,
-          "moe_delta_over_stream": 0.4316547372269685,
-          "router_top1_agreement": 0.996826171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.995361328125,
-          "router_top2_set_agreement": 0.995361328125,
-          "expert_load_reference": [
-            0.04443359375,
-            0.1650390625,
-            0.09173583984375,
-            0.29046630859375,
-            0.069580078125,
-            0.0606689453125,
-            0.148193359375,
-            0.1298828125
-          ],
-          "expert_load_observed": [
-            0.0445556640625,
-            0.1650390625,
-            0.09173583984375,
-            0.29046630859375,
-            0.06988525390625,
-            0.0606689453125,
-            0.14794921875,
-            0.12969970703125
-          ],
-          "expert_load_js_bits": 4.204230303538151e-07,
-          "expert_load_max_abs_delta": 0.00030517578125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.03315020039085974,
-          "router_margin_mean_observed": 0.03316706533730572,
-          "router_margin_mean_delta": 1.6864946445976705e-05,
-          "router_margin_median_reference": 0.024014774987458368,
-          "router_margin_median_observed": 0.02397975142504559,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2019,
-              "top1_flips": 26,
-              "top1_flip_rate": 0.012877662209014363
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4362,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1752,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 59,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.999965929851699,
-            "residual_in_drift_relative_norm": 0.008254778779977658
-          }
-        },
-        "pilot_label": "research_int4_side"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 229.87560534477234,
-        "expert_only": {
-          "label": "research_int4_side",
-          "seconds": 309.3350121974945,
-          "attention_output_cosine": 0.9849794005308738,
-          "attention_output_cosine_per_token": 0.9848368129062782,
-          "residual_stream_cosine": 0.9924074300943141,
-          "moe_input_normalized_cosine": 0.9766669769275363,
-          "router_logit_cosine": 0.998744311294021,
-          "moe_output_cosine": 0.9399137334498511,
-          "block_output_cosine": 0.9805662657439359,
-          "block_output_cosine_per_token": 0.9803507306361513,
-          "residual_drift_relative_norm": 0.12344734332232438,
-          "block_output_drift_relative_norm": 0.19772214640333557,
-          "attn_delta_over_stream": 0.5687244774086985,
-          "moe_delta_over_stream": 0.33949200216019837,
-          "router_top1_agreement": 0.82373046875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.7210693359375,
-          "router_top2_set_agreement": 0.7210693359375,
-          "expert_load_reference": [
-            0.04150390625,
-            0.05712890625,
-            0.0887451171875,
-            0.21875,
-            0.339111328125,
-            0.04656982421875,
-            0.11859130859375,
-            0.089599609375
-          ],
-          "expert_load_observed": [
-            0.044189453125,
-            0.0555419921875,
-            0.09136962890625,
-            0.225341796875,
-            0.32684326171875,
-            0.04168701171875,
-            0.124267578125,
-            0.09075927734375
-          ],
-          "expert_load_js_bits": 0.0003170502785525748,
-          "expert_load_max_abs_delta": 0.01226806640625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.034320415627369816,
-          "router_margin_mean_observed": 0.03351272956418477,
-          "router_margin_mean_delta": -0.0008076860631850392,
-          "router_margin_median_reference": 0.0220433932007284,
-          "router_margin_median_observed": 0.021772259286882895,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2219,
-              "top1_flips": 929,
-              "top1_flip_rate": 0.41865705272645337
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4206,
-              "top1_flips": 488,
-              "top1_flip_rate": 0.11602472658107466
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1595,
-              "top1_flips": 27,
-              "top1_flip_rate": 0.016927899686520375
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 170,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 2,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9886573865540497,
-            "residual_in_drift_relative_norm": 0.1504987802639529
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 336.2478401660919,
-          "attention_output_cosine": 0.9996371522691706,
-          "attention_output_cosine_per_token": 0.9996587349820896,
-          "residual_stream_cosine": 0.9998417382509542,
-          "moe_input_normalized_cosine": 0.9994953806921836,
-          "router_logit_cosine": 0.9999683118236804,
-          "moe_output_cosine": 0.9980916705559675,
-          "block_output_cosine": 0.9994370955486388,
-          "block_output_cosine_per_token": 0.9994322357588377,
-          "residual_drift_relative_norm": 0.017792575310936677,
-          "block_output_drift_relative_norm": 0.03355323588949929,
-          "attn_delta_over_stream": 0.5618916032039319,
-          "moe_delta_over_stream": 0.33880058537802515,
-          "router_top1_agreement": 0.9912109375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.987548828125,
-          "router_top2_set_agreement": 0.987548828125,
-          "expert_load_reference": [
-            0.04150390625,
-            0.05712890625,
-            0.0887451171875,
-            0.21875,
-            0.339111328125,
-            0.04656982421875,
-            0.11859130859375,
-            0.089599609375
-          ],
-          "expert_load_observed": [
-            0.04168701171875,
-            0.05718994140625,
-            0.08819580078125,
-            0.218994140625,
-            0.3394775390625,
-            0.0467529296875,
-            0.1180419921875,
-            0.08966064453125
-          ],
-          "expert_load_js_bits": 1.4895787361700699e-06,
-          "expert_load_max_abs_delta": 0.00054931640625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.034320415627369816,
-          "router_margin_mean_observed": 0.03435143862921844,
-          "router_margin_mean_delta": 3.102300184862202e-05,
-          "router_margin_median_reference": 0.0220433932007284,
-          "router_margin_median_observed": 0.021954006940788154,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2219,
-              "top1_flips": 60,
-              "top1_flip_rate": 0.027039206849932402
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4206,
-              "top1_flips": 12,
-              "top1_flip_rate": 0.0028530670470756064
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1595,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 170,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 2,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9997649252084471,
-            "residual_in_drift_relative_norm": 0.021683098492711318
-          }
-        },
-        "pilot_label": "research_int4_side"
-      }
-    ],
+    "channel_alpha_blocks": [],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.9805662657439359,
-        "residual_drift_relative_norm": 0.19772214640333557,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.19772214640333557
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9994370955486388,
-        "residual_drift_relative_norm": 0.03355323588949929,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.03355323588949929
       }
     },
+    "expert_mode": "int4",
+    "hp_blocks": [],
+    "hp_period": null,
+    "hp_schedule_kind": "none",
+    "hp_schedule_prose": "INT4 experts (research_int4_side) on all chain blocks.",
+    "int4_blocks": [
+      0,
+      1,
+      2,
+      3
+    ],
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
-        "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "research_int4_side",
-          "block_000.slot_00.moe_expert.gate": "research_int4_side",
-          "block_000.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1075,53 +67,53 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "research_int4_side",
+          "block_000.slot_01.moe_expert.down": "research_int4_side",
+          "block_000.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
-        "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "research_int4_side",
-          "block_001.slot_00.moe_expert.gate": "research_int4_side",
-          "block_001.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1152,53 +144,53 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "research_int4_side",
+          "block_001.slot_01.moe_expert.down": "research_int4_side",
+          "block_001.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
-        "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "research_int4_side",
-          "block_002.slot_00.moe_expert.gate": "research_int4_side",
-          "block_002.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1229,53 +221,53 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "research_int4_side",
+          "block_002.slot_01.moe_expert.down": "research_int4_side",
+          "block_002.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
-        "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "research_int4_side",
-          "block_003.slot_00.moe_expert.gate": "research_int4_side",
-          "block_003.slot_02.moe_expert.up": "research_int4_side"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1306,34 +298,1042 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "research_int4_side",
+          "block_003.slot_01.moe_expert.down": "research_int4_side",
+          "block_003.slot_02.moe_expert.up": "research_int4_side"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "int4",
-    "hp_period": null,
-    "hp_schedule_kind": "none",
-    "hp_blocks": [],
-    "ternary_blocks": [],
-    "int4_blocks": [
-      0,
-      1,
-      2,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.9033581150208522,
+          "block_output_cosine": 0.998636599415437,
+          "block_output_cosine_per_token": 0.9986353002909485,
+          "block_output_drift_relative_norm": 0.052476083867624736,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.15130615234375,
+            0.111328125,
+            0.15545654296875,
+            0.13671875,
+            0.10418701171875,
+            0.1141357421875,
+            0.11602783203125,
+            0.11083984375
+          ],
+          "expert_load_reference": [
+            0.15130615234375,
+            0.111328125,
+            0.15545654296875,
+            0.13671875,
+            0.10418701171875,
+            0.1141357421875,
+            0.11602783203125,
+            0.11083984375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 4299,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1846,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1700,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 1,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.49148734495865865,
+          "moe_input_normalized_cosine": 1.0000000000000002,
+          "moe_output_cosine": 0.9942099657787136,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.0346857385962856,
+          "router_margin_mean_reference": 0.0346857385962856,
+          "router_margin_median_observed": 0.008471452573598867,
+          "router_margin_median_reference": 0.008471452573598867,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 355.4767093658447,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999985728412,
+          "attention_output_cosine_per_token": 0.9999999986361572,
+          "attn_delta_over_stream": 0.9031929817106404,
+          "block_output_cosine": 0.9999662344185568,
+          "block_output_cosine_per_token": 0.9999632230144466,
+          "block_output_drift_relative_norm": 0.008217809632556623,
+          "expert_load_js_bits": 1.1395797616989257e-06,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.1513671875,
+            0.11181640625,
+            0.15570068359375,
+            0.13677978515625,
+            0.10382080078125,
+            0.11431884765625,
+            0.11578369140625,
+            0.11041259765625
+          ],
+          "expert_load_reference": [
+            0.15130615234375,
+            0.111328125,
+            0.15545654296875,
+            0.13671875,
+            0.10418701171875,
+            0.1141357421875,
+            0.11602783203125,
+            0.11083984375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 4299,
+              "top1_flip_rate": 0.0016282856478250756,
+              "top1_flips": 7
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1846,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1700,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 1,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4934264147307654,
+          "moe_input_normalized_cosine": 0.999999958445224,
+          "moe_output_cosine": 0.9998959798468963,
+          "residual_drift_relative_norm": 0.00022418911406672668,
+          "residual_stream_cosine": 0.9999999819762834,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999972602787,
+          "router_margin_mean_delta": 3.053922813402341e-06,
+          "router_margin_mean_observed": 0.034688792519098996,
+          "router_margin_mean_reference": 0.0346857385962856,
+          "router_margin_median_observed": 0.008459846907189983,
+          "router_margin_median_reference": 0.008471452573598867,
+          "router_top1_agreement": 0.9991455078125,
+          "router_top2_set_agreement": 0.99658203125,
+          "router_topk_set_agreement": 0.99658203125,
+          "seconds": 320.2840836048126,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 266.6767609119415
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9994921977874481,
+          "attention_output_cosine_per_token": 0.9994901484606165,
+          "attn_delta_over_stream": 0.42559126102455946,
+          "block_output_cosine": 0.9975672646063307,
+          "block_output_cosine_per_token": 0.9975523585688557,
+          "block_output_drift_relative_norm": 0.0698795479982047,
+          "expert_load_js_bits": 2.033074208447681e-05,
+          "expert_load_max_abs_delta": 0.00274658203125,
+          "expert_load_observed": [
+            0.16143798828125,
+            0.12744140625,
+            0.1083984375,
+            0.10687255859375,
+            0.11212158203125,
+            0.14471435546875,
+            0.112548828125,
+            0.12646484375
+          ],
+          "expert_load_reference": [
+            0.1622314453125,
+            0.1270751953125,
+            0.10992431640625,
+            0.10797119140625,
+            0.1124267578125,
+            0.145263671875,
+            0.11138916015625,
+            0.12371826171875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.28978622327790976,
+              "top1_flips": 122
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1368,
+              "top1_flip_rate": 0.016812865497076022,
+              "top1_flips": 23
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 2479,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 3608,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 316,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.27485205570786986,
+          "moe_input_normalized_cosine": 0.9984100924448689,
+          "moe_output_cosine": 0.9880094626292876,
+          "residual_drift_relative_norm": 0.044067242430541415,
+          "residual_stream_cosine": 0.9990365860991692,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.998636599415437,
+            "residual_in_drift_relative_norm": 0.052476083867624736
+          },
+          "router_logit_cosine": 0.9998245027993015,
+          "router_margin_mean_delta": -3.945701596603477e-06,
+          "router_margin_mean_observed": 0.17680783921605497,
+          "router_margin_mean_reference": 0.1768117849176516,
+          "router_margin_median_observed": 0.14095126307344535,
+          "router_margin_median_reference": 0.14185318157435073,
+          "router_top1_agreement": 0.9822998046875,
+          "router_top2_set_agreement": 0.9385986328125,
+          "router_topk_set_agreement": 0.9385986328125,
+          "seconds": 325.74283051490784,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999844464986306,
+          "attention_output_cosine_per_token": 0.9999843032690912,
+          "attn_delta_over_stream": 0.4284735778277611,
+          "block_output_cosine": 0.999965929851699,
+          "block_output_cosine_per_token": 0.9999644733042241,
+          "block_output_drift_relative_norm": 0.008254778779977658,
+          "expert_load_js_bits": 1.5620965325225452e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.1624755859375,
+            0.1270751953125,
+            0.10992431640625,
+            0.10791015625,
+            0.11224365234375,
+            0.1453857421875,
+            0.111328125,
+            0.1236572265625
+          ],
+          "expert_load_reference": [
+            0.1622314453125,
+            0.1270751953125,
+            0.10992431640625,
+            0.10797119140625,
+            0.1124267578125,
+            0.145263671875,
+            0.11138916015625,
+            0.12371826171875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.007125890736342043,
+              "top1_flips": 3
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1368,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 2479,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 3608,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 316,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.27375707876517935,
+          "moe_input_normalized_cosine": 0.9999509294401662,
+          "moe_output_cosine": 0.9999010859004773,
+          "residual_drift_relative_norm": 0.006972312249031641,
+          "residual_stream_cosine": 0.9999756963861242,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999662344185568,
+            "residual_in_drift_relative_norm": 0.008217809632556623
+          },
+          "router_logit_cosine": 0.9999932806125511,
+          "router_margin_mean_delta": 0.00012309683268611266,
+          "router_margin_mean_observed": 0.1769348817503377,
+          "router_margin_mean_reference": 0.1768117849176516,
+          "router_margin_median_observed": 0.14202488915802522,
+          "router_margin_median_reference": 0.14185318157435073,
+          "router_top1_agreement": 0.9996337890625,
+          "router_top2_set_agreement": 0.9981689453125,
+          "router_topk_set_agreement": 0.9981689453125,
+          "seconds": 311.47637486457825,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 193.54124808311462
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.9965665106057541,
+          "attention_output_cosine_per_token": 0.9966740867903803,
+          "attn_delta_over_stream": 0.6084507931815782,
+          "block_output_cosine": 0.9886573865540497,
+          "block_output_cosine_per_token": 0.9886610677209071,
+          "block_output_drift_relative_norm": 0.1504987802639529,
+          "expert_load_js_bits": 0.00019497360882110354,
+          "expert_load_max_abs_delta": 0.00946044921875,
+          "expert_load_observed": [
+            0.04437255859375,
+            0.17437744140625,
+            0.0950927734375,
+            0.281005859375,
+            0.06939697265625,
+            0.060791015625,
+            0.14910888671875,
+            0.1258544921875
+          ],
+          "expert_load_reference": [
+            0.04443359375,
+            0.1650390625,
+            0.09173583984375,
+            0.29046630859375,
+            0.069580078125,
+            0.0606689453125,
+            0.148193359375,
+            0.1298828125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2019,
+              "top1_flip_rate": 0.2694403169886082,
+              "top1_flips": 544
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4362,
+              "top1_flip_rate": 0.013755158184319119,
+              "top1_flips": 60
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1752,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 59,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.4341807436222842,
+          "moe_input_normalized_cosine": 0.9955594058712655,
+          "moe_output_cosine": 0.9612818348279588,
+          "residual_drift_relative_norm": 0.06273540273174869,
+          "residual_stream_cosine": 0.9980410644324349,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9975672646063307,
+            "residual_in_drift_relative_norm": 0.0698795479982047
+          },
+          "router_logit_cosine": 0.9996287541956903,
+          "router_margin_mean_delta": -7.849608593381847e-05,
+          "router_margin_mean_observed": 0.033071704304925925,
+          "router_margin_mean_reference": 0.03315020039085974,
+          "router_margin_median_observed": 0.023938491704430215,
+          "router_margin_median_reference": 0.024014774987458368,
+          "router_top1_agreement": 0.92626953125,
+          "router_top2_set_agreement": 0.8861083984375,
+          "router_topk_set_agreement": 0.8861083984375,
+          "seconds": 345.4744019508362,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999716287912973,
+          "attention_output_cosine_per_token": 0.9999694231843663,
+          "attn_delta_over_stream": 0.6092783179867541,
+          "block_output_cosine": 0.9997649252084471,
+          "block_output_cosine_per_token": 0.9997605920963788,
+          "block_output_drift_relative_norm": 0.021683098492711318,
+          "expert_load_js_bits": 4.204230303538151e-07,
+          "expert_load_max_abs_delta": 0.00030517578125,
+          "expert_load_observed": [
+            0.0445556640625,
+            0.1650390625,
+            0.09173583984375,
+            0.29046630859375,
+            0.06988525390625,
+            0.0606689453125,
+            0.14794921875,
+            0.12969970703125
+          ],
+          "expert_load_reference": [
+            0.04443359375,
+            0.1650390625,
+            0.09173583984375,
+            0.29046630859375,
+            0.069580078125,
+            0.0606689453125,
+            0.148193359375,
+            0.1298828125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2019,
+              "top1_flip_rate": 0.012877662209014363,
+              "top1_flips": 26
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4362,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1752,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 59,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4316547372269685,
+          "moe_input_normalized_cosine": 0.9999439196166795,
+          "moe_output_cosine": 0.9991185860861073,
+          "residual_drift_relative_norm": 0.0070732812585666514,
+          "residual_stream_cosine": 0.9999749873089938,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.999965929851699,
+            "residual_in_drift_relative_norm": 0.008254778779977658
+          },
+          "router_logit_cosine": 0.9999958994382009,
+          "router_margin_mean_delta": 1.6864946445976705e-05,
+          "router_margin_mean_observed": 0.03316706533730572,
+          "router_margin_mean_reference": 0.03315020039085974,
+          "router_margin_median_observed": 0.02397975142504559,
+          "router_margin_median_reference": 0.024014774987458368,
+          "router_top1_agreement": 0.996826171875,
+          "router_top2_set_agreement": 0.995361328125,
+          "router_topk_set_agreement": 0.995361328125,
+          "seconds": 316.63707876205444,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 242.07538318634033
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.9849794005308738,
+          "attention_output_cosine_per_token": 0.9848368129062782,
+          "attn_delta_over_stream": 0.5687244774086985,
+          "block_output_cosine": 0.9805662657439359,
+          "block_output_cosine_per_token": 0.9803507306361513,
+          "block_output_drift_relative_norm": 0.19772214640333557,
+          "expert_load_js_bits": 0.0003170502785525748,
+          "expert_load_max_abs_delta": 0.01226806640625,
+          "expert_load_observed": [
+            0.044189453125,
+            0.0555419921875,
+            0.09136962890625,
+            0.225341796875,
+            0.32684326171875,
+            0.04168701171875,
+            0.124267578125,
+            0.09075927734375
+          ],
+          "expert_load_reference": [
+            0.04150390625,
+            0.05712890625,
+            0.0887451171875,
+            0.21875,
+            0.339111328125,
+            0.04656982421875,
+            0.11859130859375,
+            0.089599609375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2219,
+              "top1_flip_rate": 0.41865705272645337,
+              "top1_flips": 929
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4206,
+              "top1_flip_rate": 0.11602472658107466,
+              "top1_flips": 488
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1595,
+              "top1_flip_rate": 0.016927899686520375,
+              "top1_flips": 27
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 170,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 2,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_side",
+          "moe_delta_over_stream": 0.33949200216019837,
+          "moe_input_normalized_cosine": 0.9766669769275363,
+          "moe_output_cosine": 0.9399137334498511,
+          "residual_drift_relative_norm": 0.12344734332232438,
+          "residual_stream_cosine": 0.9924074300943141,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9886573865540497,
+            "residual_in_drift_relative_norm": 0.1504987802639529
+          },
+          "router_logit_cosine": 0.998744311294021,
+          "router_margin_mean_delta": -0.0008076860631850392,
+          "router_margin_mean_observed": 0.03351272956418477,
+          "router_margin_mean_reference": 0.034320415627369816,
+          "router_margin_median_observed": 0.021772259286882895,
+          "router_margin_median_reference": 0.0220433932007284,
+          "router_top1_agreement": 0.82373046875,
+          "router_top2_set_agreement": 0.7210693359375,
+          "router_topk_set_agreement": 0.7210693359375,
+          "seconds": 309.3350121974945,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9996371522691706,
+          "attention_output_cosine_per_token": 0.9996587349820896,
+          "attn_delta_over_stream": 0.5618916032039319,
+          "block_output_cosine": 0.9994370955486388,
+          "block_output_cosine_per_token": 0.9994322357588377,
+          "block_output_drift_relative_norm": 0.03355323588949929,
+          "expert_load_js_bits": 1.4895787361700699e-06,
+          "expert_load_max_abs_delta": 0.00054931640625,
+          "expert_load_observed": [
+            0.04168701171875,
+            0.05718994140625,
+            0.08819580078125,
+            0.218994140625,
+            0.3394775390625,
+            0.0467529296875,
+            0.1180419921875,
+            0.08966064453125
+          ],
+          "expert_load_reference": [
+            0.04150390625,
+            0.05712890625,
+            0.0887451171875,
+            0.21875,
+            0.339111328125,
+            0.04656982421875,
+            0.11859130859375,
+            0.089599609375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2219,
+              "top1_flip_rate": 0.027039206849932402,
+              "top1_flips": 60
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4206,
+              "top1_flip_rate": 0.0028530670470756064,
+              "top1_flips": 12
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1595,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 170,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 2,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.33880058537802515,
+          "moe_input_normalized_cosine": 0.9994953806921836,
+          "moe_output_cosine": 0.9980916705559675,
+          "residual_drift_relative_norm": 0.017792575310936677,
+          "residual_stream_cosine": 0.9998417382509542,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9997649252084471,
+            "residual_in_drift_relative_norm": 0.021683098492711318
+          },
+          "router_logit_cosine": 0.9999683118236804,
+          "router_margin_mean_delta": 3.102300184862202e-05,
+          "router_margin_mean_observed": 0.03435143862921844,
+          "router_margin_mean_reference": 0.034320415627369816,
+          "router_margin_median_observed": 0.021954006940788154,
+          "router_margin_median_reference": 0.0220433932007284,
+          "router_top1_agreement": 0.9912109375,
+          "router_top2_set_agreement": 0.987548828125,
+          "router_topk_set_agreement": 0.987548828125,
+          "seconds": 336.2478401660919,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_side",
+        "reference_seconds": 229.87560534477234
+      }
     ],
-    "channel_alpha_blocks": [],
-    "hp_schedule_prose": "INT4 experts (research_int4_side) on all chain blocks.",
-    "arm_label": "expert_int4",
     "pilot_labels_per_block": [
       "research_int4_side",
       "research_int4_side",
       "research_int4_side",
       "research_int4_side"
-    ]
+    ],
+    "skip_fp16_control": false,
+    "ternary_blocks": [],
+    "token_id_first": 37,
+    "token_id_last": 131061,
+    "token_seed": 20260806,
+    "tokens": 8192,
+    "top_k": 2
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "int4",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_76_ceiling": null,
+    "baseline_76_denser": null,
+    "baseline_85": {
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "source": "GH #85 / RM-608 \u2014 protocol lock (Grok-1 max context sequence)",
+      "token_seed": 20260806,
+      "tokens": 8192,
+      "tokens_note": "8192 = Grok-1 published max context (causal sequence). Vocab size 131072 is the sampler ceiling only \u2014 not a valid T for dense attention in this harness.",
+      "top_k": 2
+    },
+    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
+    "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "secondary; no independent decision",
+    "implementation": {
+      "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
+      "dirty": false
+    },
+    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#85 protocol (Grok-1 max context tokens=8192). #72/#80 2048-token figures are historical cites only; not same-budget and not a validation failure.",
+    "model": "OpenAI Codex",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v4/int4-channel-alpha-123/metrics.json
+++ b/reports/grok-1-expert-precision-remedy-v4/int4-channel-alpha-123/metrics.json
@@ -1,1050 +1,45 @@
 {
-  "provenance": {
-    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
-    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
-    "model": "OpenAI Codex",
-    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_74": {
-      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "decision": 2,
-      "block_output_cosine": [
-        0.963572,
-        0.963211,
-        0.90536,
-        0.882308
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.279321,
-        0.449088
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.729004,
-        0.547852
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.592773,
-        0.317383
-      ],
-      "expert_load_js_bits": [
-        0.0,
-        0.005559,
-        0.008548,
-        0.025243
-      ],
-      "chain_exit_residual_drift": 0.5292121735722244,
-      "arm_label": "expert_periodic_hp_n2",
-      "pack_sha256": {
-        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
-      },
-      "pack_names": {
-        "0": "block_000-attention_plus_expert.goz1",
-        "1": "block_001-attention_plus_expert.goz1",
-        "2": "block_002-attention_plus_expert.goz1",
-        "3": "block_003-attention_plus_expert.goz1"
-      }
-    },
-    "baseline_76_denser": null,
-    "baseline_76_ceiling": null,
-    "baseline_85": {
-      "source": "GH #85 / RM-608 \u2014 protocol lock (Grok-1 max context sequence)",
-      "tokens": 8192,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "top_k": 2,
-      "tokens_note": "8192 = Grok-1 published max context (causal sequence). Vocab size 131072 is the sampler ceiling only \u2014 not a valid T for dense attention in this harness."
-    },
-    "implementation": {
-      "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle",
-    "arm": "int4_channel_alpha",
-    "metrics_filename": "metrics.json",
-    "metrics_note": "#85 protocol (Grok-1 max context tokens=8192). #72/#80 2048-token figures are historical cites only; not same-budget and not a validation failure.",
-    "evidence_role": "secondary; no independent decision"
-  },
   "chain": {
+    "arm_label": "expert_int4_channel_alpha_123",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 8192,
-    "token_seed": 20260806,
-    "token_id_first": 37,
-    "token_id_last": 131061,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 257.4511570930481,
-        "expert_only": {
-          "label": "research_int4_channel_alpha_side",
-          "seconds": 333.4465341567993,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0000000000000002,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.9934975387787467,
-          "block_output_cosine": 0.9981363940675975,
-          "block_output_cosine_per_token": 0.998144934126475,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.061248773387512494,
-          "attn_delta_over_stream": 0.9033581150208522,
-          "moe_delta_over_stream": 0.4832609877350179,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.15130615234375,
-            0.111328125,
-            0.15545654296875,
-            0.13671875,
-            0.10418701171875,
-            0.1141357421875,
-            0.11602783203125,
-            0.11083984375
-          ],
-          "expert_load_observed": [
-            0.15130615234375,
-            0.111328125,
-            0.15545654296875,
-            0.13671875,
-            0.10418701171875,
-            0.1141357421875,
-            0.11602783203125,
-            0.11083984375
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.0346857385962856,
-          "router_margin_mean_observed": 0.0346857385962856,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.008471452573598867,
-          "router_margin_median_observed": 0.008471452573598867,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 4299,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1846,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1700,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 1,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 287.79632353782654,
-          "attention_output_cosine": 0.9999999985728412,
-          "attention_output_cosine_per_token": 0.9999999986361572,
-          "residual_stream_cosine": 0.9999999819762834,
-          "moe_input_normalized_cosine": 0.999999958445224,
-          "router_logit_cosine": 0.9999999972602787,
-          "moe_output_cosine": 0.9998959798468963,
-          "block_output_cosine": 0.9999662344185568,
-          "block_output_cosine_per_token": 0.9999632230144466,
-          "residual_drift_relative_norm": 0.00022418911406672668,
-          "block_output_drift_relative_norm": 0.008217809632556623,
-          "attn_delta_over_stream": 0.9031929817106404,
-          "moe_delta_over_stream": 0.4934264147307654,
-          "router_top1_agreement": 0.9991455078125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99658203125,
-          "router_top2_set_agreement": 0.99658203125,
-          "expert_load_reference": [
-            0.15130615234375,
-            0.111328125,
-            0.15545654296875,
-            0.13671875,
-            0.10418701171875,
-            0.1141357421875,
-            0.11602783203125,
-            0.11083984375
-          ],
-          "expert_load_observed": [
-            0.1513671875,
-            0.11181640625,
-            0.15570068359375,
-            0.13677978515625,
-            0.10382080078125,
-            0.11431884765625,
-            0.11578369140625,
-            0.11041259765625
-          ],
-          "expert_load_js_bits": 1.1395797616989257e-06,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.0346857385962856,
-          "router_margin_mean_observed": 0.034688792519098996,
-          "router_margin_mean_delta": 3.053922813402341e-06,
-          "router_margin_median_reference": 0.008471452573598867,
-          "router_margin_median_observed": 0.008459846907189983,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 4299,
-              "top1_flips": 7,
-              "top1_flip_rate": 0.0016282856478250756
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1846,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1700,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 1,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "research_int4_channel_alpha_side"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 204.38440132141113,
-        "expert_only": {
-          "label": "expert_int4_channel_alpha_123",
-          "seconds": 293.18333554267883,
-          "attention_output_cosine": 0.9991453652888852,
-          "attention_output_cosine_per_token": 0.9992006416127804,
-          "residual_stream_cosine": 0.9986616815064538,
-          "moe_input_normalized_cosine": 0.9981928393441294,
-          "router_logit_cosine": 0.9998184605628635,
-          "moe_output_cosine": 0.9961783283829612,
-          "block_output_cosine": 0.9982853808940991,
-          "block_output_cosine_per_token": 0.9982959753367047,
-          "residual_drift_relative_norm": 0.05188467503474186,
-          "block_output_drift_relative_norm": 0.058674898865502985,
-          "attn_delta_over_stream": 0.4254724587590576,
-          "moe_delta_over_stream": 0.2738437610862629,
-          "router_top1_agreement": 0.9820556640625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.932861328125,
-          "router_top2_set_agreement": 0.932861328125,
-          "expert_load_reference": [
-            0.1622314453125,
-            0.1270751953125,
-            0.10992431640625,
-            0.10797119140625,
-            0.1124267578125,
-            0.145263671875,
-            0.11138916015625,
-            0.12371826171875
-          ],
-          "expert_load_observed": [
-            0.16107177734375,
-            0.12713623046875,
-            0.10845947265625,
-            0.1065673828125,
-            0.1126708984375,
-            0.1436767578125,
-            0.11456298828125,
-            0.1258544921875
-          ],
-          "expert_load_js_bits": 3.4276330251193764e-05,
-          "expert_load_max_abs_delta": 0.003173828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1768117849176516,
-          "router_margin_mean_observed": 0.1780683993963692,
-          "router_margin_mean_delta": 0.0012566144787176476,
-          "router_margin_median_reference": 0.14185318157435073,
-          "router_margin_median_observed": 0.1414818821250895,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 119,
-              "top1_flip_rate": 0.2826603325415677
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1368,
-              "top1_flips": 28,
-              "top1_flip_rate": 0.02046783625730994
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 2479,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 3608,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 316,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9981363940675975,
-            "residual_in_drift_relative_norm": 0.061248773387512494
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 335.42269349098206,
-          "attention_output_cosine": 0.9999844464986306,
-          "attention_output_cosine_per_token": 0.9999843032690912,
-          "residual_stream_cosine": 0.9999756963861242,
-          "moe_input_normalized_cosine": 0.9999509294401662,
-          "router_logit_cosine": 0.9999932806125511,
-          "moe_output_cosine": 0.9999010859004773,
-          "block_output_cosine": 0.999965929851699,
-          "block_output_cosine_per_token": 0.9999644733042241,
-          "residual_drift_relative_norm": 0.006972312249031641,
-          "block_output_drift_relative_norm": 0.008254778779977658,
-          "attn_delta_over_stream": 0.4284735778277611,
-          "moe_delta_over_stream": 0.27375707876517935,
-          "router_top1_agreement": 0.9996337890625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9981689453125,
-          "router_top2_set_agreement": 0.9981689453125,
-          "expert_load_reference": [
-            0.1622314453125,
-            0.1270751953125,
-            0.10992431640625,
-            0.10797119140625,
-            0.1124267578125,
-            0.145263671875,
-            0.11138916015625,
-            0.12371826171875
-          ],
-          "expert_load_observed": [
-            0.1624755859375,
-            0.1270751953125,
-            0.10992431640625,
-            0.10791015625,
-            0.11224365234375,
-            0.1453857421875,
-            0.111328125,
-            0.1236572265625
-          ],
-          "expert_load_js_bits": 1.5620965325225452e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1768117849176516,
-          "router_margin_mean_observed": 0.1769348817503377,
-          "router_margin_mean_delta": 0.00012309683268611266,
-          "router_margin_median_reference": 0.14185318157435073,
-          "router_margin_median_observed": 0.14202488915802522,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 3,
-              "top1_flip_rate": 0.007125890736342043
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1368,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 2479,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 3608,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 316,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999662344185568,
-            "residual_in_drift_relative_norm": 0.008217809632556623
-          }
-        },
-        "pilot_label": "expert_int4_channel_alpha_123"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 244.76727294921875,
-        "expert_only": {
-          "label": "expert_int4_channel_alpha_123",
-          "seconds": 320.02914905548096,
-          "attention_output_cosine": 0.995773390039298,
-          "attention_output_cosine_per_token": 0.9959299134443145,
-          "residual_stream_cosine": 0.9983827938054513,
-          "moe_input_normalized_cosine": 0.9967036296191482,
-          "router_logit_cosine": 0.9996170909562814,
-          "moe_output_cosine": 0.9815207489166171,
-          "block_output_cosine": 0.9939599269144929,
-          "block_output_cosine_per_token": 0.9939509512646542,
-          "residual_drift_relative_norm": 0.05691301584577628,
-          "block_output_drift_relative_norm": 0.10976319959391136,
-          "attn_delta_over_stream": 0.6082200966354006,
-          "moe_delta_over_stream": 0.4301469503551952,
-          "router_top1_agreement": 0.9351806640625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9066162109375,
-          "router_top2_set_agreement": 0.9066162109375,
-          "expert_load_reference": [
-            0.04443359375,
-            0.1650390625,
-            0.09173583984375,
-            0.29046630859375,
-            0.069580078125,
-            0.0606689453125,
-            0.148193359375,
-            0.1298828125
-          ],
-          "expert_load_observed": [
-            0.04327392578125,
-            0.16961669921875,
-            0.09539794921875,
-            0.28961181640625,
-            0.07171630859375,
-            0.0606689453125,
-            0.1494140625,
-            0.12030029296875
-          ],
-          "expert_load_js_bits": 0.00020028407461690186,
-          "expert_load_max_abs_delta": 0.00958251953125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.03315020039085974,
-          "router_margin_mean_observed": 0.03305504250558787,
-          "router_margin_mean_delta": -9.515788527187796e-05,
-          "router_margin_median_reference": 0.024014774987458368,
-          "router_margin_median_observed": 0.024203425781422316,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2019,
-              "top1_flips": 493,
-              "top1_flip_rate": 0.2441802872709262
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4362,
-              "top1_flips": 37,
-              "top1_flip_rate": 0.008482347546996791
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1752,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0005707762557077625
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 59,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9982853808940991,
-            "residual_in_drift_relative_norm": 0.058674898865502985
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 294.91808676719666,
-          "attention_output_cosine": 0.9999716287912973,
-          "attention_output_cosine_per_token": 0.9999694231843663,
-          "residual_stream_cosine": 0.9999749873089938,
-          "moe_input_normalized_cosine": 0.9999439196166795,
-          "router_logit_cosine": 0.9999958994382009,
-          "moe_output_cosine": 0.9991185860861073,
-          "block_output_cosine": 0.9997649252084471,
-          "block_output_cosine_per_token": 0.9997605920963788,
-          "residual_drift_relative_norm": 0.0070732812585666514,
-          "block_output_drift_relative_norm": 0.021683098492711318,
-          "attn_delta_over_stream": 0.6092783179867541,
-          "moe_delta_over_stream": 0.4316547372269685,
-          "router_top1_agreement": 0.996826171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.995361328125,
-          "router_top2_set_agreement": 0.995361328125,
-          "expert_load_reference": [
-            0.04443359375,
-            0.1650390625,
-            0.09173583984375,
-            0.29046630859375,
-            0.069580078125,
-            0.0606689453125,
-            0.148193359375,
-            0.1298828125
-          ],
-          "expert_load_observed": [
-            0.0445556640625,
-            0.1650390625,
-            0.09173583984375,
-            0.29046630859375,
-            0.06988525390625,
-            0.0606689453125,
-            0.14794921875,
-            0.12969970703125
-          ],
-          "expert_load_js_bits": 4.204230303538151e-07,
-          "expert_load_max_abs_delta": 0.00030517578125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.03315020039085974,
-          "router_margin_mean_observed": 0.03316706533730572,
-          "router_margin_mean_delta": 1.6864946445976705e-05,
-          "router_margin_median_reference": 0.024014774987458368,
-          "router_margin_median_observed": 0.02397975142504559,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2019,
-              "top1_flips": 26,
-              "top1_flip_rate": 0.012877662209014363
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4362,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1752,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 59,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.999965929851699,
-            "residual_in_drift_relative_norm": 0.008254778779977658
-          }
-        },
-        "pilot_label": "expert_int4_channel_alpha_123"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 203.10643815994263,
-        "expert_only": {
-          "label": "expert_int4_channel_alpha_123",
-          "seconds": 274.67492175102234,
-          "attention_output_cosine": 0.9910314247928639,
-          "attention_output_cosine_per_token": 0.9907323252533443,
-          "residual_stream_cosine": 0.9958492289168094,
-          "moe_input_normalized_cosine": 0.9875052364484207,
-          "router_logit_cosine": 0.9992178615417482,
-          "moe_output_cosine": 0.9704103764149535,
-          "block_output_cosine": 0.9900038440611516,
-          "block_output_cosine_per_token": 0.9897918491919186,
-          "residual_drift_relative_norm": 0.091368390182391,
-          "block_output_drift_relative_norm": 0.14199439171490524,
-          "attn_delta_over_stream": 0.5711743438342609,
-          "moe_delta_over_stream": 0.3380348149052451,
-          "router_top1_agreement": 0.8873291015625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.8260498046875,
-          "router_top2_set_agreement": 0.8260498046875,
-          "expert_load_reference": [
-            0.04150390625,
-            0.05712890625,
-            0.0887451171875,
-            0.21875,
-            0.339111328125,
-            0.04656982421875,
-            0.11859130859375,
-            0.089599609375
-          ],
-          "expert_load_observed": [
-            0.0430908203125,
-            0.05828857421875,
-            0.091796875,
-            0.22076416015625,
-            0.33538818359375,
-            0.047607421875,
-            0.1156005859375,
-            0.08746337890625
-          ],
-          "expert_load_js_bits": 7.148238084593193e-05,
-          "expert_load_max_abs_delta": 0.00372314453125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.034320415627369816,
-          "router_margin_mean_observed": 0.03386946999688343,
-          "router_margin_mean_delta": -0.0004509456304863861,
-          "router_margin_median_reference": 0.0220433932007284,
-          "router_margin_median_observed": 0.02150663319172212,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2219,
-              "top1_flips": 674,
-              "top1_flip_rate": 0.30374042361424064
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4206,
-              "top1_flips": 230,
-              "top1_flip_rate": 0.05468378506894912
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1595,
-              "top1_flips": 19,
-              "top1_flip_rate": 0.011912225705329153
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 170,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 2,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9939599269144929,
-            "residual_in_drift_relative_norm": 0.10976319959391136
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 301.19865012168884,
-          "attention_output_cosine": 0.9996371522691706,
-          "attention_output_cosine_per_token": 0.9996587349820896,
-          "residual_stream_cosine": 0.9998417382509542,
-          "moe_input_normalized_cosine": 0.9994953806921836,
-          "router_logit_cosine": 0.9999683118236804,
-          "moe_output_cosine": 0.9980916705559675,
-          "block_output_cosine": 0.9994370955486388,
-          "block_output_cosine_per_token": 0.9994322357588377,
-          "residual_drift_relative_norm": 0.017792575310936677,
-          "block_output_drift_relative_norm": 0.03355323588949929,
-          "attn_delta_over_stream": 0.5618916032039319,
-          "moe_delta_over_stream": 0.33880058537802515,
-          "router_top1_agreement": 0.9912109375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.987548828125,
-          "router_top2_set_agreement": 0.987548828125,
-          "expert_load_reference": [
-            0.04150390625,
-            0.05712890625,
-            0.0887451171875,
-            0.21875,
-            0.339111328125,
-            0.04656982421875,
-            0.11859130859375,
-            0.089599609375
-          ],
-          "expert_load_observed": [
-            0.04168701171875,
-            0.05718994140625,
-            0.08819580078125,
-            0.218994140625,
-            0.3394775390625,
-            0.0467529296875,
-            0.1180419921875,
-            0.08966064453125
-          ],
-          "expert_load_js_bits": 1.4895787361700699e-06,
-          "expert_load_max_abs_delta": 0.00054931640625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.034320415627369816,
-          "router_margin_mean_observed": 0.03435143862921844,
-          "router_margin_mean_delta": 3.102300184862202e-05,
-          "router_margin_median_reference": 0.0220433932007284,
-          "router_margin_median_observed": 0.021954006940788154,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 2219,
-              "top1_flips": 60,
-              "top1_flip_rate": 0.027039206849932402
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 4206,
-              "top1_flips": 12,
-              "top1_flip_rate": 0.0028530670470756064
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 1595,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 170,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 2,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9997649252084471,
-            "residual_in_drift_relative_norm": 0.021683098492711318
-          }
-        },
-        "pilot_label": "expert_int4_channel_alpha_123"
-      }
+    "channel_alpha_blocks": [
+      0
     ],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.9900038440611516,
-        "residual_drift_relative_norm": 0.14199439171490524,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.14199439171490524
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9994370955486388,
-        "residual_drift_relative_norm": 0.03355323588949929,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.03355323588949929
       }
     },
+    "expert_mode": "int4_channel_alpha",
+    "hp_blocks": [
+      1,
+      2,
+      3
+    ],
+    "hp_period": null,
+    "hp_schedule_kind": "explicit",
+    "hp_schedule_prose": "Stacked INT4+LS-\u03b1 label `expert_int4_channel_alpha_123`: INT4 codes with LS channel-\u03b1 on {0}, HP (FP16 experts) on {1,2,3}.",
+    "int4_blocks": [
+      0
+    ],
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
-        "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
-          "block_000.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
-          "block_000.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
-        },
-        "pack_scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1075,53 +70,53 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
+          "block_000.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
+          "block_000.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
-        "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "fp16_control",
-          "block_001.slot_00.moe_expert.gate": "fp16_control",
-          "block_001.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1152,53 +147,53 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "fp16_control",
+          "block_001.slot_01.moe_expert.down": "fp16_control",
+          "block_001.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
-        "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "fp16_control",
-          "block_002.slot_00.moe_expert.gate": "fp16_control",
-          "block_002.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1229,53 +224,53 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "fp16_control",
+          "block_002.slot_01.moe_expert.down": "fp16_control",
+          "block_002.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
-        "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "fp16_control",
-          "block_003.slot_00.moe_expert.gate": "fp16_control",
-          "block_003.slot_02.moe_expert.up": "fp16_control"
-        },
-        "pack_scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1306,37 +301,1042 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "fp16_control",
+          "block_003.slot_01.moe_expert.down": "fp16_control",
+          "block_003.slot_02.moe_expert.up": "fp16_control"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "int4_channel_alpha",
-    "hp_period": null,
-    "hp_schedule_kind": "explicit",
-    "hp_blocks": [
-      1,
-      2,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.9033581150208522,
+          "block_output_cosine": 0.9981363940675975,
+          "block_output_cosine_per_token": 0.998144934126475,
+          "block_output_drift_relative_norm": 0.061248773387512494,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.15130615234375,
+            0.111328125,
+            0.15545654296875,
+            0.13671875,
+            0.10418701171875,
+            0.1141357421875,
+            0.11602783203125,
+            0.11083984375
+          ],
+          "expert_load_reference": [
+            0.15130615234375,
+            0.111328125,
+            0.15545654296875,
+            0.13671875,
+            0.10418701171875,
+            0.1141357421875,
+            0.11602783203125,
+            0.11083984375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 4299,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1846,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1700,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 1,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_int4_channel_alpha_side",
+          "moe_delta_over_stream": 0.4832609877350179,
+          "moe_input_normalized_cosine": 1.0000000000000002,
+          "moe_output_cosine": 0.9934975387787467,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.0346857385962856,
+          "router_margin_mean_reference": 0.0346857385962856,
+          "router_margin_median_observed": 0.008471452573598867,
+          "router_margin_median_reference": 0.008471452573598867,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 333.4465341567993,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999985728412,
+          "attention_output_cosine_per_token": 0.9999999986361572,
+          "attn_delta_over_stream": 0.9031929817106404,
+          "block_output_cosine": 0.9999662344185568,
+          "block_output_cosine_per_token": 0.9999632230144466,
+          "block_output_drift_relative_norm": 0.008217809632556623,
+          "expert_load_js_bits": 1.1395797616989257e-06,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.1513671875,
+            0.11181640625,
+            0.15570068359375,
+            0.13677978515625,
+            0.10382080078125,
+            0.11431884765625,
+            0.11578369140625,
+            0.11041259765625
+          ],
+          "expert_load_reference": [
+            0.15130615234375,
+            0.111328125,
+            0.15545654296875,
+            0.13671875,
+            0.10418701171875,
+            0.1141357421875,
+            0.11602783203125,
+            0.11083984375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 4299,
+              "top1_flip_rate": 0.0016282856478250756,
+              "top1_flips": 7
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1846,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1700,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 1,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4934264147307654,
+          "moe_input_normalized_cosine": 0.999999958445224,
+          "moe_output_cosine": 0.9998959798468963,
+          "residual_drift_relative_norm": 0.00022418911406672668,
+          "residual_stream_cosine": 0.9999999819762834,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999972602787,
+          "router_margin_mean_delta": 3.053922813402341e-06,
+          "router_margin_mean_observed": 0.034688792519098996,
+          "router_margin_mean_reference": 0.0346857385962856,
+          "router_margin_median_observed": 0.008459846907189983,
+          "router_margin_median_reference": 0.008471452573598867,
+          "router_top1_agreement": 0.9991455078125,
+          "router_top2_set_agreement": 0.99658203125,
+          "router_topk_set_agreement": 0.99658203125,
+          "seconds": 287.79632353782654,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_int4_channel_alpha_side",
+        "reference_seconds": 257.4511570930481
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9991453652888852,
+          "attention_output_cosine_per_token": 0.9992006416127804,
+          "attn_delta_over_stream": 0.4254724587590576,
+          "block_output_cosine": 0.9982853808940991,
+          "block_output_cosine_per_token": 0.9982959753367047,
+          "block_output_drift_relative_norm": 0.058674898865502985,
+          "expert_load_js_bits": 3.4276330251193764e-05,
+          "expert_load_max_abs_delta": 0.003173828125,
+          "expert_load_observed": [
+            0.16107177734375,
+            0.12713623046875,
+            0.10845947265625,
+            0.1065673828125,
+            0.1126708984375,
+            0.1436767578125,
+            0.11456298828125,
+            0.1258544921875
+          ],
+          "expert_load_reference": [
+            0.1622314453125,
+            0.1270751953125,
+            0.10992431640625,
+            0.10797119140625,
+            0.1124267578125,
+            0.145263671875,
+            0.11138916015625,
+            0.12371826171875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.2826603325415677,
+              "top1_flips": 119
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1368,
+              "top1_flip_rate": 0.02046783625730994,
+              "top1_flips": 28
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 2479,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 3608,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 316,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_int4_channel_alpha_123",
+          "moe_delta_over_stream": 0.2738437610862629,
+          "moe_input_normalized_cosine": 0.9981928393441294,
+          "moe_output_cosine": 0.9961783283829612,
+          "residual_drift_relative_norm": 0.05188467503474186,
+          "residual_stream_cosine": 0.9986616815064538,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9981363940675975,
+            "residual_in_drift_relative_norm": 0.061248773387512494
+          },
+          "router_logit_cosine": 0.9998184605628635,
+          "router_margin_mean_delta": 0.0012566144787176476,
+          "router_margin_mean_observed": 0.1780683993963692,
+          "router_margin_mean_reference": 0.1768117849176516,
+          "router_margin_median_observed": 0.1414818821250895,
+          "router_margin_median_reference": 0.14185318157435073,
+          "router_top1_agreement": 0.9820556640625,
+          "router_top2_set_agreement": 0.932861328125,
+          "router_topk_set_agreement": 0.932861328125,
+          "seconds": 293.18333554267883,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999844464986306,
+          "attention_output_cosine_per_token": 0.9999843032690912,
+          "attn_delta_over_stream": 0.4284735778277611,
+          "block_output_cosine": 0.999965929851699,
+          "block_output_cosine_per_token": 0.9999644733042241,
+          "block_output_drift_relative_norm": 0.008254778779977658,
+          "expert_load_js_bits": 1.5620965325225452e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.1624755859375,
+            0.1270751953125,
+            0.10992431640625,
+            0.10791015625,
+            0.11224365234375,
+            0.1453857421875,
+            0.111328125,
+            0.1236572265625
+          ],
+          "expert_load_reference": [
+            0.1622314453125,
+            0.1270751953125,
+            0.10992431640625,
+            0.10797119140625,
+            0.1124267578125,
+            0.145263671875,
+            0.11138916015625,
+            0.12371826171875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.007125890736342043,
+              "top1_flips": 3
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1368,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 2479,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 3608,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 316,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.27375707876517935,
+          "moe_input_normalized_cosine": 0.9999509294401662,
+          "moe_output_cosine": 0.9999010859004773,
+          "residual_drift_relative_norm": 0.006972312249031641,
+          "residual_stream_cosine": 0.9999756963861242,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999662344185568,
+            "residual_in_drift_relative_norm": 0.008217809632556623
+          },
+          "router_logit_cosine": 0.9999932806125511,
+          "router_margin_mean_delta": 0.00012309683268611266,
+          "router_margin_mean_observed": 0.1769348817503377,
+          "router_margin_mean_reference": 0.1768117849176516,
+          "router_margin_median_observed": 0.14202488915802522,
+          "router_margin_median_reference": 0.14185318157435073,
+          "router_top1_agreement": 0.9996337890625,
+          "router_top2_set_agreement": 0.9981689453125,
+          "router_topk_set_agreement": 0.9981689453125,
+          "seconds": 335.42269349098206,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_int4_channel_alpha_123",
+        "reference_seconds": 204.38440132141113
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.995773390039298,
+          "attention_output_cosine_per_token": 0.9959299134443145,
+          "attn_delta_over_stream": 0.6082200966354006,
+          "block_output_cosine": 0.9939599269144929,
+          "block_output_cosine_per_token": 0.9939509512646542,
+          "block_output_drift_relative_norm": 0.10976319959391136,
+          "expert_load_js_bits": 0.00020028407461690186,
+          "expert_load_max_abs_delta": 0.00958251953125,
+          "expert_load_observed": [
+            0.04327392578125,
+            0.16961669921875,
+            0.09539794921875,
+            0.28961181640625,
+            0.07171630859375,
+            0.0606689453125,
+            0.1494140625,
+            0.12030029296875
+          ],
+          "expert_load_reference": [
+            0.04443359375,
+            0.1650390625,
+            0.09173583984375,
+            0.29046630859375,
+            0.069580078125,
+            0.0606689453125,
+            0.148193359375,
+            0.1298828125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2019,
+              "top1_flip_rate": 0.2441802872709262,
+              "top1_flips": 493
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4362,
+              "top1_flip_rate": 0.008482347546996791,
+              "top1_flips": 37
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1752,
+              "top1_flip_rate": 0.0005707762557077625,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 59,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_int4_channel_alpha_123",
+          "moe_delta_over_stream": 0.4301469503551952,
+          "moe_input_normalized_cosine": 0.9967036296191482,
+          "moe_output_cosine": 0.9815207489166171,
+          "residual_drift_relative_norm": 0.05691301584577628,
+          "residual_stream_cosine": 0.9983827938054513,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9982853808940991,
+            "residual_in_drift_relative_norm": 0.058674898865502985
+          },
+          "router_logit_cosine": 0.9996170909562814,
+          "router_margin_mean_delta": -9.515788527187796e-05,
+          "router_margin_mean_observed": 0.03305504250558787,
+          "router_margin_mean_reference": 0.03315020039085974,
+          "router_margin_median_observed": 0.024203425781422316,
+          "router_margin_median_reference": 0.024014774987458368,
+          "router_top1_agreement": 0.9351806640625,
+          "router_top2_set_agreement": 0.9066162109375,
+          "router_topk_set_agreement": 0.9066162109375,
+          "seconds": 320.02914905548096,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999716287912973,
+          "attention_output_cosine_per_token": 0.9999694231843663,
+          "attn_delta_over_stream": 0.6092783179867541,
+          "block_output_cosine": 0.9997649252084471,
+          "block_output_cosine_per_token": 0.9997605920963788,
+          "block_output_drift_relative_norm": 0.021683098492711318,
+          "expert_load_js_bits": 4.204230303538151e-07,
+          "expert_load_max_abs_delta": 0.00030517578125,
+          "expert_load_observed": [
+            0.0445556640625,
+            0.1650390625,
+            0.09173583984375,
+            0.29046630859375,
+            0.06988525390625,
+            0.0606689453125,
+            0.14794921875,
+            0.12969970703125
+          ],
+          "expert_load_reference": [
+            0.04443359375,
+            0.1650390625,
+            0.09173583984375,
+            0.29046630859375,
+            0.069580078125,
+            0.0606689453125,
+            0.148193359375,
+            0.1298828125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2019,
+              "top1_flip_rate": 0.012877662209014363,
+              "top1_flips": 26
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4362,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1752,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 59,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4316547372269685,
+          "moe_input_normalized_cosine": 0.9999439196166795,
+          "moe_output_cosine": 0.9991185860861073,
+          "residual_drift_relative_norm": 0.0070732812585666514,
+          "residual_stream_cosine": 0.9999749873089938,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.999965929851699,
+            "residual_in_drift_relative_norm": 0.008254778779977658
+          },
+          "router_logit_cosine": 0.9999958994382009,
+          "router_margin_mean_delta": 1.6864946445976705e-05,
+          "router_margin_mean_observed": 0.03316706533730572,
+          "router_margin_mean_reference": 0.03315020039085974,
+          "router_margin_median_observed": 0.02397975142504559,
+          "router_margin_median_reference": 0.024014774987458368,
+          "router_top1_agreement": 0.996826171875,
+          "router_top2_set_agreement": 0.995361328125,
+          "router_topk_set_agreement": 0.995361328125,
+          "seconds": 294.91808676719666,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_int4_channel_alpha_123",
+        "reference_seconds": 244.76727294921875
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.9910314247928639,
+          "attention_output_cosine_per_token": 0.9907323252533443,
+          "attn_delta_over_stream": 0.5711743438342609,
+          "block_output_cosine": 0.9900038440611516,
+          "block_output_cosine_per_token": 0.9897918491919186,
+          "block_output_drift_relative_norm": 0.14199439171490524,
+          "expert_load_js_bits": 7.148238084593193e-05,
+          "expert_load_max_abs_delta": 0.00372314453125,
+          "expert_load_observed": [
+            0.0430908203125,
+            0.05828857421875,
+            0.091796875,
+            0.22076416015625,
+            0.33538818359375,
+            0.047607421875,
+            0.1156005859375,
+            0.08746337890625
+          ],
+          "expert_load_reference": [
+            0.04150390625,
+            0.05712890625,
+            0.0887451171875,
+            0.21875,
+            0.339111328125,
+            0.04656982421875,
+            0.11859130859375,
+            0.089599609375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2219,
+              "top1_flip_rate": 0.30374042361424064,
+              "top1_flips": 674
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4206,
+              "top1_flip_rate": 0.05468378506894912,
+              "top1_flips": 230
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1595,
+              "top1_flip_rate": 0.011912225705329153,
+              "top1_flips": 19
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 170,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 2,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_int4_channel_alpha_123",
+          "moe_delta_over_stream": 0.3380348149052451,
+          "moe_input_normalized_cosine": 0.9875052364484207,
+          "moe_output_cosine": 0.9704103764149535,
+          "residual_drift_relative_norm": 0.091368390182391,
+          "residual_stream_cosine": 0.9958492289168094,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9939599269144929,
+            "residual_in_drift_relative_norm": 0.10976319959391136
+          },
+          "router_logit_cosine": 0.9992178615417482,
+          "router_margin_mean_delta": -0.0004509456304863861,
+          "router_margin_mean_observed": 0.03386946999688343,
+          "router_margin_mean_reference": 0.034320415627369816,
+          "router_margin_median_observed": 0.02150663319172212,
+          "router_margin_median_reference": 0.0220433932007284,
+          "router_top1_agreement": 0.8873291015625,
+          "router_top2_set_agreement": 0.8260498046875,
+          "router_topk_set_agreement": 0.8260498046875,
+          "seconds": 274.67492175102234,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9996371522691706,
+          "attention_output_cosine_per_token": 0.9996587349820896,
+          "attn_delta_over_stream": 0.5618916032039319,
+          "block_output_cosine": 0.9994370955486388,
+          "block_output_cosine_per_token": 0.9994322357588377,
+          "block_output_drift_relative_norm": 0.03355323588949929,
+          "expert_load_js_bits": 1.4895787361700699e-06,
+          "expert_load_max_abs_delta": 0.00054931640625,
+          "expert_load_observed": [
+            0.04168701171875,
+            0.05718994140625,
+            0.08819580078125,
+            0.218994140625,
+            0.3394775390625,
+            0.0467529296875,
+            0.1180419921875,
+            0.08966064453125
+          ],
+          "expert_load_reference": [
+            0.04150390625,
+            0.05712890625,
+            0.0887451171875,
+            0.21875,
+            0.339111328125,
+            0.04656982421875,
+            0.11859130859375,
+            0.089599609375
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 2219,
+              "top1_flip_rate": 0.027039206849932402,
+              "top1_flips": 60
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 4206,
+              "top1_flip_rate": 0.0028530670470756064,
+              "top1_flips": 12
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 1595,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 170,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 2,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.33880058537802515,
+          "moe_input_normalized_cosine": 0.9994953806921836,
+          "moe_output_cosine": 0.9980916705559675,
+          "residual_drift_relative_norm": 0.017792575310936677,
+          "residual_stream_cosine": 0.9998417382509542,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9997649252084471,
+            "residual_in_drift_relative_norm": 0.021683098492711318
+          },
+          "router_logit_cosine": 0.9999683118236804,
+          "router_margin_mean_delta": 3.102300184862202e-05,
+          "router_margin_mean_observed": 0.03435143862921844,
+          "router_margin_mean_reference": 0.034320415627369816,
+          "router_margin_median_observed": 0.021954006940788154,
+          "router_margin_median_reference": 0.0220433932007284,
+          "router_top1_agreement": 0.9912109375,
+          "router_top2_set_agreement": 0.987548828125,
+          "router_topk_set_agreement": 0.987548828125,
+          "seconds": 301.19865012168884,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_int4_channel_alpha_123",
+        "reference_seconds": 203.10643815994263
+      }
     ],
-    "ternary_blocks": [],
-    "int4_blocks": [
-      0
-    ],
-    "channel_alpha_blocks": [
-      0
-    ],
-    "hp_schedule_prose": "Stacked INT4+LS-\u03b1 label `expert_int4_channel_alpha_123`: INT4 codes with LS channel-\u03b1 on {0}, HP (FP16 experts) on {1,2,3}.",
-    "arm_label": "expert_int4_channel_alpha_123",
     "pilot_labels_per_block": [
       "research_int4_channel_alpha_side",
       "expert_int4_channel_alpha_123",
       "expert_int4_channel_alpha_123",
       "expert_int4_channel_alpha_123"
-    ]
+    ],
+    "skip_fp16_control": false,
+    "ternary_blocks": [],
+    "token_id_first": 37,
+    "token_id_last": 131061,
+    "token_seed": 20260806,
+    "tokens": 8192,
+    "top_k": 2
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "int4_channel_alpha",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_74": {
+      "arm_label": "expert_periodic_hp_n2",
+      "block_output_cosine": [
+        0.963572,
+        0.963211,
+        0.90536,
+        0.882308
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.5292121735722244,
+      "decision": 2,
+      "expert_load_js_bits": [
+        0.0,
+        0.005559,
+        0.008548,
+        0.025243
+      ],
+      "pack_names": {
+        "0": "block_000-attention_plus_expert.goz1",
+        "1": "block_001-attention_plus_expert.goz1",
+        "2": "block_002-attention_plus_expert.goz1",
+        "3": "block_003-attention_plus_expert.goz1"
+      },
+      "pack_sha256": {
+        "0": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "1": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "2": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "3": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302"
+      },
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.279321,
+        0.449088
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.729004,
+        0.547852
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.592773,
+        0.317383
+      ],
+      "source": "reports/grok-1-expert-precision-remedy/ (PR #74 / #73 / RM-362)",
+      "token_seed": 20260806,
+      "tokens": 2048,
+      "top_k": 2
+    },
+    "baseline_76_ceiling": null,
+    "baseline_76_denser": null,
+    "baseline_85": {
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "source": "GH #85 / RM-608 \u2014 protocol lock (Grok-1 max context sequence)",
+      "token_seed": 20260806,
+      "tokens": 8192,
+      "tokens_note": "8192 = Grok-1 published max context (causal sequence). Vocab size 131072 is the sampler ceiling only \u2014 not a valid T for dense attention in this harness.",
+      "top_k": 2
+    },
+    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
+    "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "evidence_role": "secondary; no independent decision",
+    "implementation": {
+      "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
+      "dirty": false
+    },
+    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
+    "metrics_filename": "metrics.json",
+    "metrics_note": "#85 protocol (Grok-1 max context tokens=8192). #72/#80 2048-token figures are historical cites only; not same-budget and not a validation failure.",
+    "model": "OpenAI Codex",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy-v4/progress-int4-baseline.json
+++ b/reports/grok-1-expert-precision-remedy-v4/progress-int4-baseline.json
@@ -1,81 +1,33 @@
 {
   "arm": "int4",
-  "protocol": {
-    "tokens": 8192,
-    "seed": 20260806,
-    "blocks": [
-      0,
-      1,
-      2,
-      3
-    ],
-    "top_k": 2
-  },
+  "arm_label": "expert_int4",
+  "completed_blocks": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "current_block": 3,
+  "hp_blocks": [],
   "implementation": {
     "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
     "dirty": false
   },
   "input_identity": {
-    "npy_root": "<NPY_ROOT>",
-    "npy_pattern": "goz68-block_{block:03d}-attn",
-    "pack_root": "<PACK_ROOT>",
-    "pack_pattern": "block_{block:03d}-attention_plus_expert.goz1",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
     "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
-    "int4_side_root": "<INT4_SIDE_ROOT>"
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "int4_side_root": "<INT4_SIDE_ROOT>",
+    "npy_pattern": "goz68-block_{block:03d}-attn",
+    "npy_root": "<NPY_ROOT>",
+    "pack_pattern": "block_{block:03d}-attention_plus_expert.goz1",
+    "pack_root": "<PACK_ROOT>"
   },
-  "provenance_identity": {
-    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
-    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
-    "model": "OpenAI Codex",
-    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle"
-  },
-  "arm_label": "expert_int4",
-  "hp_blocks": [],
   "pack_provenance": [
     {
       "block": 0,
-      "pack": "block_000-attention_plus_expert.goz1",
-      "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_000-attn",
-      "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_000.slot_01.moe_expert.down": "research_int4_side",
-        "block_000.slot_00.moe_expert.gate": "research_int4_side",
-        "block_000.slot_02.moe_expert.up": "research_int4_side"
-      },
-      "pack_scale_sources": {
-        "block_000.slot_01.moe_expert.down": "pack_v2",
-        "block_000.slot_00.moe_expert.gate": "pack_v2",
-        "block_000.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_000.slot_00.moe_expert.gate": {
-          "alpha": 0.03446429222822189,
-          "sparsity": 0.652848777671655,
-          "fired": 559126180,
-          "total": 1610612736
-        },
-        "block_000.slot_01.moe_expert.down": {
-          "alpha": 0.02270425483584404,
-          "sparsity": 0.6372781544923782,
-          "fired": 584204424,
-          "total": 1610612736
-        },
-        "block_000.slot_02.moe_expert.up": {
-          "alpha": 0.0343967042863369,
-          "sparsity": 0.6443704627454281,
-          "fired": 572781462,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_000.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -106,53 +58,53 @@
           "threshold_abs": 0.004230931401252747
         }
       },
+      "npy_dir": "goz68-block_000-attn",
+      "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
+      "pack": "block_000-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_000.slot_00.moe_expert.gate": "pack_v2",
+        "block_000.slot_01.moe_expert.down": "pack_v2",
+        "block_000.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+      "scale_sources": {
+        "block_000.slot_00.moe_expert.gate": "research_int4_side",
+        "block_000.slot_01.moe_expert.down": "research_int4_side",
+        "block_000.slot_02.moe_expert.up": "research_int4_side"
+      },
+      "ternary_scales": {
+        "block_000.slot_00.moe_expert.gate": {
+          "alpha": 0.03446429222822189,
+          "fired": 559126180,
+          "sparsity": 0.652848777671655,
+          "total": 1610612736
+        },
+        "block_000.slot_01.moe_expert.down": {
+          "alpha": 0.02270425483584404,
+          "fired": 584204424,
+          "sparsity": 0.6372781544923782,
+          "total": 1610612736
+        },
+        "block_000.slot_02.moe_expert.up": {
+          "alpha": 0.0343967042863369,
+          "fired": 572781462,
+          "sparsity": 0.6443704627454281,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 1,
-      "pack": "block_001-attention_plus_expert.goz1",
-      "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_001-attn",
-      "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_001.slot_01.moe_expert.down": "research_int4_side",
-        "block_001.slot_00.moe_expert.gate": "research_int4_side",
-        "block_001.slot_02.moe_expert.up": "research_int4_side"
-      },
-      "pack_scale_sources": {
-        "block_001.slot_01.moe_expert.down": "pack_v2",
-        "block_001.slot_00.moe_expert.gate": "pack_v2",
-        "block_001.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_001.slot_00.moe_expert.gate": {
-          "alpha": 0.04331796243786812,
-          "sparsity": 0.633674278234442,
-          "fired": 590008873,
-          "total": 1610612736
-        },
-        "block_001.slot_01.moe_expert.down": {
-          "alpha": 0.010844916105270386,
-          "sparsity": 0.6404839977622032,
-          "fired": 579041052,
-          "total": 1610612736
-        },
-        "block_001.slot_02.moe_expert.up": {
-          "alpha": 0.04337596148252487,
-          "sparsity": 0.6348795853555202,
-          "fired": 588067590,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_001.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -183,53 +135,53 @@
           "threshold_abs": 0.007041923236101866
         }
       },
+      "npy_dir": "goz68-block_001-attn",
+      "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
+      "pack": "block_001-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_001.slot_00.moe_expert.gate": "pack_v2",
+        "block_001.slot_01.moe_expert.down": "pack_v2",
+        "block_001.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+      "scale_sources": {
+        "block_001.slot_00.moe_expert.gate": "research_int4_side",
+        "block_001.slot_01.moe_expert.down": "research_int4_side",
+        "block_001.slot_02.moe_expert.up": "research_int4_side"
+      },
+      "ternary_scales": {
+        "block_001.slot_00.moe_expert.gate": {
+          "alpha": 0.04331796243786812,
+          "fired": 590008873,
+          "sparsity": 0.633674278234442,
+          "total": 1610612736
+        },
+        "block_001.slot_01.moe_expert.down": {
+          "alpha": 0.010844916105270386,
+          "fired": 579041052,
+          "sparsity": 0.6404839977622032,
+          "total": 1610612736
+        },
+        "block_001.slot_02.moe_expert.up": {
+          "alpha": 0.04337596148252487,
+          "fired": 588067590,
+          "sparsity": 0.6348795853555202,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 2,
-      "pack": "block_002-attention_plus_expert.goz1",
-      "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_002-attn",
-      "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_002.slot_01.moe_expert.down": "research_int4_side",
-        "block_002.slot_00.moe_expert.gate": "research_int4_side",
-        "block_002.slot_02.moe_expert.up": "research_int4_side"
-      },
-      "pack_scale_sources": {
-        "block_002.slot_01.moe_expert.down": "pack_v2",
-        "block_002.slot_00.moe_expert.gate": "pack_v2",
-        "block_002.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_002.slot_00.moe_expert.gate": {
-          "alpha": 0.047630175948143005,
-          "sparsity": 0.6356016273299854,
-          "fired": 586904660,
-          "total": 1610612736
-        },
-        "block_002.slot_01.moe_expert.down": {
-          "alpha": 0.022462978959083557,
-          "sparsity": 0.6368899804850419,
-          "fired": 584829622,
-          "total": 1610612736
-        },
-        "block_002.slot_02.moe_expert.up": {
-          "alpha": 0.047669243067502975,
-          "sparsity": 0.6359017888704936,
-          "fired": 586421216,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_002.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -260,53 +212,53 @@
           "threshold_abs": 0.01309292297810316
         }
       },
+      "npy_dir": "goz68-block_002-attn",
+      "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
+      "pack": "block_002-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_002.slot_00.moe_expert.gate": "pack_v2",
+        "block_002.slot_01.moe_expert.down": "pack_v2",
+        "block_002.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+      "scale_sources": {
+        "block_002.slot_00.moe_expert.gate": "research_int4_side",
+        "block_002.slot_01.moe_expert.down": "research_int4_side",
+        "block_002.slot_02.moe_expert.up": "research_int4_side"
+      },
+      "ternary_scales": {
+        "block_002.slot_00.moe_expert.gate": {
+          "alpha": 0.047630175948143005,
+          "fired": 586904660,
+          "sparsity": 0.6356016273299854,
+          "total": 1610612736
+        },
+        "block_002.slot_01.moe_expert.down": {
+          "alpha": 0.022462978959083557,
+          "fired": 584829622,
+          "sparsity": 0.6368899804850419,
+          "total": 1610612736
+        },
+        "block_002.slot_02.moe_expert.up": {
+          "alpha": 0.047669243067502975,
+          "fired": 586421216,
+          "sparsity": 0.6359017888704936,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 3,
-      "pack": "block_003-attention_plus_expert.goz1",
-      "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_003-attn",
-      "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_003.slot_01.moe_expert.down": "research_int4_side",
-        "block_003.slot_00.moe_expert.gate": "research_int4_side",
-        "block_003.slot_02.moe_expert.up": "research_int4_side"
-      },
-      "pack_scale_sources": {
-        "block_003.slot_01.moe_expert.down": "pack_v2",
-        "block_003.slot_00.moe_expert.gate": "pack_v2",
-        "block_003.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_003.slot_00.moe_expert.gate": {
-          "alpha": 0.03307119756937027,
-          "sparsity": 0.6364477450648944,
-          "fired": 585541892,
-          "total": 1610612736
-        },
-        "block_003.slot_01.moe_expert.down": {
-          "alpha": 0.015412655659019947,
-          "sparsity": 0.6372132208198309,
-          "fired": 584309007,
-          "total": 1610612736
-        },
-        "block_003.slot_02.moe_expert.up": {
-          "alpha": 0.033106379210948944,
-          "sparsity": 0.6368649223198493,
-          "fired": 584869981,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_003.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -337,20 +289,68 @@
           "threshold_abs": 0.0016606772551313043
         }
       },
+      "npy_dir": "goz68-block_003-attn",
+      "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
+      "pack": "block_003-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_003.slot_00.moe_expert.gate": "pack_v2",
+        "block_003.slot_01.moe_expert.down": "pack_v2",
+        "block_003.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+      "scale_sources": {
+        "block_003.slot_00.moe_expert.gate": "research_int4_side",
+        "block_003.slot_01.moe_expert.down": "research_int4_side",
+        "block_003.slot_02.moe_expert.up": "research_int4_side"
+      },
+      "ternary_scales": {
+        "block_003.slot_00.moe_expert.gate": {
+          "alpha": 0.03307119756937027,
+          "fired": 585541892,
+          "sparsity": 0.6364477450648944,
+          "total": 1610612736
+        },
+        "block_003.slot_01.moe_expert.down": {
+          "alpha": 0.015412655659019947,
+          "fired": 584309007,
+          "sparsity": 0.6372132208198309,
+          "total": 1610612736
+        },
+        "block_003.slot_02.moe_expert.up": {
+          "alpha": 0.033106379210948944,
+          "fired": 584869981,
+          "sparsity": 0.6368649223198493,
+          "total": 1610612736
+        }
       }
     }
   ],
-  "status": "running",
-  "current_block": 3,
-  "completed_blocks": [
-    0,
-    1,
-    2,
-    3
-  ]
+  "protocol": {
+    "blocks": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "seed": 20260806,
+    "tokens": 8192,
+    "top_k": 2
+  },
+  "provenance_identity": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
+    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
+    "model": "OpenAI Codex",
+    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle"
+  },
+  "status": "running"
 }

--- a/reports/grok-1-expert-precision-remedy-v4/progress-int4-channel-alpha-123.json
+++ b/reports/grok-1-expert-precision-remedy-v4/progress-int4-channel-alpha-123.json
@@ -1,85 +1,37 @@
 {
   "arm": "int4_channel_alpha",
-  "protocol": {
-    "tokens": 8192,
-    "seed": 20260806,
-    "blocks": [
-      0,
-      1,
-      2,
-      3
-    ],
-    "top_k": 2
-  },
-  "implementation": {
-    "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
-    "dirty": false
-  },
-  "input_identity": {
-    "npy_root": "<NPY_ROOT>",
-    "npy_pattern": "goz68-block_{block:03d}-attn",
-    "pack_root": "<PACK_ROOT>",
-    "pack_pattern": "block_{block:03d}-attention_plus_expert.goz1",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
-    "int4_side_root": "<INT4_SIDE_ROOT>"
-  },
-  "provenance_identity": {
-    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
-    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
-    "model": "OpenAI Codex",
-    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle"
-  },
   "arm_label": "expert_int4_channel_alpha_123",
+  "completed_blocks": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "current_block": 3,
   "hp_blocks": [
     1,
     2,
     3
   ],
+  "implementation": {
+    "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
+    "dirty": false
+  },
+  "input_identity": {
+    "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "int4_side_root": "<INT4_SIDE_ROOT>",
+    "npy_pattern": "goz68-block_{block:03d}-attn",
+    "npy_root": "<NPY_ROOT>",
+    "pack_pattern": "block_{block:03d}-attention_plus_expert.goz1",
+    "pack_root": "<PACK_ROOT>"
+  },
   "pack_provenance": [
     {
       "block": 0,
-      "pack": "block_000-attention_plus_expert.goz1",
-      "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_000-attn",
-      "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_000.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
-        "block_000.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
-        "block_000.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
-      },
-      "pack_scale_sources": {
-        "block_000.slot_01.moe_expert.down": "pack_v2",
-        "block_000.slot_00.moe_expert.gate": "pack_v2",
-        "block_000.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_000.slot_00.moe_expert.gate": {
-          "alpha": 0.03446429222822189,
-          "sparsity": 0.652848777671655,
-          "fired": 559126180,
-          "total": 1610612736
-        },
-        "block_000.slot_01.moe_expert.down": {
-          "alpha": 0.02270425483584404,
-          "sparsity": 0.6372781544923782,
-          "fired": 584204424,
-          "total": 1610612736
-        },
-        "block_000.slot_02.moe_expert.up": {
-          "alpha": 0.0343967042863369,
-          "sparsity": 0.6443704627454281,
-          "fired": 572781462,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_000.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -110,53 +62,53 @@
           "threshold_abs": 0.004230931401252747
         }
       },
+      "npy_dir": "goz68-block_000-attn",
+      "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
+      "pack": "block_000-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_000.slot_00.moe_expert.gate": "pack_v2",
+        "block_000.slot_01.moe_expert.down": "pack_v2",
+        "block_000.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+      "scale_sources": {
+        "block_000.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
+        "block_000.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
+        "block_000.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
+      },
+      "ternary_scales": {
+        "block_000.slot_00.moe_expert.gate": {
+          "alpha": 0.03446429222822189,
+          "fired": 559126180,
+          "sparsity": 0.652848777671655,
+          "total": 1610612736
+        },
+        "block_000.slot_01.moe_expert.down": {
+          "alpha": 0.02270425483584404,
+          "fired": 584204424,
+          "sparsity": 0.6372781544923782,
+          "total": 1610612736
+        },
+        "block_000.slot_02.moe_expert.up": {
+          "alpha": 0.0343967042863369,
+          "fired": 572781462,
+          "sparsity": 0.6443704627454281,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 1,
-      "pack": "block_001-attention_plus_expert.goz1",
-      "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_001-attn",
-      "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_001.slot_01.moe_expert.down": "fp16_control",
-        "block_001.slot_00.moe_expert.gate": "fp16_control",
-        "block_001.slot_02.moe_expert.up": "fp16_control"
-      },
-      "pack_scale_sources": {
-        "block_001.slot_01.moe_expert.down": "pack_v2",
-        "block_001.slot_00.moe_expert.gate": "pack_v2",
-        "block_001.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_001.slot_00.moe_expert.gate": {
-          "alpha": 0.04331796243786812,
-          "sparsity": 0.633674278234442,
-          "fired": 590008873,
-          "total": 1610612736
-        },
-        "block_001.slot_01.moe_expert.down": {
-          "alpha": 0.010844916105270386,
-          "sparsity": 0.6404839977622032,
-          "fired": 579041052,
-          "total": 1610612736
-        },
-        "block_001.slot_02.moe_expert.up": {
-          "alpha": 0.04337596148252487,
-          "sparsity": 0.6348795853555202,
-          "fired": 588067590,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_001.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -187,53 +139,53 @@
           "threshold_abs": 0.007041923236101866
         }
       },
+      "npy_dir": "goz68-block_001-attn",
+      "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
+      "pack": "block_001-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_001.slot_00.moe_expert.gate": "pack_v2",
+        "block_001.slot_01.moe_expert.down": "pack_v2",
+        "block_001.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+      "scale_sources": {
+        "block_001.slot_00.moe_expert.gate": "fp16_control",
+        "block_001.slot_01.moe_expert.down": "fp16_control",
+        "block_001.slot_02.moe_expert.up": "fp16_control"
+      },
+      "ternary_scales": {
+        "block_001.slot_00.moe_expert.gate": {
+          "alpha": 0.04331796243786812,
+          "fired": 590008873,
+          "sparsity": 0.633674278234442,
+          "total": 1610612736
+        },
+        "block_001.slot_01.moe_expert.down": {
+          "alpha": 0.010844916105270386,
+          "fired": 579041052,
+          "sparsity": 0.6404839977622032,
+          "total": 1610612736
+        },
+        "block_001.slot_02.moe_expert.up": {
+          "alpha": 0.04337596148252487,
+          "fired": 588067590,
+          "sparsity": 0.6348795853555202,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 2,
-      "pack": "block_002-attention_plus_expert.goz1",
-      "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_002-attn",
-      "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_002.slot_01.moe_expert.down": "fp16_control",
-        "block_002.slot_00.moe_expert.gate": "fp16_control",
-        "block_002.slot_02.moe_expert.up": "fp16_control"
-      },
-      "pack_scale_sources": {
-        "block_002.slot_01.moe_expert.down": "pack_v2",
-        "block_002.slot_00.moe_expert.gate": "pack_v2",
-        "block_002.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_002.slot_00.moe_expert.gate": {
-          "alpha": 0.047630175948143005,
-          "sparsity": 0.6356016273299854,
-          "fired": 586904660,
-          "total": 1610612736
-        },
-        "block_002.slot_01.moe_expert.down": {
-          "alpha": 0.022462978959083557,
-          "sparsity": 0.6368899804850419,
-          "fired": 584829622,
-          "total": 1610612736
-        },
-        "block_002.slot_02.moe_expert.up": {
-          "alpha": 0.047669243067502975,
-          "sparsity": 0.6359017888704936,
-          "fired": 586421216,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_002.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -264,53 +216,53 @@
           "threshold_abs": 0.01309292297810316
         }
       },
+      "npy_dir": "goz68-block_002-attn",
+      "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
+      "pack": "block_002-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_002.slot_00.moe_expert.gate": "pack_v2",
+        "block_002.slot_01.moe_expert.down": "pack_v2",
+        "block_002.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+      "scale_sources": {
+        "block_002.slot_00.moe_expert.gate": "fp16_control",
+        "block_002.slot_01.moe_expert.down": "fp16_control",
+        "block_002.slot_02.moe_expert.up": "fp16_control"
+      },
+      "ternary_scales": {
+        "block_002.slot_00.moe_expert.gate": {
+          "alpha": 0.047630175948143005,
+          "fired": 586904660,
+          "sparsity": 0.6356016273299854,
+          "total": 1610612736
+        },
+        "block_002.slot_01.moe_expert.down": {
+          "alpha": 0.022462978959083557,
+          "fired": 584829622,
+          "sparsity": 0.6368899804850419,
+          "total": 1610612736
+        },
+        "block_002.slot_02.moe_expert.up": {
+          "alpha": 0.047669243067502975,
+          "fired": 586421216,
+          "sparsity": 0.6359017888704936,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 3,
-      "pack": "block_003-attention_plus_expert.goz1",
-      "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_003-attn",
-      "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_003.slot_01.moe_expert.down": "fp16_control",
-        "block_003.slot_00.moe_expert.gate": "fp16_control",
-        "block_003.slot_02.moe_expert.up": "fp16_control"
-      },
-      "pack_scale_sources": {
-        "block_003.slot_01.moe_expert.down": "pack_v2",
-        "block_003.slot_00.moe_expert.gate": "pack_v2",
-        "block_003.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_003.slot_00.moe_expert.gate": {
-          "alpha": 0.03307119756937027,
-          "sparsity": 0.6364477450648944,
-          "fired": 585541892,
-          "total": 1610612736
-        },
-        "block_003.slot_01.moe_expert.down": {
-          "alpha": 0.015412655659019947,
-          "sparsity": 0.6372132208198309,
-          "fired": 584309007,
-          "total": 1610612736
-        },
-        "block_003.slot_02.moe_expert.up": {
-          "alpha": 0.033106379210948944,
-          "sparsity": 0.6368649223198493,
-          "fired": 584869981,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_003.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -341,20 +293,68 @@
           "threshold_abs": 0.0016606772551313043
         }
       },
+      "npy_dir": "goz68-block_003-attn",
+      "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
+      "pack": "block_003-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_003.slot_00.moe_expert.gate": "pack_v2",
+        "block_003.slot_01.moe_expert.down": "pack_v2",
+        "block_003.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+      "scale_sources": {
+        "block_003.slot_00.moe_expert.gate": "fp16_control",
+        "block_003.slot_01.moe_expert.down": "fp16_control",
+        "block_003.slot_02.moe_expert.up": "fp16_control"
+      },
+      "ternary_scales": {
+        "block_003.slot_00.moe_expert.gate": {
+          "alpha": 0.03307119756937027,
+          "fired": 585541892,
+          "sparsity": 0.6364477450648944,
+          "total": 1610612736
+        },
+        "block_003.slot_01.moe_expert.down": {
+          "alpha": 0.015412655659019947,
+          "fired": 584309007,
+          "sparsity": 0.6372132208198309,
+          "total": 1610612736
+        },
+        "block_003.slot_02.moe_expert.up": {
+          "alpha": 0.033106379210948944,
+          "fired": 584869981,
+          "sparsity": 0.6368649223198493,
+          "total": 1610612736
+        }
       }
     }
   ],
-  "status": "running",
-  "current_block": 3,
-  "completed_blocks": [
-    0,
-    1,
-    2,
-    3
-  ]
+  "protocol": {
+    "blocks": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "seed": 20260806,
+    "tokens": 8192,
+    "top_k": 2
+  },
+  "provenance_identity": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
+    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
+    "model": "OpenAI Codex",
+    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle"
+  },
+  "status": "running"
 }

--- a/reports/grok-1-expert-precision-remedy-v4/progress-int4-channel-alpha.json
+++ b/reports/grok-1-expert-precision-remedy-v4/progress-int4-channel-alpha.json
@@ -1,81 +1,33 @@
 {
   "arm": "int4_channel_alpha",
-  "protocol": {
-    "tokens": 8192,
-    "seed": 20260806,
-    "blocks": [
-      0,
-      1,
-      2,
-      3
-    ],
-    "top_k": 2
-  },
+  "arm_label": "expert_int4_channel_alpha",
+  "completed_blocks": [
+    0,
+    1,
+    2,
+    3
+  ],
+  "current_block": 3,
+  "hp_blocks": [],
   "implementation": {
     "commit": "a159d89df1dbe2374b56a1c43ec2b4ac80dbe82e",
     "dirty": false
   },
   "input_identity": {
-    "npy_root": "<NPY_ROOT>",
-    "npy_pattern": "goz68-block_{block:03d}-attn",
-    "pack_root": "<PACK_ROOT>",
-    "pack_pattern": "block_{block:03d}-attention_plus_expert.goz1",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
     "embedding_sha256": "55ec19a8fdd45960579514bf471e8f5cba24436cdc3f6e9e6bcd3a004ed863f6",
-    "int4_side_root": "<INT4_SIDE_ROOT>"
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "int4_side_root": "<INT4_SIDE_ROOT>",
+    "npy_pattern": "goz68-block_{block:03d}-attn",
+    "npy_root": "<NPY_ROOT>",
+    "pack_pattern": "block_{block:03d}-attention_plus_expert.goz1",
+    "pack_root": "<PACK_ROOT>"
   },
-  "provenance_identity": {
-    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
-    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
-    "model": "OpenAI Codex",
-    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle"
-  },
-  "arm_label": "expert_int4_channel_alpha",
-  "hp_blocks": [],
   "pack_provenance": [
     {
       "block": 0,
-      "pack": "block_000-attention_plus_expert.goz1",
-      "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_000-attn",
-      "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_000.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
-        "block_000.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
-        "block_000.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
-      },
-      "pack_scale_sources": {
-        "block_000.slot_01.moe_expert.down": "pack_v2",
-        "block_000.slot_00.moe_expert.gate": "pack_v2",
-        "block_000.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_000.slot_00.moe_expert.gate": {
-          "alpha": 0.03446429222822189,
-          "sparsity": 0.652848777671655,
-          "fired": 559126180,
-          "total": 1610612736
-        },
-        "block_000.slot_01.moe_expert.down": {
-          "alpha": 0.02270425483584404,
-          "sparsity": 0.6372781544923782,
-          "fired": 584204424,
-          "total": 1610612736
-        },
-        "block_000.slot_02.moe_expert.up": {
-          "alpha": 0.0343967042863369,
-          "sparsity": 0.6443704627454281,
-          "fired": 572781462,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_000.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -106,53 +58,53 @@
           "threshold_abs": 0.004230931401252747
         }
       },
+      "npy_dir": "goz68-block_000-attn",
+      "npy_sha256": "42ccd9c9a98a6a222d95a157f72e49c0364624f89074c7a7a381cf3cdcf6aa9b",
+      "pack": "block_000-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_000.slot_00.moe_expert.gate": "pack_v2",
+        "block_000.slot_01.moe_expert.down": "pack_v2",
+        "block_000.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+      "scale_sources": {
+        "block_000.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
+        "block_000.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
+        "block_000.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
+      },
+      "ternary_scales": {
+        "block_000.slot_00.moe_expert.gate": {
+          "alpha": 0.03446429222822189,
+          "fired": 559126180,
+          "sparsity": 0.652848777671655,
+          "total": 1610612736
+        },
+        "block_000.slot_01.moe_expert.down": {
+          "alpha": 0.02270425483584404,
+          "fired": 584204424,
+          "sparsity": 0.6372781544923782,
+          "total": 1610612736
+        },
+        "block_000.slot_02.moe_expert.up": {
+          "alpha": 0.0343967042863369,
+          "fired": 572781462,
+          "sparsity": 0.6443704627454281,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 1,
-      "pack": "block_001-attention_plus_expert.goz1",
-      "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_001-attn",
-      "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_001.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
-        "block_001.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
-        "block_001.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
-      },
-      "pack_scale_sources": {
-        "block_001.slot_01.moe_expert.down": "pack_v2",
-        "block_001.slot_00.moe_expert.gate": "pack_v2",
-        "block_001.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_001.slot_00.moe_expert.gate": {
-          "alpha": 0.04331796243786812,
-          "sparsity": 0.633674278234442,
-          "fired": 590008873,
-          "total": 1610612736
-        },
-        "block_001.slot_01.moe_expert.down": {
-          "alpha": 0.010844916105270386,
-          "sparsity": 0.6404839977622032,
-          "fired": 579041052,
-          "total": 1610612736
-        },
-        "block_001.slot_02.moe_expert.up": {
-          "alpha": 0.04337596148252487,
-          "sparsity": 0.6348795853555202,
-          "fired": 588067590,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_001.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -183,53 +135,53 @@
           "threshold_abs": 0.007041923236101866
         }
       },
+      "npy_dir": "goz68-block_001-attn",
+      "npy_sha256": "fada26dbc8f2c330d01f9e6b18c4384d35850e55c52ae1b5162885a9d7cdd181",
+      "pack": "block_001-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_001.slot_00.moe_expert.gate": "pack_v2",
+        "block_001.slot_01.moe_expert.down": "pack_v2",
+        "block_001.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+      "scale_sources": {
+        "block_001.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
+        "block_001.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
+        "block_001.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
+      },
+      "ternary_scales": {
+        "block_001.slot_00.moe_expert.gate": {
+          "alpha": 0.04331796243786812,
+          "fired": 590008873,
+          "sparsity": 0.633674278234442,
+          "total": 1610612736
+        },
+        "block_001.slot_01.moe_expert.down": {
+          "alpha": 0.010844916105270386,
+          "fired": 579041052,
+          "sparsity": 0.6404839977622032,
+          "total": 1610612736
+        },
+        "block_001.slot_02.moe_expert.up": {
+          "alpha": 0.04337596148252487,
+          "fired": 588067590,
+          "sparsity": 0.6348795853555202,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 2,
-      "pack": "block_002-attention_plus_expert.goz1",
-      "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_002-attn",
-      "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_002.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
-        "block_002.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
-        "block_002.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
-      },
-      "pack_scale_sources": {
-        "block_002.slot_01.moe_expert.down": "pack_v2",
-        "block_002.slot_00.moe_expert.gate": "pack_v2",
-        "block_002.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_002.slot_00.moe_expert.gate": {
-          "alpha": 0.047630175948143005,
-          "sparsity": 0.6356016273299854,
-          "fired": 586904660,
-          "total": 1610612736
-        },
-        "block_002.slot_01.moe_expert.down": {
-          "alpha": 0.022462978959083557,
-          "sparsity": 0.6368899804850419,
-          "fired": 584829622,
-          "total": 1610612736
-        },
-        "block_002.slot_02.moe_expert.up": {
-          "alpha": 0.047669243067502975,
-          "sparsity": 0.6359017888704936,
-          "fired": 586421216,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_002.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -260,53 +212,53 @@
           "threshold_abs": 0.01309292297810316
         }
       },
+      "npy_dir": "goz68-block_002-attn",
+      "npy_sha256": "5e9a15c0de698645f82491a1b3e5118f1230f39751fc513303dffb0067f55c7f",
+      "pack": "block_002-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_002.slot_00.moe_expert.gate": "pack_v2",
+        "block_002.slot_01.moe_expert.down": "pack_v2",
+        "block_002.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+      "scale_sources": {
+        "block_002.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
+        "block_002.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
+        "block_002.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
+      },
+      "ternary_scales": {
+        "block_002.slot_00.moe_expert.gate": {
+          "alpha": 0.047630175948143005,
+          "fired": 586904660,
+          "sparsity": 0.6356016273299854,
+          "total": 1610612736
+        },
+        "block_002.slot_01.moe_expert.down": {
+          "alpha": 0.022462978959083557,
+          "fired": 584829622,
+          "sparsity": 0.6368899804850419,
+          "total": 1610612736
+        },
+        "block_002.slot_02.moe_expert.up": {
+          "alpha": 0.047669243067502975,
+          "fired": 586421216,
+          "sparsity": 0.6359017888704936,
+          "total": 1610612736
+        }
       }
     },
     {
       "block": 3,
-      "pack": "block_003-attention_plus_expert.goz1",
-      "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-      "pack_bytes": 1230128768,
-      "npy_dir": "goz68-block_003-attn",
-      "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
       "container_versions": [
         3
       ],
-      "scale_sources": {
-        "block_003.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
-        "block_003.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
-        "block_003.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
-      },
-      "pack_scale_sources": {
-        "block_003.slot_01.moe_expert.down": "pack_v2",
-        "block_003.slot_00.moe_expert.gate": "pack_v2",
-        "block_003.slot_02.moe_expert.up": "pack_v2"
-      },
-      "ternary_scales": {
-        "block_003.slot_00.moe_expert.gate": {
-          "alpha": 0.03307119756937027,
-          "sparsity": 0.6364477450648944,
-          "fired": 585541892,
-          "total": 1610612736
-        },
-        "block_003.slot_01.moe_expert.down": {
-          "alpha": 0.015412655659019947,
-          "sparsity": 0.6372132208198309,
-          "fired": 584309007,
-          "total": 1610612736
-        },
-        "block_003.slot_02.moe_expert.up": {
-          "alpha": 0.033106379210948944,
-          "sparsity": 0.6368649223198493,
-          "fired": 584869981,
-          "total": 1610612736
-        }
-      },
       "gif_thresholds": {
         "block_003.slot_00.moe_expert.gate": {
           "gif_threshold": 0.8999999761581421,
@@ -337,20 +289,68 @@
           "threshold_abs": 0.0016606772551313043
         }
       },
+      "npy_dir": "goz68-block_003-attn",
+      "npy_sha256": "39322c3f8ae0f13313439faa8dd5a54edc102310cb0f8c03cf131b87bf5909e7",
+      "pack": "block_003-attention_plus_expert.goz1",
+      "pack_bytes": 1230128768,
       "pack_metadata": {
-        "oz.quantization_version": 3,
         "oz.gif_threshold": "0.05",
         "oz.gif_threshold_authority": "tensor_row",
-        "oz.gif_threshold_scope": "baseline_only_not_applied"
+        "oz.gif_threshold_scope": "baseline_only_not_applied",
+        "oz.quantization_version": 3
+      },
+      "pack_scale_sources": {
+        "block_003.slot_00.moe_expert.gate": "pack_v2",
+        "block_003.slot_01.moe_expert.down": "pack_v2",
+        "block_003.slot_02.moe_expert.up": "pack_v2"
+      },
+      "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+      "scale_sources": {
+        "block_003.slot_00.moe_expert.gate": "research_int4_channel_alpha_side",
+        "block_003.slot_01.moe_expert.down": "research_int4_channel_alpha_side",
+        "block_003.slot_02.moe_expert.up": "research_int4_channel_alpha_side"
+      },
+      "ternary_scales": {
+        "block_003.slot_00.moe_expert.gate": {
+          "alpha": 0.03307119756937027,
+          "fired": 585541892,
+          "sparsity": 0.6364477450648944,
+          "total": 1610612736
+        },
+        "block_003.slot_01.moe_expert.down": {
+          "alpha": 0.015412655659019947,
+          "fired": 584309007,
+          "sparsity": 0.6372132208198309,
+          "total": 1610612736
+        },
+        "block_003.slot_02.moe_expert.up": {
+          "alpha": 0.033106379210948944,
+          "fired": 584869981,
+          "sparsity": 0.6368649223198493,
+          "total": 1610612736
+        }
       }
     }
   ],
-  "status": "running",
-  "current_block": 3,
-  "completed_blocks": [
-    0,
-    1,
-    2,
-    3
-  ]
+  "protocol": {
+    "blocks": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "seed": 20260806,
+    "tokens": 8192,
+    "top_k": 2
+  },
+  "provenance_identity": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Codex (OpenAI) \u00b7 Issue: #85 / Linear RM-608 \u00b7 beads goz-3h3",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "design": "Grok issue-planning lock: INT4 codes \u00d7 LS channel-\u03b1 stack at Grok-1 max context (8192); re-measure INT4 baseline same-budget; #80@2048 historical only; implementation and evidence by Codex (OpenAI)",
+    "issue": "GH #85 / Linear RM-608 / beads goz-3h3",
+    "model": "OpenAI Codex",
+    "scale_policy": "research_int4_channel_alpha_side: INT4 codes \u00d7 LS channel-\u03b1 scales; absmax INT4 baseline uses research_int4_side; abort on legacy_oracle"
+  },
+  "status": "running"
 }

--- a/reports/grok-1-expert-precision-remedy-v4/run-int4-baseline-8192.log
+++ b/reports/grok-1-expert-precision-remedy-v4/run-int4-baseline-8192.log
@@ -1,0 +1,1 @@
+== block 000  residual_in shape=(8192, 6144)

--- a/reports/grok-1-expert-precision-remedy/metrics-channel_alpha.json
+++ b/reports/grok-1-expert-precision-remedy/metrics-channel_alpha.json
@@ -1,956 +1,34 @@
 {
-  "provenance": {
-    "issue": "GH #73 / Linear RM-362",
-    "agent": "Grok Build: Grok 4.5 (xAI) \u00b7 Model: Grok-4.5 (high) \u00b7 Issue: #73 / Linear RM-362",
-    "model": "Grok-4.5 (high)",
-    "design": "Grok Build design lock: arms C (periodic HP) and A (channel \u03b1 side-table)",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only"
-    },
-    "implementation": {
-      "commit": "352b2c791f8c2021a1ca5f4bcddb94ad3af458fb",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-    "arm": "channel_alpha",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (bit-identical seed/tokens/packs)."
-  },
   "chain": {
+    "arm_label": "research_per_channel_side",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 18.705220222473145,
-        "expert_only": {
-          "label": "research_per_channel_side",
-          "seconds": 52.15810227394104,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.8575021325175156,
-          "block_output_cosine": 0.9726518418824985,
-          "block_output_cosine_per_token": 0.9711405779244828,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.23605952988625684,
-          "attn_delta_over_stream": 0.876171414302045,
-          "moe_delta_over_stream": 0.5075108767930497,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030204767217204893,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.006170911132304002,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 26.173985481262207,
-          "attention_output_cosine": 0.9999999984424572,
-          "attention_output_cosine_per_token": 0.9999999986030829,
-          "residual_stream_cosine": 0.9999999831365632,
-          "moe_input_normalized_cosine": 0.9999999606124855,
-          "router_logit_cosine": 0.9999999971511485,
-          "moe_output_cosine": 0.9999813002410165,
-          "block_output_cosine": 0.9999870040318545,
-          "block_output_cosine_per_token": 0.9999880581321908,
-          "residual_drift_relative_norm": 0.00021537234101925558,
-          "block_output_drift_relative_norm": 0.005098830221729304,
-          "attn_delta_over_stream": 0.8760054853350859,
-          "moe_delta_over_stream": 0.482784499720899,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030207654444896787,
-          "router_margin_mean_delta": 2.8872276918900968e-06,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.0061808020273402264,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "research_per_channel_side"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 17.26996350288391,
-        "expert_only": {
-          "label": "research_per_channel_side",
-          "seconds": 116.0497362613678,
-          "attention_output_cosine": 0.9537457156673946,
-          "attention_output_cosine_per_token": 0.9547903753451848,
-          "residual_stream_cosine": 0.975650816741865,
-          "moe_input_normalized_cosine": 0.9601410677087391,
-          "router_logit_cosine": 0.9955318340337534,
-          "moe_output_cosine": 0.8347619044786736,
-          "block_output_cosine": 0.9600927819414423,
-          "block_output_cosine_per_token": 0.958778070515431,
-          "residual_drift_relative_norm": 0.2222674144249521,
-          "block_output_drift_relative_norm": 0.2821252125246301,
-          "attn_delta_over_stream": 0.3751567865863136,
-          "moe_delta_over_stream": 0.2816794273870807,
-          "router_top1_agreement": 0.9052734375,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.7041015625,
-          "router_top2_set_agreement": 0.7041015625,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.167724609375,
-            0.11767578125,
-            0.117431640625,
-            0.065185546875,
-            0.128173828125,
-            0.187255859375,
-            0.103271484375,
-            0.11328125
-          ],
-          "expert_load_js_bits": 0.004022827027534971,
-          "expert_load_max_abs_delta": 0.03173828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18998075964725553,
-          "router_margin_mean_delta": 0.007031238266256821,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15411157062482517,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 47,
-              "top1_flip_rate": 0.4895833333333333
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 100,
-              "top1_flip_rate": 0.3105590062111801
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 44,
-              "top1_flip_rate": 0.07419898819561552
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 3,
-              "top1_flip_rate": 0.003121748178980229
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9726518418824985,
-            "residual_in_drift_relative_norm": 0.23605952988625684
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 24.42089557647705,
-          "attention_output_cosine": 0.9999955239311591,
-          "attention_output_cosine_per_token": 0.9999949975985942,
-          "residual_stream_cosine": 0.9999902372591066,
-          "moe_input_normalized_cosine": 0.9999833030390249,
-          "router_logit_cosine": 0.9999982162936869,
-          "moe_output_cosine": 0.9999664606659787,
-          "block_output_cosine": 0.9999859463222839,
-          "block_output_cosine_per_token": 0.9999851320664912,
-          "residual_drift_relative_norm": 0.0044204095195649025,
-          "block_output_drift_relative_norm": 0.005302552236880725,
-          "attn_delta_over_stream": 0.3961794228342294,
-          "moe_delta_over_stream": 0.2896839054949744,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18297782060234993,
-          "router_margin_mean_delta": 2.8299221351235133e-05,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15256866411484876,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040318545,
-            "residual_in_drift_relative_norm": 0.005098830221729304
-          }
-        },
-        "pilot_label": "research_per_channel_side"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 18.66638684272766,
-        "expert_only": {
-          "label": "research_per_channel_side",
-          "seconds": 51.07951521873474,
-          "attention_output_cosine": 0.8891932450584559,
-          "attention_output_cosine_per_token": 0.8889428706246407,
-          "residual_stream_cosine": 0.9598158304522321,
-          "moe_input_normalized_cosine": 0.9096375792574706,
-          "router_logit_cosine": 0.9858454750112352,
-          "moe_output_cosine": 0.7146998135873978,
-          "block_output_cosine": 0.9079562616631467,
-          "block_output_cosine_per_token": 0.9077618806423716,
-          "residual_drift_relative_norm": 0.28710828926893817,
-          "block_output_drift_relative_norm": 0.42882545404308425,
-          "attn_delta_over_stream": 0.6316003927138658,
-          "moe_delta_over_stream": 0.4401584344873611,
-          "router_top1_agreement": 0.71044921875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.576171875,
-          "router_top2_set_agreement": 0.576171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.050537109375,
-            0.133544921875,
-            0.085693359375,
-            0.25439453125,
-            0.05615234375,
-            0.072509765625,
-            0.117919921875,
-            0.229248046875
-          ],
-          "expert_load_js_bits": 0.009103057818254226,
-          "expert_load_max_abs_delta": 0.0546875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.032926145235088106,
-          "router_margin_mean_delta": -0.0028888003319352614,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.023054049147424205,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 248,
-              "top1_flip_rate": 0.5391304347826087
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 319,
-              "top1_flip_rate": 0.3023696682464455
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 26,
-              "top1_flip_rate": 0.050682261208576995
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9600927819414423,
-            "residual_in_drift_relative_norm": 0.2821252125246301
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 23.645471811294556,
-          "attention_output_cosine": 0.9999951789408488,
-          "attention_output_cosine_per_token": 0.9999948156177104,
-          "residual_stream_cosine": 0.999991030697749,
-          "moe_input_normalized_cosine": 0.9999805357628218,
-          "router_logit_cosine": 0.99999830045166,
-          "moe_output_cosine": 0.9998240608794524,
-          "block_output_cosine": 0.9999682697724989,
-          "block_output_cosine_per_token": 0.9999678107548897,
-          "residual_drift_relative_norm": 0.004235465975258782,
-          "block_output_drift_relative_norm": 0.007966186310686194,
-          "attn_delta_over_stream": 0.584956965059082,
-          "moe_delta_over_stream": 0.4112808355956077,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03582240155308043,
-          "router_margin_mean_delta": 7.4559860570678075e-06,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025836218008428474,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463222839,
-            "residual_in_drift_relative_norm": 0.005302552236880725
-          }
-        },
-        "pilot_label": "research_per_channel_side"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 17.219409704208374,
-        "expert_only": {
-          "label": "research_per_channel_side",
-          "seconds": 51.595229387283325,
-          "attention_output_cosine": 0.8059361742721601,
-          "attention_output_cosine_per_token": 0.8052274619283526,
-          "residual_stream_cosine": 0.9268905177113522,
-          "moe_input_normalized_cosine": 0.7800119659835328,
-          "router_logit_cosine": 0.9917596937843725,
-          "moe_output_cosine": 0.6475815600694682,
-          "block_output_cosine": 0.8661685780605771,
-          "block_output_cosine_per_token": 0.8664079732486951,
-          "residual_drift_relative_norm": 0.38528154024160605,
-          "block_output_drift_relative_norm": 0.5641451735503821,
-          "attn_delta_over_stream": 0.52137685236193,
-          "moe_delta_over_stream": 0.3649334904973628,
-          "router_top1_agreement": 0.5634765625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.32568359375,
-          "router_top2_set_agreement": 0.32568359375,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.054443359375,
-            0.09716796875,
-            0.068603515625,
-            0.18505859375,
-            0.342529296875,
-            0.01513671875,
-            0.114990234375,
-            0.1220703125
-          ],
-          "expert_load_js_bits": 0.01710532530986991,
-          "expert_load_max_abs_delta": 0.0791015625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.03736410504431831,
-          "router_margin_mean_delta": -0.006703707920916686,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.02448905168829496,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 283,
-              "top1_flip_rate": 0.672209026128266
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 476,
-              "top1_flip_rate": 0.4817813765182186
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 135,
-              "top1_flip_rate": 0.23767605633802816
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9079562616631467,
-            "residual_in_drift_relative_norm": 0.42882545404308425
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 24.485295057296753,
-          "attention_output_cosine": 0.999967551568842,
-          "attention_output_cosine_per_token": 0.9999677009593164,
-          "residual_stream_cosine": 0.9999786349806121,
-          "moe_input_normalized_cosine": 0.9999317807120685,
-          "router_logit_cosine": 0.9999963366294831,
-          "moe_output_cosine": 0.9996961823732479,
-          "block_output_cosine": 0.9999195401900538,
-          "block_output_cosine_per_token": 0.9999220112059125,
-          "residual_drift_relative_norm": 0.006536817583550683,
-          "block_output_drift_relative_norm": 0.012685837908964355,
-          "attn_delta_over_stream": 0.5008011118859926,
-          "moe_delta_over_stream": 0.35685089524601604,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.04404335021260723,
-          "router_margin_mean_delta": -2.446275262776493e-05,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.029497699031347163,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697724989,
-            "residual_in_drift_relative_norm": 0.007966186310686194
-          }
-        },
-        "pilot_label": "research_per_channel_side"
-      }
-    ],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.8661685780605771,
-        "residual_drift_relative_norm": 0.5641451735503821,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.5641451735503821
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401900538,
-        "residual_drift_relative_norm": 0.012685837908964355,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685837908964355
       }
     },
+    "expert_mode": "channel_alpha",
+    "hp_blocks": [],
+    "hp_period": null,
+    "hp_schedule_prose": null,
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -981,47 +59,47 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1052,47 +130,47 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1123,47 +201,47 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1194,34 +272,886 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171414302045,
+          "block_output_cosine": 0.9726518418824985,
+          "block_output_cosine_per_token": 0.9711405779244828,
+          "block_output_drift_relative_norm": 0.23605952988625684,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_per_channel_side",
+          "moe_delta_over_stream": 0.5075108767930497,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.8575021325175156,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204767217204893,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.006170911132304002,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 52.15810227394104,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984424572,
+          "attention_output_cosine_per_token": 0.9999999986030829,
+          "attn_delta_over_stream": 0.8760054853350859,
+          "block_output_cosine": 0.9999870040318545,
+          "block_output_cosine_per_token": 0.9999880581321908,
+          "block_output_drift_relative_norm": 0.005098830221729304,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.482784499720899,
+          "moe_input_normalized_cosine": 0.9999999606124855,
+          "moe_output_cosine": 0.9999813002410165,
+          "residual_drift_relative_norm": 0.00021537234101925558,
+          "residual_stream_cosine": 0.9999999831365632,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971511485,
+          "router_margin_mean_delta": 2.8872276918900968e-06,
+          "router_margin_mean_observed": 0.030207654444896787,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.0061808020273402264,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 26.173985481262207,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_per_channel_side",
+        "reference_seconds": 18.705220222473145
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9537457156673946,
+          "attention_output_cosine_per_token": 0.9547903753451848,
+          "attn_delta_over_stream": 0.3751567865863136,
+          "block_output_cosine": 0.9600927819414423,
+          "block_output_cosine_per_token": 0.958778070515431,
+          "block_output_drift_relative_norm": 0.2821252125246301,
+          "expert_load_js_bits": 0.004022827027534971,
+          "expert_load_max_abs_delta": 0.03173828125,
+          "expert_load_observed": [
+            0.167724609375,
+            0.11767578125,
+            0.117431640625,
+            0.065185546875,
+            0.128173828125,
+            0.187255859375,
+            0.103271484375,
+            0.11328125
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.4895833333333333,
+              "top1_flips": 47
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.3105590062111801,
+              "top1_flips": 100
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.07419898819561552,
+              "top1_flips": 44
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.003121748178980229,
+              "top1_flips": 3
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_per_channel_side",
+          "moe_delta_over_stream": 0.2816794273870807,
+          "moe_input_normalized_cosine": 0.9601410677087391,
+          "moe_output_cosine": 0.8347619044786736,
+          "residual_drift_relative_norm": 0.2222674144249521,
+          "residual_stream_cosine": 0.975650816741865,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9726518418824985,
+            "residual_in_drift_relative_norm": 0.23605952988625684
+          },
+          "router_logit_cosine": 0.9955318340337534,
+          "router_margin_mean_delta": 0.007031238266256821,
+          "router_margin_mean_observed": 0.18998075964725553,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15411157062482517,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.9052734375,
+          "router_top2_set_agreement": 0.7041015625,
+          "router_topk_set_agreement": 0.7041015625,
+          "seconds": 116.0497362613678,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239311591,
+          "attention_output_cosine_per_token": 0.9999949975985942,
+          "attn_delta_over_stream": 0.3961794228342294,
+          "block_output_cosine": 0.9999859463222839,
+          "block_output_cosine_per_token": 0.9999851320664912,
+          "block_output_drift_relative_norm": 0.005302552236880725,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839054949744,
+          "moe_input_normalized_cosine": 0.9999833030390249,
+          "moe_output_cosine": 0.9999664606659787,
+          "residual_drift_relative_norm": 0.0044204095195649025,
+          "residual_stream_cosine": 0.9999902372591066,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040318545,
+            "residual_in_drift_relative_norm": 0.005098830221729304
+          },
+          "router_logit_cosine": 0.9999982162936869,
+          "router_margin_mean_delta": 2.8299221351235133e-05,
+          "router_margin_mean_observed": 0.18297782060234993,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15256866411484876,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 24.42089557647705,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_per_channel_side",
+        "reference_seconds": 17.26996350288391
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.8891932450584559,
+          "attention_output_cosine_per_token": 0.8889428706246407,
+          "attn_delta_over_stream": 0.6316003927138658,
+          "block_output_cosine": 0.9079562616631467,
+          "block_output_cosine_per_token": 0.9077618806423716,
+          "block_output_drift_relative_norm": 0.42882545404308425,
+          "expert_load_js_bits": 0.009103057818254226,
+          "expert_load_max_abs_delta": 0.0546875,
+          "expert_load_observed": [
+            0.050537109375,
+            0.133544921875,
+            0.085693359375,
+            0.25439453125,
+            0.05615234375,
+            0.072509765625,
+            0.117919921875,
+            0.229248046875
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.5391304347826087,
+              "top1_flips": 248
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.3023696682464455,
+              "top1_flips": 319
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.050682261208576995,
+              "top1_flips": 26
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_per_channel_side",
+          "moe_delta_over_stream": 0.4401584344873611,
+          "moe_input_normalized_cosine": 0.9096375792574706,
+          "moe_output_cosine": 0.7146998135873978,
+          "residual_drift_relative_norm": 0.28710828926893817,
+          "residual_stream_cosine": 0.9598158304522321,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9600927819414423,
+            "residual_in_drift_relative_norm": 0.2821252125246301
+          },
+          "router_logit_cosine": 0.9858454750112352,
+          "router_margin_mean_delta": -0.0028888003319352614,
+          "router_margin_mean_observed": 0.032926145235088106,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.023054049147424205,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.71044921875,
+          "router_top2_set_agreement": 0.576171875,
+          "router_topk_set_agreement": 0.576171875,
+          "seconds": 51.07951521873474,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789408488,
+          "attention_output_cosine_per_token": 0.9999948156177104,
+          "attn_delta_over_stream": 0.584956965059082,
+          "block_output_cosine": 0.9999682697724989,
+          "block_output_cosine_per_token": 0.9999678107548897,
+          "block_output_drift_relative_norm": 0.007966186310686194,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808355956077,
+          "moe_input_normalized_cosine": 0.9999805357628218,
+          "moe_output_cosine": 0.9998240608794524,
+          "residual_drift_relative_norm": 0.004235465975258782,
+          "residual_stream_cosine": 0.999991030697749,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463222839,
+            "residual_in_drift_relative_norm": 0.005302552236880725
+          },
+          "router_logit_cosine": 0.99999830045166,
+          "router_margin_mean_delta": 7.4559860570678075e-06,
+          "router_margin_mean_observed": 0.03582240155308043,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025836218008428474,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 23.645471811294556,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_per_channel_side",
+        "reference_seconds": 18.66638684272766
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.8059361742721601,
+          "attention_output_cosine_per_token": 0.8052274619283526,
+          "attn_delta_over_stream": 0.52137685236193,
+          "block_output_cosine": 0.8661685780605771,
+          "block_output_cosine_per_token": 0.8664079732486951,
+          "block_output_drift_relative_norm": 0.5641451735503821,
+          "expert_load_js_bits": 0.01710532530986991,
+          "expert_load_max_abs_delta": 0.0791015625,
+          "expert_load_observed": [
+            0.054443359375,
+            0.09716796875,
+            0.068603515625,
+            0.18505859375,
+            0.342529296875,
+            0.01513671875,
+            0.114990234375,
+            0.1220703125
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.672209026128266,
+              "top1_flips": 283
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.4817813765182186,
+              "top1_flips": 476
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.23767605633802816,
+              "top1_flips": 135
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "research_per_channel_side",
+          "moe_delta_over_stream": 0.3649334904973628,
+          "moe_input_normalized_cosine": 0.7800119659835328,
+          "moe_output_cosine": 0.6475815600694682,
+          "residual_drift_relative_norm": 0.38528154024160605,
+          "residual_stream_cosine": 0.9268905177113522,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9079562616631467,
+            "residual_in_drift_relative_norm": 0.42882545404308425
+          },
+          "router_logit_cosine": 0.9917596937843725,
+          "router_margin_mean_delta": -0.006703707920916686,
+          "router_margin_mean_observed": 0.03736410504431831,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.02448905168829496,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.5634765625,
+          "router_top2_set_agreement": 0.32568359375,
+          "router_topk_set_agreement": 0.32568359375,
+          "seconds": 51.595229387283325,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.999967551568842,
+          "attention_output_cosine_per_token": 0.9999677009593164,
+          "attn_delta_over_stream": 0.5008011118859926,
+          "block_output_cosine": 0.9999195401900538,
+          "block_output_cosine_per_token": 0.9999220112059125,
+          "block_output_drift_relative_norm": 0.012685837908964355,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.35685089524601604,
+          "moe_input_normalized_cosine": 0.9999317807120685,
+          "moe_output_cosine": 0.9996961823732479,
+          "residual_drift_relative_norm": 0.006536817583550683,
+          "residual_stream_cosine": 0.9999786349806121,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697724989,
+            "residual_in_drift_relative_norm": 0.007966186310686194
+          },
+          "router_logit_cosine": 0.9999963366294831,
+          "router_margin_mean_delta": -2.446275262776493e-05,
+          "router_margin_mean_observed": 0.04404335021260723,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.029497699031347163,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 24.485295057296753,
+          "selected_experts": 2
+        },
+        "pilot_label": "research_per_channel_side",
+        "reference_seconds": 17.219409704208374
+      }
+    ],
+    "pilot_labels_per_block": [
+      "research_per_channel_side",
+      "research_per_channel_side",
+      "research_per_channel_side",
+      "research_per_channel_side"
+    ],
     "skip_fp16_control": false,
-    "expert_mode": "channel_alpha",
-    "hp_period": null,
-    "hp_blocks": [],
     "ternary_blocks": [
       0,
       1,
       2,
       3
     ],
-    "hp_schedule_prose": null,
-    "arm_label": "research_per_channel_side",
-    "pilot_labels_per_block": [
-      "research_per_channel_side",
-      "research_per_channel_side",
-      "research_per_channel_side",
-      "research_per_channel_side"
-    ]
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
   },
   "decision": {
+    "compounding": "roughly_linear",
     "decision": 2,
     "decision_text": "Remedy helps but needs further correction (clear improvement vs #72; residual still compounds).",
     "rationale": [
@@ -1238,7 +1168,77 @@
       "#64 block0 expert-only block_output_cosine baseline=0.963572",
       "#72 baseline chain_exit_drift=0.653886 b3_top1=0.528320 b3_cos=0.839144 (cited, not re-run)",
       "arm=research_per_channel_side"
-    ],
-    "compounding": "roughly_linear"
+    ]
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Grok Build: Grok 4.5 (xAI) \u00b7 Model: Grok-4.5 (high) \u00b7 Issue: #73 / Linear RM-362",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "channel_alpha",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048
+    },
+    "design": "Grok Build design lock: arms C (periodic HP) and A (channel \u03b1 side-table)",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "implementation": {
+      "commit": "352b2c791f8c2021a1ca5f4bcddb94ad3af458fb",
+      "dirty": false
+    },
+    "issue": "GH #73 / Linear RM-362",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (bit-identical seed/tokens/packs).",
+    "model": "Grok-4.5 (high)",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-expert-precision-remedy/metrics.json
+++ b/reports/grok-1-expert-precision-remedy/metrics.json
@@ -1,956 +1,37 @@
 {
-  "provenance": {
-    "issue": "GH #73 / Linear RM-362",
-    "agent": "Grok Build: Grok 4.5 (xAI) \u00b7 Model: Grok-4.5 (high) \u00b7 Issue: #73 / Linear RM-362",
-    "model": "Grok-4.5 (high)",
-    "design": "Grok Build design lock: arms C (periodic HP) and A (channel \u03b1 side-table)",
-    "baseline_64": {
-      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
-      "tokens": 2048,
-      "expert_only": {
-        "block_output_cosine": 0.963572,
-        "residual_stream_cosine": 1.0,
-        "residual_drift_relative_norm": 0.0,
-        "router_top1_agreement": 1.0,
-        "router_top2_set_agreement": 1.0,
-        "expert_load_js_bits": 0.0,
-        "moe_output_cosine": 0.773483
-      }
-    },
-    "baseline_72": {
-      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
-      "tokens": 2048,
-      "token_seed": 20260806,
-      "blocks": [
-        0,
-        1,
-        2,
-        3
-      ],
-      "decision": 3,
-      "block_output_cosine": [
-        0.963572,
-        0.945765,
-        0.884956,
-        0.839144
-      ],
-      "residual_in_drift": [
-        0.0,
-        0.277351,
-        0.341935,
-        0.498308
-      ],
-      "router_top1": [
-        1.0,
-        0.887695,
-        0.666504,
-        0.52832
-      ],
-      "router_top2": [
-        1.0,
-        0.680664,
-        0.548828,
-        0.289551
-      ],
-      "chain_exit_residual_drift": 0.6538863846584987,
-      "arm_label": "goz1_expert_ternary_only"
-    },
-    "implementation": {
-      "commit": "352b2c791f8c2021a1ca5f4bcddb94ad3af458fb",
-      "dirty": false
-    },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "skip_fp16_control": false,
-    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
-    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision",
-    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
-    "arm": "periodic_hp",
-    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (bit-identical seed/tokens/packs)."
-  },
   "chain": {
+    "arm_label": "expert_periodic_hp_n2",
     "blocks": [
       0,
       1,
       2,
       3
     ],
-    "tokens": 2048,
-    "token_seed": 20260806,
-    "token_id_first": 61,
-    "token_id_last": 130950,
-    "top_k": 2,
-    "per_block": [
-      {
-        "block": 0,
-        "reference_seconds": 25.18864417076111,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 33.61930704116821,
-          "attention_output_cosine": 1.0,
-          "attention_output_cosine_per_token": 1.0,
-          "residual_stream_cosine": 1.0000000000000002,
-          "moe_input_normalized_cosine": 1.0,
-          "router_logit_cosine": 1.0,
-          "moe_output_cosine": 0.7734826618659498,
-          "block_output_cosine": 0.9635717953874715,
-          "block_output_cosine_per_token": 0.9610040055361724,
-          "residual_drift_relative_norm": 0.0,
-          "block_output_drift_relative_norm": 0.2773508234849458,
-          "attn_delta_over_stream": 0.876171414302045,
-          "moe_delta_over_stream": 0.5761949397414952,
-          "router_top1_agreement": 1.0,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 1.0,
-          "router_top2_set_agreement": 1.0,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_js_bits": 0.0,
-          "expert_load_max_abs_delta": 0.0,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030204767217204893,
-          "router_margin_mean_delta": 0.0,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.006170911132304002,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 28.600367784500122,
-          "attention_output_cosine": 0.9999999984424572,
-          "attention_output_cosine_per_token": 0.9999999986030829,
-          "residual_stream_cosine": 0.9999999831365632,
-          "moe_input_normalized_cosine": 0.9999999606124855,
-          "router_logit_cosine": 0.9999999971511485,
-          "moe_output_cosine": 0.9999813002410165,
-          "block_output_cosine": 0.9999870040318545,
-          "block_output_cosine_per_token": 0.9999880581321908,
-          "residual_drift_relative_norm": 0.00021537234101925558,
-          "block_output_drift_relative_norm": 0.005098830221729304,
-          "attn_delta_over_stream": 0.8760054853350859,
-          "moe_delta_over_stream": 0.482784499720899,
-          "router_top1_agreement": 0.9970703125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.114013671875,
-            0.127197265625,
-            0.12841796875,
-            0.1044921875
-          ],
-          "expert_load_observed": [
-            0.131591796875,
-            0.102294921875,
-            0.166259765625,
-            0.125732421875,
-            0.11376953125,
-            0.127685546875,
-            0.12841796875,
-            0.104248046875
-          ],
-          "expert_load_js_bits": 5.347430923457726e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.030204767217204893,
-          "router_margin_mean_observed": 0.030207654444896787,
-          "router_margin_mean_delta": 2.8872276918900968e-06,
-          "router_margin_median_reference": 0.006170911132304002,
-          "router_margin_median_observed": 0.0061808020273402264,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 1173,
-              "top1_flips": 6,
-              "top1_flip_rate": 0.005115089514066497
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 443,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 346,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 86,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 1.0,
-            "residual_in_drift_relative_norm": 0.0
-          }
-        },
-        "pilot_label": "goz1_expert_ternary_only"
-      },
-      {
-        "block": 1,
-        "reference_seconds": 24.6301052570343,
-        "expert_only": {
-          "label": "expert_periodic_hp_n2",
-          "seconds": 29.81546711921692,
-          "attention_output_cosine": 0.9451666095439264,
-          "attention_output_cosine_per_token": 0.9468242743871829,
-          "residual_stream_cosine": 0.9687463905726936,
-          "moe_input_normalized_cosine": 0.949999970457743,
-          "router_logit_cosine": 0.9938496092111954,
-          "moe_output_cosine": 0.9017609468338897,
-          "block_output_cosine": 0.9632111940699978,
-          "block_output_cosine_per_token": 0.9612838387855572,
-          "residual_drift_relative_norm": 0.2568268586347572,
-          "block_output_drift_relative_norm": 0.27932072685345943,
-          "attn_delta_over_stream": 0.37358909903748555,
-          "moe_delta_over_stream": 0.29437542575967357,
-          "router_top1_agreement": 0.8876953125,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.6806640625,
-          "router_top2_set_agreement": 0.6806640625,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.171875,
-            0.1142578125,
-            0.118408203125,
-            0.0625,
-            0.12744140625,
-            0.19775390625,
-            0.097412109375,
-            0.1103515625
-          ],
-          "expert_load_js_bits": 0.005558745183592211,
-          "expert_load_max_abs_delta": 0.03955078125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.195868570026339,
-          "router_margin_mean_delta": 0.012919048645340278,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.16081369486833108,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 49,
-              "top1_flip_rate": 0.5104166666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 114,
-              "top1_flip_rate": 0.35403726708074534
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 57,
-              "top1_flip_rate": 0.09612141652613827
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 10,
-              "top1_flip_rate": 0.01040582726326743
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9635717953874715,
-            "residual_in_drift_relative_norm": 0.2773508234849458
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 24.643250226974487,
-          "attention_output_cosine": 0.9999955239311591,
-          "attention_output_cosine_per_token": 0.9999949975985942,
-          "residual_stream_cosine": 0.9999902372591066,
-          "moe_input_normalized_cosine": 0.9999833030390249,
-          "router_logit_cosine": 0.9999982162936869,
-          "moe_output_cosine": 0.9999664606659787,
-          "block_output_cosine": 0.9999859463222839,
-          "block_output_cosine_per_token": 0.9999851320664912,
-          "residual_drift_relative_norm": 0.0044204095195649025,
-          "block_output_drift_relative_norm": 0.005302552236880725,
-          "attn_delta_over_stream": 0.3961794228342294,
-          "moe_delta_over_stream": 0.2896839054949744,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.9990234375,
-          "router_top2_set_agreement": 0.9990234375,
-          "expert_load_reference": [
-            0.1611328125,
-            0.120361328125,
-            0.109619140625,
-            0.096923828125,
-            0.117431640625,
-            0.158203125,
-            0.103515625,
-            0.1328125
-          ],
-          "expert_load_observed": [
-            0.161376953125,
-            0.1201171875,
-            0.109619140625,
-            0.096923828125,
-            0.11767578125,
-            0.158203125,
-            0.103515625,
-            0.132568359375
-          ],
-          "expert_load_js_bits": 3.2849983466729546e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.1829495213809987,
-          "router_margin_mean_observed": 0.18297782060234993,
-          "router_margin_mean_delta": 2.8299221351235133e-05,
-          "router_margin_median_reference": 0.15255148410556432,
-          "router_margin_median_observed": 0.15256866411484876,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 96,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.010416666666666666
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 322,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 593,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 961,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 76,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999870040318545,
-            "residual_in_drift_relative_norm": 0.005098830221729304
-          }
-        },
-        "pilot_label": "expert_periodic_hp_n2"
-      },
-      {
-        "block": 2,
-        "reference_seconds": 17.931037664413452,
-        "expert_only": {
-          "label": "goz1_expert_ternary_only",
-          "seconds": 32.00498867034912,
-          "attention_output_cosine": 0.9047309506532298,
-          "attention_output_cosine_per_token": 0.9037477193363658,
-          "residual_stream_cosine": 0.9648533420001547,
-          "moe_input_normalized_cosine": 0.9259938960972086,
-          "router_logit_cosine": 0.9883752457973156,
-          "moe_output_cosine": 0.599421444042343,
-          "block_output_cosine": 0.9053595369142478,
-          "block_output_cosine_per_token": 0.9046997079541444,
-          "residual_drift_relative_norm": 0.27894141485027485,
-          "block_output_drift_relative_norm": 0.4490877008202646,
-          "attn_delta_over_stream": 0.6183179321460256,
-          "moe_delta_over_stream": 0.48376410916278434,
-          "router_top1_agreement": 0.72900390625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.5927734375,
-          "router_top2_set_agreement": 0.5927734375,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.065185546875,
-            0.09619140625,
-            0.085205078125,
-            0.285400390625,
-            0.047119140625,
-            0.067626953125,
-            0.134033203125,
-            0.21923828125
-          ],
-          "expert_load_js_bits": 0.008547932604502501,
-          "expert_load_max_abs_delta": 0.03857421875,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03511417386760163,
-          "router_margin_mean_delta": -0.0007007716994217449,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025096056745317674,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 238,
-              "top1_flip_rate": 0.5173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 299,
-              "top1_flip_rate": 0.2834123222748815
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 18,
-              "top1_flip_rate": 0.03508771929824561
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9632111940699978,
-            "residual_in_drift_relative_norm": 0.27932072685345943
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 23.9533793926239,
-          "attention_output_cosine": 0.9999951789408488,
-          "attention_output_cosine_per_token": 0.9999948156177104,
-          "residual_stream_cosine": 0.999991030697749,
-          "moe_input_normalized_cosine": 0.9999805357628218,
-          "router_logit_cosine": 0.99999830045166,
-          "moe_output_cosine": 0.9998240608794524,
-          "block_output_cosine": 0.9999682697724989,
-          "block_output_cosine_per_token": 0.9999678107548897,
-          "residual_drift_relative_norm": 0.004235465975258782,
-          "block_output_drift_relative_norm": 0.007966186310686194,
-          "attn_delta_over_stream": 0.584956965059082,
-          "moe_delta_over_stream": 0.4112808355956077,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.99951171875,
-          "router_top2_set_agreement": 0.99951171875,
-          "expert_load_reference": [
-            0.047607421875,
-            0.12646484375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.238525390625
-          ],
-          "expert_load_observed": [
-            0.047607421875,
-            0.126708984375,
-            0.060791015625,
-            0.255615234375,
-            0.02734375,
-            0.071044921875,
-            0.172607421875,
-            0.23828125
-          ],
-          "expert_load_js_bits": 1.300004449968095e-07,
-          "expert_load_max_abs_delta": 0.000244140625,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.035814945567023374,
-          "router_margin_mean_observed": 0.03582240155308043,
-          "router_margin_mean_delta": 7.4559860570678075e-06,
-          "router_margin_median_reference": 0.025870355622028635,
-          "router_margin_median_observed": 0.025836218008428474,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 460,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.002173913043478261
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 1055,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 513,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 20,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999859463222839,
-            "residual_in_drift_relative_norm": 0.005302552236880725
-          }
-        },
-        "pilot_label": "goz1_expert_ternary_only"
-      },
-      {
-        "block": 3,
-        "reference_seconds": 18.59751272201538,
-        "expert_only": {
-          "label": "expert_periodic_hp_n2",
-          "seconds": 25.75456190109253,
-          "attention_output_cosine": 0.8063387072367575,
-          "attention_output_cosine_per_token": 0.8062995364004137,
-          "residual_stream_cosine": 0.9257811730988034,
-          "moe_input_normalized_cosine": 0.7771194639183103,
-          "router_logit_cosine": 0.9911220006774988,
-          "moe_output_cosine": 0.7306627890646148,
-          "block_output_cosine": 0.8823075408657535,
-          "block_output_cosine_per_token": 0.8826683616382343,
-          "residual_drift_relative_norm": 0.39815503227303634,
-          "block_output_drift_relative_norm": 0.5292121735722244,
-          "attn_delta_over_stream": 0.5021969324455889,
-          "moe_delta_over_stream": 0.3395709362290844,
-          "router_top1_agreement": 0.5478515625,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.3173828125,
-          "router_top2_set_agreement": 0.3173828125,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.05419921875,
-            0.140625,
-            0.057373046875,
-            0.146240234375,
-            0.3330078125,
-            0.0166015625,
-            0.111083984375,
-            0.140869140625
-          ],
-          "expert_load_js_bits": 0.02524271898962335,
-          "expert_load_max_abs_delta": 0.0830078125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.040556678574664495,
-          "router_margin_mean_delta": -0.0035111343905704978,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.028280055194312995,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 294,
-              "top1_flip_rate": 0.6983372921615202
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 518,
-              "top1_flip_rate": 0.5242914979757085
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 114,
-              "top1_flip_rate": 0.2007042253521127
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9053595369142478,
-            "residual_in_drift_relative_norm": 0.4490877008202646
-          }
-        },
-        "fp16_control": {
-          "label": "fp16_roundtrip",
-          "seconds": 25.87843656539917,
-          "attention_output_cosine": 0.999967551568842,
-          "attention_output_cosine_per_token": 0.9999677009593164,
-          "residual_stream_cosine": 0.9999786349806121,
-          "moe_input_normalized_cosine": 0.9999317807120685,
-          "router_logit_cosine": 0.9999963366294831,
-          "moe_output_cosine": 0.9996961823732479,
-          "block_output_cosine": 0.9999195401900538,
-          "block_output_cosine_per_token": 0.9999220112059125,
-          "residual_drift_relative_norm": 0.006536817583550683,
-          "block_output_drift_relative_norm": 0.012685837908964355,
-          "attn_delta_over_stream": 0.5008011118859926,
-          "moe_delta_over_stream": 0.35685089524601604,
-          "router_top1_agreement": 0.99951171875,
-          "selected_experts": 2,
-          "router_topk_set_agreement": 0.998046875,
-          "router_top2_set_agreement": 0.998046875,
-          "expert_load_reference": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.15625,
-            0.38330078125,
-            0.0224609375,
-            0.194091796875,
-            0.084716796875
-          ],
-          "expert_load_observed": [
-            0.0517578125,
-            0.070556640625,
-            0.036865234375,
-            0.156494140625,
-            0.38330078125,
-            0.0224609375,
-            0.1943359375,
-            0.084228515625
-          ],
-          "expert_load_js_bits": 6.330749621763374e-07,
-          "expert_load_max_abs_delta": 0.00048828125,
-          "experts_unused_reference": 0,
-          "experts_unused_observed": 0,
-          "router_margin_mean_reference": 0.044067812965235,
-          "router_margin_mean_observed": 0.04404335021260723,
-          "router_margin_mean_delta": -2.446275262776493e-05,
-          "router_margin_median_reference": 0.0295396135928446,
-          "router_margin_median_observed": 0.029497699031347163,
-          "flip_stratification_by_reference_margin": [
-            {
-              "margin_low": 0.0,
-              "margin_high": 0.01,
-              "tokens": 421,
-              "top1_flips": 1,
-              "top1_flip_rate": 0.0023752969121140144
-            },
-            {
-              "margin_low": 0.01,
-              "margin_high": 0.05,
-              "tokens": 988,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.05,
-              "margin_high": 0.15,
-              "tokens": 568,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.15,
-              "margin_high": 0.5,
-              "tokens": 71,
-              "top1_flips": 0,
-              "top1_flip_rate": 0.0
-            },
-            {
-              "margin_low": 0.5,
-              "margin_high": 1.01,
-              "tokens": 0,
-              "top1_flips": 0,
-              "top1_flip_rate": null
-            }
-          ],
-          "experts_touched": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7
-          ],
-          "residual_stream_in": {
-            "residual_in_cosine": 0.9999682697724989,
-            "residual_in_drift_relative_norm": 0.007966186310686194
-          }
-        },
-        "pilot_label": "expert_periodic_hp_n2"
-      }
-    ],
     "end_of_chain": {
       "expert_only_chain_exit": {
+        "note": "post-final-block residual stream (chain exit), not last-block residual-in",
         "residual_cosine": 0.8823075408657535,
-        "residual_drift_relative_norm": 0.5292121735722244,
-        "note": "post-final-block residual stream (chain exit), not last-block residual-in"
+        "residual_drift_relative_norm": 0.5292121735722244
       },
       "fp16_chain_exit": {
+        "note": "post-final-block residual stream under FP16 control",
         "residual_cosine": 0.9999195401900538,
-        "residual_drift_relative_norm": 0.012685837908964355,
-        "note": "post-final-block residual stream under FP16 control"
+        "residual_drift_relative_norm": 0.012685837908964355
       }
     },
+    "expert_mode": "periodic_hp",
+    "hp_blocks": [
+      1,
+      3
+    ],
+    "hp_period": 2,
+    "hp_schedule_prose": "Arm C label `expert_periodic_hp_n2`: ternary on {0,2}, HP (FP16 experts) on {1,3}.",
     "pack_provenance": [
       {
         "block": 0,
-        "pack": "block_000-attention_plus_expert.goz1",
-        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_000-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_000.slot_01.moe_expert.down": "pack_v2",
-          "block_000.slot_00.moe_expert.gate": "pack_v2",
-          "block_000.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_000.slot_00.moe_expert.gate": {
-            "alpha": 0.03446429222822189,
-            "sparsity": 0.652848777671655,
-            "fired": 559126180,
-            "total": 1610612736
-          },
-          "block_000.slot_01.moe_expert.down": {
-            "alpha": 0.02270425483584404,
-            "sparsity": 0.6372781544923782,
-            "fired": 584204424,
-            "total": 1610612736
-          },
-          "block_000.slot_02.moe_expert.up": {
-            "alpha": 0.0343967042863369,
-            "sparsity": 0.6443704627454281,
-            "fired": 572781462,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_000.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -981,47 +62,47 @@
             "threshold_abs": 0.004230931401252747
           }
         },
+        "npy_dir": "goz68-block_000-attn",
+        "pack": "block_000-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "eb28728b6b66454753bc67072b105e701d99f589ca20f4edf174fecd06e0e1c4",
+        "scale_sources": {
+          "block_000.slot_00.moe_expert.gate": "pack_v2",
+          "block_000.slot_01.moe_expert.down": "pack_v2",
+          "block_000.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_000.slot_00.moe_expert.gate": {
+            "alpha": 0.03446429222822189,
+            "fired": 559126180,
+            "sparsity": 0.652848777671655,
+            "total": 1610612736
+          },
+          "block_000.slot_01.moe_expert.down": {
+            "alpha": 0.02270425483584404,
+            "fired": 584204424,
+            "sparsity": 0.6372781544923782,
+            "total": 1610612736
+          },
+          "block_000.slot_02.moe_expert.up": {
+            "alpha": 0.0343967042863369,
+            "fired": 572781462,
+            "sparsity": 0.6443704627454281,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 1,
-        "pack": "block_001-attention_plus_expert.goz1",
-        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_001-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_001.slot_01.moe_expert.down": "pack_v2",
-          "block_001.slot_00.moe_expert.gate": "pack_v2",
-          "block_001.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_001.slot_00.moe_expert.gate": {
-            "alpha": 0.04331796243786812,
-            "sparsity": 0.633674278234442,
-            "fired": 590008873,
-            "total": 1610612736
-          },
-          "block_001.slot_01.moe_expert.down": {
-            "alpha": 0.010844916105270386,
-            "sparsity": 0.6404839977622032,
-            "fired": 579041052,
-            "total": 1610612736
-          },
-          "block_001.slot_02.moe_expert.up": {
-            "alpha": 0.04337596148252487,
-            "sparsity": 0.6348795853555202,
-            "fired": 588067590,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_001.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1052,47 +133,47 @@
             "threshold_abs": 0.007041923236101866
           }
         },
+        "npy_dir": "goz68-block_001-attn",
+        "pack": "block_001-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "dd66181d6ce42ed47a6a257feaf606d20c4b0b23f471004ae373b21c1398c17f",
+        "scale_sources": {
+          "block_001.slot_00.moe_expert.gate": "pack_v2",
+          "block_001.slot_01.moe_expert.down": "pack_v2",
+          "block_001.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_001.slot_00.moe_expert.gate": {
+            "alpha": 0.04331796243786812,
+            "fired": 590008873,
+            "sparsity": 0.633674278234442,
+            "total": 1610612736
+          },
+          "block_001.slot_01.moe_expert.down": {
+            "alpha": 0.010844916105270386,
+            "fired": 579041052,
+            "sparsity": 0.6404839977622032,
+            "total": 1610612736
+          },
+          "block_001.slot_02.moe_expert.up": {
+            "alpha": 0.04337596148252487,
+            "fired": 588067590,
+            "sparsity": 0.6348795853555202,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 2,
-        "pack": "block_002-attention_plus_expert.goz1",
-        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_002-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_002.slot_01.moe_expert.down": "pack_v2",
-          "block_002.slot_00.moe_expert.gate": "pack_v2",
-          "block_002.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_002.slot_00.moe_expert.gate": {
-            "alpha": 0.047630175948143005,
-            "sparsity": 0.6356016273299854,
-            "fired": 586904660,
-            "total": 1610612736
-          },
-          "block_002.slot_01.moe_expert.down": {
-            "alpha": 0.022462978959083557,
-            "sparsity": 0.6368899804850419,
-            "fired": 584829622,
-            "total": 1610612736
-          },
-          "block_002.slot_02.moe_expert.up": {
-            "alpha": 0.047669243067502975,
-            "sparsity": 0.6359017888704936,
-            "fired": 586421216,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_002.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1123,47 +204,47 @@
             "threshold_abs": 0.01309292297810316
           }
         },
+        "npy_dir": "goz68-block_002-attn",
+        "pack": "block_002-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "e61641e19735293e6802c33d69dda6f83507480fc955141f358eb0df31da8560",
+        "scale_sources": {
+          "block_002.slot_00.moe_expert.gate": "pack_v2",
+          "block_002.slot_01.moe_expert.down": "pack_v2",
+          "block_002.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_002.slot_00.moe_expert.gate": {
+            "alpha": 0.047630175948143005,
+            "fired": 586904660,
+            "sparsity": 0.6356016273299854,
+            "total": 1610612736
+          },
+          "block_002.slot_01.moe_expert.down": {
+            "alpha": 0.022462978959083557,
+            "fired": 584829622,
+            "sparsity": 0.6368899804850419,
+            "total": 1610612736
+          },
+          "block_002.slot_02.moe_expert.up": {
+            "alpha": 0.047669243067502975,
+            "fired": 586421216,
+            "sparsity": 0.6359017888704936,
+            "total": 1610612736
+          }
         }
       },
       {
         "block": 3,
-        "pack": "block_003-attention_plus_expert.goz1",
-        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
-        "pack_bytes": 1230128768,
-        "npy_dir": "goz68-block_003-attn",
         "container_versions": [
           3
         ],
-        "scale_sources": {
-          "block_003.slot_01.moe_expert.down": "pack_v2",
-          "block_003.slot_00.moe_expert.gate": "pack_v2",
-          "block_003.slot_02.moe_expert.up": "pack_v2"
-        },
-        "ternary_scales": {
-          "block_003.slot_00.moe_expert.gate": {
-            "alpha": 0.03307119756937027,
-            "sparsity": 0.6364477450648944,
-            "fired": 585541892,
-            "total": 1610612736
-          },
-          "block_003.slot_01.moe_expert.down": {
-            "alpha": 0.015412655659019947,
-            "sparsity": 0.6372132208198309,
-            "fired": 584309007,
-            "total": 1610612736
-          },
-          "block_003.slot_02.moe_expert.up": {
-            "alpha": 0.033106379210948944,
-            "sparsity": 0.6368649223198493,
-            "fired": 584869981,
-            "total": 1610612736
-          }
-        },
         "gif_thresholds": {
           "block_003.slot_00.moe_expert.gate": {
             "gif_threshold": 0.8999999761581421,
@@ -1194,35 +275,884 @@
             "threshold_abs": 0.0016606772551313043
           }
         },
+        "npy_dir": "goz68-block_003-attn",
+        "pack": "block_003-attention_plus_expert.goz1",
+        "pack_bytes": 1230128768,
         "pack_metadata": {
-          "oz.quantization_version": 3,
           "oz.gif_threshold": "0.05",
           "oz.gif_threshold_authority": "tensor_row",
-          "oz.gif_threshold_scope": "baseline_only_not_applied"
+          "oz.gif_threshold_scope": "baseline_only_not_applied",
+          "oz.quantization_version": 3
+        },
+        "pack_sha256": "9db504ff9ee08a2523f74e3f842228296458fc524a1ccf406de46c53d9e18302",
+        "scale_sources": {
+          "block_003.slot_00.moe_expert.gate": "pack_v2",
+          "block_003.slot_01.moe_expert.down": "pack_v2",
+          "block_003.slot_02.moe_expert.up": "pack_v2"
+        },
+        "ternary_scales": {
+          "block_003.slot_00.moe_expert.gate": {
+            "alpha": 0.03307119756937027,
+            "fired": 585541892,
+            "sparsity": 0.6364477450648944,
+            "total": 1610612736
+          },
+          "block_003.slot_01.moe_expert.down": {
+            "alpha": 0.015412655659019947,
+            "fired": 584309007,
+            "sparsity": 0.6372132208198309,
+            "total": 1610612736
+          },
+          "block_003.slot_02.moe_expert.up": {
+            "alpha": 0.033106379210948944,
+            "fired": 584869981,
+            "sparsity": 0.6368649223198493,
+            "total": 1610612736
+          }
         }
       }
     ],
-    "skip_fp16_control": false,
-    "expert_mode": "periodic_hp",
-    "hp_period": 2,
-    "hp_blocks": [
-      1,
-      3
+    "per_block": [
+      {
+        "block": 0,
+        "expert_only": {
+          "attention_output_cosine": 1.0,
+          "attention_output_cosine_per_token": 1.0,
+          "attn_delta_over_stream": 0.876171414302045,
+          "block_output_cosine": 0.9635717953874715,
+          "block_output_cosine_per_token": 0.9610040055361724,
+          "block_output_drift_relative_norm": 0.2773508234849458,
+          "expert_load_js_bits": 0.0,
+          "expert_load_max_abs_delta": 0.0,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.5761949397414952,
+          "moe_input_normalized_cosine": 1.0,
+          "moe_output_cosine": 0.7734826618659498,
+          "residual_drift_relative_norm": 0.0,
+          "residual_stream_cosine": 1.0000000000000002,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 1.0,
+          "router_margin_mean_delta": 0.0,
+          "router_margin_mean_observed": 0.030204767217204893,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.006170911132304002,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 1.0,
+          "router_top2_set_agreement": 1.0,
+          "router_topk_set_agreement": 1.0,
+          "seconds": 33.61930704116821,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999999984424572,
+          "attention_output_cosine_per_token": 0.9999999986030829,
+          "attn_delta_over_stream": 0.8760054853350859,
+          "block_output_cosine": 0.9999870040318545,
+          "block_output_cosine_per_token": 0.9999880581321908,
+          "block_output_drift_relative_norm": 0.005098830221729304,
+          "expert_load_js_bits": 5.347430923457726e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.11376953125,
+            0.127685546875,
+            0.12841796875,
+            0.104248046875
+          ],
+          "expert_load_reference": [
+            0.131591796875,
+            0.102294921875,
+            0.166259765625,
+            0.125732421875,
+            0.114013671875,
+            0.127197265625,
+            0.12841796875,
+            0.1044921875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 1173,
+              "top1_flip_rate": 0.005115089514066497,
+              "top1_flips": 6
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 443,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 346,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 86,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.482784499720899,
+          "moe_input_normalized_cosine": 0.9999999606124855,
+          "moe_output_cosine": 0.9999813002410165,
+          "residual_drift_relative_norm": 0.00021537234101925558,
+          "residual_stream_cosine": 0.9999999831365632,
+          "residual_stream_in": {
+            "residual_in_cosine": 1.0,
+            "residual_in_drift_relative_norm": 0.0
+          },
+          "router_logit_cosine": 0.9999999971511485,
+          "router_margin_mean_delta": 2.8872276918900968e-06,
+          "router_margin_mean_observed": 0.030207654444896787,
+          "router_margin_mean_reference": 0.030204767217204893,
+          "router_margin_median_observed": 0.0061808020273402264,
+          "router_margin_median_reference": 0.006170911132304002,
+          "router_top1_agreement": 0.9970703125,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 28.600367784500122,
+          "selected_experts": 2
+        },
+        "pilot_label": "goz1_expert_ternary_only",
+        "reference_seconds": 25.18864417076111
+      },
+      {
+        "block": 1,
+        "expert_only": {
+          "attention_output_cosine": 0.9451666095439264,
+          "attention_output_cosine_per_token": 0.9468242743871829,
+          "attn_delta_over_stream": 0.37358909903748555,
+          "block_output_cosine": 0.9632111940699978,
+          "block_output_cosine_per_token": 0.9612838387855572,
+          "block_output_drift_relative_norm": 0.27932072685345943,
+          "expert_load_js_bits": 0.005558745183592211,
+          "expert_load_max_abs_delta": 0.03955078125,
+          "expert_load_observed": [
+            0.171875,
+            0.1142578125,
+            0.118408203125,
+            0.0625,
+            0.12744140625,
+            0.19775390625,
+            0.097412109375,
+            0.1103515625
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.5104166666666666,
+              "top1_flips": 49
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.35403726708074534,
+              "top1_flips": 114
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.09612141652613827,
+              "top1_flips": 57
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.01040582726326743,
+              "top1_flips": 10
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_n2",
+          "moe_delta_over_stream": 0.29437542575967357,
+          "moe_input_normalized_cosine": 0.949999970457743,
+          "moe_output_cosine": 0.9017609468338897,
+          "residual_drift_relative_norm": 0.2568268586347572,
+          "residual_stream_cosine": 0.9687463905726936,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9635717953874715,
+            "residual_in_drift_relative_norm": 0.2773508234849458
+          },
+          "router_logit_cosine": 0.9938496092111954,
+          "router_margin_mean_delta": 0.012919048645340278,
+          "router_margin_mean_observed": 0.195868570026339,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.16081369486833108,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.8876953125,
+          "router_top2_set_agreement": 0.6806640625,
+          "router_topk_set_agreement": 0.6806640625,
+          "seconds": 29.81546711921692,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999955239311591,
+          "attention_output_cosine_per_token": 0.9999949975985942,
+          "attn_delta_over_stream": 0.3961794228342294,
+          "block_output_cosine": 0.9999859463222839,
+          "block_output_cosine_per_token": 0.9999851320664912,
+          "block_output_drift_relative_norm": 0.005302552236880725,
+          "expert_load_js_bits": 3.2849983466729546e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.161376953125,
+            0.1201171875,
+            0.109619140625,
+            0.096923828125,
+            0.11767578125,
+            0.158203125,
+            0.103515625,
+            0.132568359375
+          ],
+          "expert_load_reference": [
+            0.1611328125,
+            0.120361328125,
+            0.109619140625,
+            0.096923828125,
+            0.117431640625,
+            0.158203125,
+            0.103515625,
+            0.1328125
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 96,
+              "top1_flip_rate": 0.010416666666666666,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 322,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 593,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 961,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 76,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.2896839054949744,
+          "moe_input_normalized_cosine": 0.9999833030390249,
+          "moe_output_cosine": 0.9999664606659787,
+          "residual_drift_relative_norm": 0.0044204095195649025,
+          "residual_stream_cosine": 0.9999902372591066,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999870040318545,
+            "residual_in_drift_relative_norm": 0.005098830221729304
+          },
+          "router_logit_cosine": 0.9999982162936869,
+          "router_margin_mean_delta": 2.8299221351235133e-05,
+          "router_margin_mean_observed": 0.18297782060234993,
+          "router_margin_mean_reference": 0.1829495213809987,
+          "router_margin_median_observed": 0.15256866411484876,
+          "router_margin_median_reference": 0.15255148410556432,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.9990234375,
+          "router_topk_set_agreement": 0.9990234375,
+          "seconds": 24.643250226974487,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_n2",
+        "reference_seconds": 24.6301052570343
+      },
+      {
+        "block": 2,
+        "expert_only": {
+          "attention_output_cosine": 0.9047309506532298,
+          "attention_output_cosine_per_token": 0.9037477193363658,
+          "attn_delta_over_stream": 0.6183179321460256,
+          "block_output_cosine": 0.9053595369142478,
+          "block_output_cosine_per_token": 0.9046997079541444,
+          "block_output_drift_relative_norm": 0.4490877008202646,
+          "expert_load_js_bits": 0.008547932604502501,
+          "expert_load_max_abs_delta": 0.03857421875,
+          "expert_load_observed": [
+            0.065185546875,
+            0.09619140625,
+            0.085205078125,
+            0.285400390625,
+            0.047119140625,
+            0.067626953125,
+            0.134033203125,
+            0.21923828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.5173913043478261,
+              "top1_flips": 238
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.2834123222748815,
+              "top1_flips": 299
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.03508771929824561,
+              "top1_flips": 18
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "goz1_expert_ternary_only",
+          "moe_delta_over_stream": 0.48376410916278434,
+          "moe_input_normalized_cosine": 0.9259938960972086,
+          "moe_output_cosine": 0.599421444042343,
+          "residual_drift_relative_norm": 0.27894141485027485,
+          "residual_stream_cosine": 0.9648533420001547,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9632111940699978,
+            "residual_in_drift_relative_norm": 0.27932072685345943
+          },
+          "router_logit_cosine": 0.9883752457973156,
+          "router_margin_mean_delta": -0.0007007716994217449,
+          "router_margin_mean_observed": 0.03511417386760163,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025096056745317674,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.72900390625,
+          "router_top2_set_agreement": 0.5927734375,
+          "router_topk_set_agreement": 0.5927734375,
+          "seconds": 32.00498867034912,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.9999951789408488,
+          "attention_output_cosine_per_token": 0.9999948156177104,
+          "attn_delta_over_stream": 0.584956965059082,
+          "block_output_cosine": 0.9999682697724989,
+          "block_output_cosine_per_token": 0.9999678107548897,
+          "block_output_drift_relative_norm": 0.007966186310686194,
+          "expert_load_js_bits": 1.300004449968095e-07,
+          "expert_load_max_abs_delta": 0.000244140625,
+          "expert_load_observed": [
+            0.047607421875,
+            0.126708984375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.23828125
+          ],
+          "expert_load_reference": [
+            0.047607421875,
+            0.12646484375,
+            0.060791015625,
+            0.255615234375,
+            0.02734375,
+            0.071044921875,
+            0.172607421875,
+            0.238525390625
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 460,
+              "top1_flip_rate": 0.002173913043478261,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 1055,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 513,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 20,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.4112808355956077,
+          "moe_input_normalized_cosine": 0.9999805357628218,
+          "moe_output_cosine": 0.9998240608794524,
+          "residual_drift_relative_norm": 0.004235465975258782,
+          "residual_stream_cosine": 0.999991030697749,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999859463222839,
+            "residual_in_drift_relative_norm": 0.005302552236880725
+          },
+          "router_logit_cosine": 0.99999830045166,
+          "router_margin_mean_delta": 7.4559860570678075e-06,
+          "router_margin_mean_observed": 0.03582240155308043,
+          "router_margin_mean_reference": 0.035814945567023374,
+          "router_margin_median_observed": 0.025836218008428474,
+          "router_margin_median_reference": 0.025870355622028635,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.99951171875,
+          "router_topk_set_agreement": 0.99951171875,
+          "seconds": 23.9533793926239,
+          "selected_experts": 2
+        },
+        "pilot_label": "goz1_expert_ternary_only",
+        "reference_seconds": 17.931037664413452
+      },
+      {
+        "block": 3,
+        "expert_only": {
+          "attention_output_cosine": 0.8063387072367575,
+          "attention_output_cosine_per_token": 0.8062995364004137,
+          "attn_delta_over_stream": 0.5021969324455889,
+          "block_output_cosine": 0.8823075408657535,
+          "block_output_cosine_per_token": 0.8826683616382343,
+          "block_output_drift_relative_norm": 0.5292121735722244,
+          "expert_load_js_bits": 0.02524271898962335,
+          "expert_load_max_abs_delta": 0.0830078125,
+          "expert_load_observed": [
+            0.05419921875,
+            0.140625,
+            0.057373046875,
+            0.146240234375,
+            0.3330078125,
+            0.0166015625,
+            0.111083984375,
+            0.140869140625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.6983372921615202,
+              "top1_flips": 294
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.5242914979757085,
+              "top1_flips": 518
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.2007042253521127,
+              "top1_flips": 114
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "expert_periodic_hp_n2",
+          "moe_delta_over_stream": 0.3395709362290844,
+          "moe_input_normalized_cosine": 0.7771194639183103,
+          "moe_output_cosine": 0.7306627890646148,
+          "residual_drift_relative_norm": 0.39815503227303634,
+          "residual_stream_cosine": 0.9257811730988034,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9053595369142478,
+            "residual_in_drift_relative_norm": 0.4490877008202646
+          },
+          "router_logit_cosine": 0.9911220006774988,
+          "router_margin_mean_delta": -0.0035111343905704978,
+          "router_margin_mean_observed": 0.040556678574664495,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.028280055194312995,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.5478515625,
+          "router_top2_set_agreement": 0.3173828125,
+          "router_topk_set_agreement": 0.3173828125,
+          "seconds": 25.75456190109253,
+          "selected_experts": 2
+        },
+        "fp16_control": {
+          "attention_output_cosine": 0.999967551568842,
+          "attention_output_cosine_per_token": 0.9999677009593164,
+          "attn_delta_over_stream": 0.5008011118859926,
+          "block_output_cosine": 0.9999195401900538,
+          "block_output_cosine_per_token": 0.9999220112059125,
+          "block_output_drift_relative_norm": 0.012685837908964355,
+          "expert_load_js_bits": 6.330749621763374e-07,
+          "expert_load_max_abs_delta": 0.00048828125,
+          "expert_load_observed": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.156494140625,
+            0.38330078125,
+            0.0224609375,
+            0.1943359375,
+            0.084228515625
+          ],
+          "expert_load_reference": [
+            0.0517578125,
+            0.070556640625,
+            0.036865234375,
+            0.15625,
+            0.38330078125,
+            0.0224609375,
+            0.194091796875,
+            0.084716796875
+          ],
+          "experts_touched": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7
+          ],
+          "experts_unused_observed": 0,
+          "experts_unused_reference": 0,
+          "flip_stratification_by_reference_margin": [
+            {
+              "margin_high": 0.01,
+              "margin_low": 0.0,
+              "tokens": 421,
+              "top1_flip_rate": 0.0023752969121140144,
+              "top1_flips": 1
+            },
+            {
+              "margin_high": 0.05,
+              "margin_low": 0.01,
+              "tokens": 988,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.15,
+              "margin_low": 0.05,
+              "tokens": 568,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 0.5,
+              "margin_low": 0.15,
+              "tokens": 71,
+              "top1_flip_rate": 0.0,
+              "top1_flips": 0
+            },
+            {
+              "margin_high": 1.01,
+              "margin_low": 0.5,
+              "tokens": 0,
+              "top1_flip_rate": null,
+              "top1_flips": 0
+            }
+          ],
+          "label": "fp16_roundtrip",
+          "moe_delta_over_stream": 0.35685089524601604,
+          "moe_input_normalized_cosine": 0.9999317807120685,
+          "moe_output_cosine": 0.9996961823732479,
+          "residual_drift_relative_norm": 0.006536817583550683,
+          "residual_stream_cosine": 0.9999786349806121,
+          "residual_stream_in": {
+            "residual_in_cosine": 0.9999682697724989,
+            "residual_in_drift_relative_norm": 0.007966186310686194
+          },
+          "router_logit_cosine": 0.9999963366294831,
+          "router_margin_mean_delta": -2.446275262776493e-05,
+          "router_margin_mean_observed": 0.04404335021260723,
+          "router_margin_mean_reference": 0.044067812965235,
+          "router_margin_median_observed": 0.029497699031347163,
+          "router_margin_median_reference": 0.0295396135928446,
+          "router_top1_agreement": 0.99951171875,
+          "router_top2_set_agreement": 0.998046875,
+          "router_topk_set_agreement": 0.998046875,
+          "seconds": 25.87843656539917,
+          "selected_experts": 2
+        },
+        "pilot_label": "expert_periodic_hp_n2",
+        "reference_seconds": 18.59751272201538
+      }
     ],
-    "ternary_blocks": [
-      0,
-      2
-    ],
-    "hp_schedule_prose": "Arm C label `expert_periodic_hp_n2`: ternary on {0,2}, HP (FP16 experts) on {1,3}.",
-    "arm_label": "expert_periodic_hp_n2",
     "pilot_labels_per_block": [
       "goz1_expert_ternary_only",
       "expert_periodic_hp_n2",
       "goz1_expert_ternary_only",
       "expert_periodic_hp_n2"
-    ]
+    ],
+    "skip_fp16_control": false,
+    "ternary_blocks": [
+      0,
+      2
+    ],
+    "token_id_first": 61,
+    "token_id_last": 130950,
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
   },
   "decision": {
+    "compounding": "roughly_linear",
     "decision": 2,
     "decision_text": "Remedy helps but needs further correction (clear improvement vs #72; residual still compounds).",
     "rationale": [
@@ -1240,7 +1170,77 @@
       "#72 baseline chain_exit_drift=0.653886 b3_top1=0.528320 b3_cos=0.839144 (cited, not re-run)",
       "arm=expert_periodic_hp_n2",
       "hp_schedule=Arm C label `expert_periodic_hp_n2`: ternary on {0,2}, HP (FP16 experts) on {1,3}."
-    ],
-    "compounding": "roughly_linear"
+    ]
+  },
+  "provenance": {
+    "activation_policy": "paired residuals; no Gaussian; no embed for b!=0",
+    "agent": "Grok Build: Grok 4.5 (xAI) \u00b7 Model: Grok-4.5 (high) \u00b7 Issue: #73 / Linear RM-362",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "arm": "periodic_hp",
+    "baseline_64": {
+      "expert_only": {
+        "block_output_cosine": 0.963572,
+        "expert_load_js_bits": 0.0,
+        "moe_output_cosine": 0.773483,
+        "residual_drift_relative_norm": 0.0,
+        "residual_stream_cosine": 1.0,
+        "router_top1_agreement": 1.0,
+        "router_top2_set_agreement": 1.0
+      },
+      "source": "reports/grok-1-full-block-forward/results.md (PR #64 / #61 / RM-249)",
+      "tokens": 2048
+    },
+    "baseline_72": {
+      "arm_label": "goz1_expert_ternary_only",
+      "block_output_cosine": [
+        0.963572,
+        0.945765,
+        0.884956,
+        0.839144
+      ],
+      "blocks": [
+        0,
+        1,
+        2,
+        3
+      ],
+      "chain_exit_residual_drift": 0.6538863846584987,
+      "decision": 3,
+      "residual_in_drift": [
+        0.0,
+        0.277351,
+        0.341935,
+        0.498308
+      ],
+      "router_top1": [
+        1.0,
+        0.887695,
+        0.666504,
+        0.52832
+      ],
+      "router_top2": [
+        1.0,
+        0.680664,
+        0.548828,
+        0.289551
+      ],
+      "source": "reports/grok-1-expert-only-multiblock/ (PR #72 / #68 / RM-255)",
+      "token_seed": 20260806,
+      "tokens": 2048
+    },
+    "design": "Grok Build design lock: arms C (periodic HP) and A (channel \u03b1 side-table)",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "implementation": {
+      "commit": "352b2c791f8c2021a1ca5f4bcddb94ad3af458fb",
+      "dirty": false
+    },
+    "issue": "GH #73 / Linear RM-362",
+    "metrics_note": "#72 single-scale ternary baseline cited from reports/grok-1-expert-only-multiblock/ (bit-identical seed/tokens/packs).",
+    "model": "Grok-4.5 (high)",
+    "numpy": "2.5.1",
+    "python": "3.14.6",
+    "scale_policy": "GOZ1 v3 pack-only on ternary path; abort on legacy_oracle",
+    "skip_fp16_control": false,
+    "ternary_policy": "experts only on ternary blocks; attention/routers/norms high precision"
   }
 }

--- a/reports/grok-1-full-block-forward/block0-forward-metrics.json
+++ b/reports/grok-1-full-block-forward/block0-forward-metrics.json
@@ -1,14 +1,453 @@
 {
+  "comparisons": [
+    {
+      "attention_output_cosine": 0.9999999984424572,
+      "attention_output_cosine_per_token": 0.9999999986030829,
+      "attn_delta_over_stream": 0.8760054853350859,
+      "block_output_cosine": 0.9999870040318545,
+      "block_output_cosine_per_token": 0.9999880581321908,
+      "block_output_drift_relative_norm": 0.005098830221729304,
+      "expert_load_js_bits": 5.347430923457726e-07,
+      "expert_load_max_abs_delta": 0.00048828125,
+      "expert_load_observed": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.11376953125,
+        0.127685546875,
+        0.12841796875,
+        0.104248046875
+      ],
+      "expert_load_reference": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.114013671875,
+        0.127197265625,
+        0.12841796875,
+        0.1044921875
+      ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.005115089514066497,
+          "top1_flips": 6
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "fp16_roundtrip",
+      "moe_delta_over_stream": 0.482784499720899,
+      "moe_input_normalized_cosine": 0.9999999606124855,
+      "moe_output_cosine": 0.9999813002410165,
+      "residual_drift_relative_norm": 0.00021537234101925558,
+      "residual_stream_cosine": 0.9999999831365632,
+      "router_logit_cosine": 0.9999999971511485,
+      "router_margin_mean_delta": 2.8872276918900968e-06,
+      "router_margin_mean_observed": 0.030207654444896787,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.0061808020273402264,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.9970703125,
+      "router_top2_set_agreement": 0.9990234375,
+      "router_topk_set_agreement": 0.9990234375,
+      "seconds": 28.2824227809906,
+      "selected_experts": 2
+    },
+    {
+      "attention_output_cosine": 0.6940020562994945,
+      "attention_output_cosine_per_token": 0.7152323961545908,
+      "attn_delta_over_stream": 0.9221869464012775,
+      "block_output_cosine": 0.7722995693811194,
+      "block_output_cosine_per_token": 0.7725224441728881,
+      "block_output_drift_relative_norm": 0.673047973331658,
+      "expert_load_js_bits": 0.10899600597624538,
+      "expert_load_max_abs_delta": 0.11181640625,
+      "expert_load_observed": [
+        0.21728515625,
+        0.21337890625,
+        0.0751953125,
+        0.087158203125,
+        0.002197265625,
+        0.05126953125,
+        0.21044921875,
+        0.14306640625
+      ],
+      "expert_load_reference": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.114013671875,
+        0.127197265625,
+        0.12841796875,
+        0.1044921875
+      ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6018755328218244,
+          "top1_flips": 706
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.345372460496614,
+          "top1_flips": 153
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.1676300578034682,
+          "top1_flips": 58
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.03488372093023256,
+          "top1_flips": 3
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "goz1_pack",
+      "moe_delta_over_stream": 0.6064982247591109,
+      "moe_input_normalized_cosine": 0.9015387170318874,
+      "moe_output_cosine": 0.5318363043404472,
+      "residual_drift_relative_norm": 0.5290353565880637,
+      "residual_stream_cosine": 0.8520368529920752,
+      "router_logit_cosine": 0.9919558242505194,
+      "router_margin_mean_delta": 0.017153960094265886,
+      "router_margin_mean_observed": 0.047358727311470776,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.010049757370186749,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.55078125,
+      "router_top2_set_agreement": 0.3037109375,
+      "router_topk_set_agreement": 0.3037109375,
+      "seconds": 32.133864641189575,
+      "selected_experts": 2
+    },
+    {
+      "attention_output_cosine": 0.6940020873463366,
+      "attention_output_cosine_per_token": 0.7152333533468802,
+      "attn_delta_over_stream": 0.9222133116118338,
+      "block_output_cosine": 0.8064531098603722,
+      "block_output_cosine_per_token": 0.8063090968761824,
+      "block_output_drift_relative_norm": 0.6088791597007991,
+      "expert_load_js_bits": 0.10895478710434198,
+      "expert_load_max_abs_delta": 0.11181640625,
+      "expert_load_observed": [
+        0.21728515625,
+        0.213134765625,
+        0.074951171875,
+        0.087158203125,
+        0.002197265625,
+        0.051513671875,
+        0.21044921875,
+        0.143310546875
+      ],
+      "expert_load_reference": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.114013671875,
+        0.127197265625,
+        0.12841796875,
+        0.1044921875
+      ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6027280477408354,
+          "top1_flips": 707
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.3431151241534989,
+          "top1_flips": 152
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.16473988439306358,
+          "top1_flips": 57
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.03488372093023256,
+          "top1_flips": 3
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "goz1_attention_ternary_only",
+      "moe_delta_over_stream": 0.5459685107507056,
+      "moe_input_normalized_cosine": 0.9015516802670659,
+      "moe_output_cosine": 0.7447908827677504,
+      "residual_drift_relative_norm": 0.5289903859151668,
+      "residual_stream_cosine": 0.8520638509820196,
+      "router_logit_cosine": 0.9919571994722097,
+      "router_margin_mean_delta": 0.017146109675473108,
+      "router_margin_mean_observed": 0.047350876892678,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.010032188356574379,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.55126953125,
+      "router_top2_set_agreement": 0.30419921875,
+      "router_topk_set_agreement": 0.30419921875,
+      "seconds": 14.24652647972107,
+      "selected_experts": 2
+    },
+    {
+      "attention_output_cosine": 1.0,
+      "attention_output_cosine_per_token": 1.0,
+      "attn_delta_over_stream": 0.876171414302045,
+      "block_output_cosine": 0.9635717953874715,
+      "block_output_cosine_per_token": 0.9610040055361724,
+      "block_output_drift_relative_norm": 0.2773508234849458,
+      "expert_load_js_bits": 0.0,
+      "expert_load_max_abs_delta": 0.0,
+      "expert_load_observed": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.114013671875,
+        0.127197265625,
+        0.12841796875,
+        0.1044921875
+      ],
+      "expert_load_reference": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.114013671875,
+        0.127197265625,
+        0.12841796875,
+        0.1044921875
+      ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.0,
+          "top1_flips": 0
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "goz1_expert_ternary_only",
+      "moe_delta_over_stream": 0.5761949397414952,
+      "moe_input_normalized_cosine": 1.0,
+      "moe_output_cosine": 0.7734826618659498,
+      "residual_drift_relative_norm": 0.0,
+      "residual_stream_cosine": 1.0000000000000002,
+      "router_logit_cosine": 1.0,
+      "router_margin_mean_delta": 0.0,
+      "router_margin_mean_observed": 0.030204767217204893,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.006170911132304002,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 1.0,
+      "router_top2_set_agreement": 1.0,
+      "router_topk_set_agreement": 1.0,
+      "seconds": 32.887836933135986,
+      "selected_experts": 2
+    }
+  ],
   "provenance": {
-    "issue": "GH #61 / Linear RM-249",
     "agent": "Claude Code: Fable 5 (xhigh)",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
     "implementation": {
       "commit": "51875473106dfa20d214dede4153b6390f195943",
       "dirty": false
     },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "issue": "GH #61 / Linear RM-249",
+    "npy_dir": "goz53-block000-attn",
+    "numpy": "2.5.1",
+    "oracle_alpha": {
+      "block_000.slot_00.moe_expert.gate": {
+        "alpha": 0.03446429262403113,
+        "fired": 559126180,
+        "sign_mismatches": 0,
+        "sparsity": 0.652848777671655,
+        "total": 1610612736
+      },
+      "block_000.slot_01.moe_expert.down": {
+        "alpha": 0.022704254828049837,
+        "fired": 584204424,
+        "sign_mismatches": 0,
+        "sparsity": 0.6372781544923782,
+        "total": 1610612736
+      },
+      "block_000.slot_02.moe_expert.up": {
+        "alpha": 0.034396705025337225,
+        "fired": 572781462,
+        "sign_mismatches": 0,
+        "sparsity": 0.6443704627454281,
+        "total": 1610612736
+      },
+      "block_000.slot_03.attn_proj_i8.narrow": {
+        "alpha": 0.011270628247707765,
+        "fired": 4174122,
+        "sign_mismatches": 0,
+        "sparsity": 0.33654117584228516,
+        "total": 6291456
+      },
+      "block_000.slot_04.attn_proj_i8.model_width": {
+        "alpha": 0.00769032174762091,
+        "fired": 25152318,
+        "sign_mismatches": 0,
+        "sparsity": 0.3336911201477051,
+        "total": 37748736
+      },
+      "block_000.slot_05.attn_proj_i8.model_width": {
+        "alpha": 0.011285860723522544,
+        "fired": 25586902,
+        "sign_mismatches": 0,
+        "sparsity": 0.3221785757276747,
+        "total": 37748736
+      },
+      "block_000.slot_06.attn_proj_i8.narrow": {
+        "alpha": 0.011283784705669356,
+        "fired": 4244425,
+        "sign_mismatches": 0,
+        "sparsity": 0.32536681493123376,
+        "total": 6291456
+      }
+    },
     "pack": "block_000-attention_plus_expert.goz1",
-    "pack_sha256": "711ba726bf2838a7a7f37adb896c28279a430653148e9f39059ef5e2c8a5ac85",
     "pack_bytes": 1230128448,
     "pack_metadata": {
       "grok1.architecture": "grok-1",
@@ -24,67 +463,41 @@
       "oz.quantization_version": 1
     },
     "pack_metadata_caveat": "oz.gif_threshold is unreliable under per-tensor tau (records defaults||config only, see #66); derive the applied threshold from oracle_alpha[].sparsity",
-    "npy_dir": "goz53-block000-attn",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "tokens": 2048,
-    "token_seed": 20260806,
+    "pack_sha256": "711ba726bf2838a7a7f37adb896c28279a430653148e9f39059ef5e2c8a5ac85",
+    "python": "3.14.6",
+    "ternary_scale_note": "GOZ1 stores no per-tensor scale, so ternary weights are reconstructed with the least-squares optimal alpha derived from the original f32 weights. This is an oracle a real runtime does not have, so every number here is a best case.",
     "token_id_first": 61,
     "token_id_last": 130950,
-    "top_k": 2,
-    "numpy": "2.5.1",
-    "python": "3.14.6",
-    "oracle_alpha": {
-      "block_000.slot_00.moe_expert.gate": {
-        "alpha": 0.03446429262403113,
-        "sparsity": 0.652848777671655,
-        "fired": 559126180,
-        "total": 1610612736,
-        "sign_mismatches": 0
-      },
-      "block_000.slot_01.moe_expert.down": {
-        "alpha": 0.022704254828049837,
-        "sparsity": 0.6372781544923782,
-        "fired": 584204424,
-        "total": 1610612736,
-        "sign_mismatches": 0
-      },
-      "block_000.slot_02.moe_expert.up": {
-        "alpha": 0.034396705025337225,
-        "sparsity": 0.6443704627454281,
-        "fired": 572781462,
-        "total": 1610612736,
-        "sign_mismatches": 0
-      },
-      "block_000.slot_03.attn_proj_i8.narrow": {
-        "alpha": 0.011270628247707765,
-        "sparsity": 0.33654117584228516,
-        "fired": 4174122,
-        "total": 6291456,
-        "sign_mismatches": 0
-      },
-      "block_000.slot_04.attn_proj_i8.model_width": {
-        "alpha": 0.00769032174762091,
-        "sparsity": 0.3336911201477051,
-        "fired": 25152318,
-        "total": 37748736,
-        "sign_mismatches": 0
-      },
-      "block_000.slot_05.attn_proj_i8.model_width": {
-        "alpha": 0.011285860723522544,
-        "sparsity": 0.3221785757276747,
-        "fired": 25586902,
-        "total": 37748736,
-        "sign_mismatches": 0
-      },
-      "block_000.slot_06.attn_proj_i8.narrow": {
-        "alpha": 0.011283784705669356,
-        "sparsity": 0.32536681493123376,
-        "fired": 4244425,
-        "total": 6291456,
-        "sign_mismatches": 0
-      }
-    },
-    "ternary_scale_note": "GOZ1 stores no per-tensor scale, so ternary weights are reconstructed with the least-squares optimal alpha derived from the original f32 weights. This is an oracle a real runtime does not have, so every number here is a best case."
+    "token_seed": 20260806,
+    "tokens": 2048,
+    "top_k": 2
+  },
+  "reference": {
+    "attn_delta_over_stream": 0.876171414302045,
+    "expert_load": [
+      0.131591796875,
+      0.102294921875,
+      0.166259765625,
+      0.125732421875,
+      0.114013671875,
+      0.127197265625,
+      0.12841796875,
+      0.1044921875
+    ],
+    "experts_touched": [
+      0,
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "moe_delta_over_stream": 0.4827437027494788,
+    "router_margin_mean": 0.030204767217204893,
+    "router_margin_median": 0.006170911132304002,
+    "seconds": 16.39786982536316
   },
   "slot_roles": {
     "attn_out": "block_000.slot_04.attn_proj_i8.model_width",
@@ -99,418 +512,5 @@
     "query": "block_000.slot_05.attn_proj_i8.model_width",
     "router": "block_000.slot_11.router",
     "value": "block_000.slot_06.attn_proj_i8.narrow"
-  },
-  "reference": {
-    "expert_load": [
-      0.131591796875,
-      0.102294921875,
-      0.166259765625,
-      0.125732421875,
-      0.114013671875,
-      0.127197265625,
-      0.12841796875,
-      0.1044921875
-    ],
-    "router_margin_mean": 0.030204767217204893,
-    "router_margin_median": 0.006170911132304002,
-    "experts_touched": [
-      0,
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7
-    ],
-    "attn_delta_over_stream": 0.876171414302045,
-    "moe_delta_over_stream": 0.4827437027494788,
-    "seconds": 16.39786982536316
-  },
-  "comparisons": [
-    {
-      "label": "fp16_roundtrip",
-      "seconds": 28.2824227809906,
-      "attention_output_cosine": 0.9999999984424572,
-      "attention_output_cosine_per_token": 0.9999999986030829,
-      "residual_stream_cosine": 0.9999999831365632,
-      "moe_input_normalized_cosine": 0.9999999606124855,
-      "router_logit_cosine": 0.9999999971511485,
-      "moe_output_cosine": 0.9999813002410165,
-      "block_output_cosine": 0.9999870040318545,
-      "block_output_cosine_per_token": 0.9999880581321908,
-      "residual_drift_relative_norm": 0.00021537234101925558,
-      "block_output_drift_relative_norm": 0.005098830221729304,
-      "attn_delta_over_stream": 0.8760054853350859,
-      "moe_delta_over_stream": 0.482784499720899,
-      "router_top1_agreement": 0.9970703125,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.9990234375,
-      "router_top2_set_agreement": 0.9990234375,
-      "expert_load_reference": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.114013671875,
-        0.127197265625,
-        0.12841796875,
-        0.1044921875
-      ],
-      "expert_load_observed": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.11376953125,
-        0.127685546875,
-        0.12841796875,
-        0.104248046875
-      ],
-      "expert_load_js_bits": 5.347430923457726e-07,
-      "expert_load_max_abs_delta": 0.00048828125,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.030207654444896787,
-      "router_margin_mean_delta": 2.8872276918900968e-06,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.0061808020273402264,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 6,
-          "top1_flip_rate": 0.005115089514066497
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "label": "goz1_pack",
-      "seconds": 32.133864641189575,
-      "attention_output_cosine": 0.6940020562994945,
-      "attention_output_cosine_per_token": 0.7152323961545908,
-      "residual_stream_cosine": 0.8520368529920752,
-      "moe_input_normalized_cosine": 0.9015387170318874,
-      "router_logit_cosine": 0.9919558242505194,
-      "moe_output_cosine": 0.5318363043404472,
-      "block_output_cosine": 0.7722995693811194,
-      "block_output_cosine_per_token": 0.7725224441728881,
-      "residual_drift_relative_norm": 0.5290353565880637,
-      "block_output_drift_relative_norm": 0.673047973331658,
-      "attn_delta_over_stream": 0.9221869464012775,
-      "moe_delta_over_stream": 0.6064982247591109,
-      "router_top1_agreement": 0.55078125,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.3037109375,
-      "router_top2_set_agreement": 0.3037109375,
-      "expert_load_reference": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.114013671875,
-        0.127197265625,
-        0.12841796875,
-        0.1044921875
-      ],
-      "expert_load_observed": [
-        0.21728515625,
-        0.21337890625,
-        0.0751953125,
-        0.087158203125,
-        0.002197265625,
-        0.05126953125,
-        0.21044921875,
-        0.14306640625
-      ],
-      "expert_load_js_bits": 0.10899600597624538,
-      "expert_load_max_abs_delta": 0.11181640625,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.047358727311470776,
-      "router_margin_mean_delta": 0.017153960094265886,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.010049757370186749,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 706,
-          "top1_flip_rate": 0.6018755328218244
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 153,
-          "top1_flip_rate": 0.345372460496614
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 58,
-          "top1_flip_rate": 0.1676300578034682
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 3,
-          "top1_flip_rate": 0.03488372093023256
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "label": "goz1_attention_ternary_only",
-      "seconds": 14.24652647972107,
-      "attention_output_cosine": 0.6940020873463366,
-      "attention_output_cosine_per_token": 0.7152333533468802,
-      "residual_stream_cosine": 0.8520638509820196,
-      "moe_input_normalized_cosine": 0.9015516802670659,
-      "router_logit_cosine": 0.9919571994722097,
-      "moe_output_cosine": 0.7447908827677504,
-      "block_output_cosine": 0.8064531098603722,
-      "block_output_cosine_per_token": 0.8063090968761824,
-      "residual_drift_relative_norm": 0.5289903859151668,
-      "block_output_drift_relative_norm": 0.6088791597007991,
-      "attn_delta_over_stream": 0.9222133116118338,
-      "moe_delta_over_stream": 0.5459685107507056,
-      "router_top1_agreement": 0.55126953125,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.30419921875,
-      "router_top2_set_agreement": 0.30419921875,
-      "expert_load_reference": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.114013671875,
-        0.127197265625,
-        0.12841796875,
-        0.1044921875
-      ],
-      "expert_load_observed": [
-        0.21728515625,
-        0.213134765625,
-        0.074951171875,
-        0.087158203125,
-        0.002197265625,
-        0.051513671875,
-        0.21044921875,
-        0.143310546875
-      ],
-      "expert_load_js_bits": 0.10895478710434198,
-      "expert_load_max_abs_delta": 0.11181640625,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.047350876892678,
-      "router_margin_mean_delta": 0.017146109675473108,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.010032188356574379,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 707,
-          "top1_flip_rate": 0.6027280477408354
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 152,
-          "top1_flip_rate": 0.3431151241534989
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 57,
-          "top1_flip_rate": 0.16473988439306358
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 3,
-          "top1_flip_rate": 0.03488372093023256
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "label": "goz1_expert_ternary_only",
-      "seconds": 32.887836933135986,
-      "attention_output_cosine": 1.0,
-      "attention_output_cosine_per_token": 1.0,
-      "residual_stream_cosine": 1.0000000000000002,
-      "moe_input_normalized_cosine": 1.0,
-      "router_logit_cosine": 1.0,
-      "moe_output_cosine": 0.7734826618659498,
-      "block_output_cosine": 0.9635717953874715,
-      "block_output_cosine_per_token": 0.9610040055361724,
-      "residual_drift_relative_norm": 0.0,
-      "block_output_drift_relative_norm": 0.2773508234849458,
-      "attn_delta_over_stream": 0.876171414302045,
-      "moe_delta_over_stream": 0.5761949397414952,
-      "router_top1_agreement": 1.0,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 1.0,
-      "router_top2_set_agreement": 1.0,
-      "expert_load_reference": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.114013671875,
-        0.127197265625,
-        0.12841796875,
-        0.1044921875
-      ],
-      "expert_load_observed": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.114013671875,
-        0.127197265625,
-        0.12841796875,
-        0.1044921875
-      ],
-      "expert_load_js_bits": 0.0,
-      "expert_load_max_abs_delta": 0.0,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.030204767217204893,
-      "router_margin_mean_delta": 0.0,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.006170911132304002,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 0,
-          "top1_flip_rate": 0.0
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    }
-  ]
+  }
 }

--- a/reports/grok-1-full-block-forward/block0-forward-tau-sweep.json
+++ b/reports/grok-1-full-block-forward/block0-forward-tau-sweep.json
@@ -1,23 +1,36 @@
 {
   "provenance": {
-    "issue": "GH #61 / Linear RM-249",
     "agent": "Claude Code: Fable 5 (xhigh)",
+    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "attn_npy_dir": "goz61-block000-attn-only",
+    "design": "Attention tier only; experts held at the f32 reference because single-block routing is computed upstream of the experts.",
+    "embedding_shard": "embedding__slot_00__token_embedding.npy",
+    "expect_block": "block_000",
     "implementation": {
       "commit": "51875473106dfa20d214dede4153b6390f195943",
       "dirty": false
     },
-    "architecture_source": "github.com/xai-org/grok-1 model.py + run.py",
+    "issue": "GH #61 / Linear RM-249",
     "npy_dir": "goz53-block000-attn",
-    "attn_npy_dir": "goz61-block000-attn-only",
-    "embedding_shard": "embedding__slot_00__token_embedding.npy",
-    "expect_block": "block_000",
+    "numpy": "2.5.1",
     "python": "3.14.6",
     "tau_source": "parsed from each pack filename and cross-checked against measured sparsity vs erf(tau/sqrt2); oz.gif_threshold is unreliable under per-tensor tau (see #66)",
-    "design": "Attention tier only; experts held at the f32 reference because single-block routing is computed upstream of the experts.",
-    "tokens": 2048,
     "token_seed": 20260806,
-    "top_k": 2,
-    "numpy": "2.5.1"
+    "tokens": 2048,
+    "top_k": 2
+  },
+  "reference": {
+    "expert_load": [
+      0.131591796875,
+      0.102294921875,
+      0.166259765625,
+      0.125732421875,
+      0.114013671875,
+      0.127197265625,
+      0.12841796875,
+      0.1044921875
+    ],
+    "router_margin_median": 0.006170911132304002
   },
   "slot_roles": {
     "attn_out": "block_000.slot_04.attn_proj_i8.model_width",
@@ -33,60 +46,16 @@
     "router": "block_000.slot_11.router",
     "value": "block_000.slot_06.attn_proj_i8.narrow"
   },
-  "reference": {
-    "expert_load": [
-      0.131591796875,
-      0.102294921875,
-      0.166259765625,
-      0.125732421875,
-      0.114013671875,
-      0.127197265625,
-      0.12841796875,
-      0.1044921875
-    ],
-    "router_margin_median": 0.006170911132304002
-  },
   "sweep": [
     {
-      "tau": 0.1,
-      "pack": "attn-tau-0.1.goz1",
-      "pack_sha256": "a71e4be1b697d846cf9391b5238e9a93c9efb114103e8c2d6002c14d54b32e12",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.08666308720906579,
-        "slot_04.attn_proj_i8.model_width": 0.0859593550364176,
-        "slot_05.attn_proj_i8.model_width": 0.08295186360677087,
-        "slot_06.attn_proj_i8.narrow": 0.08370224634806311
-      },
-      "sparsity_expected_gaussian": 0.07965567455405796,
-      "label": "attn_tau_0.1",
-      "seconds": 13.65711784362793,
       "attention_output_cosine": 0.6592071839720569,
       "attention_output_cosine_per_token": 0.6819371823399478,
-      "residual_stream_cosine": 0.8296113150997796,
-      "moe_input_normalized_cosine": 0.8701497686564467,
-      "router_logit_cosine": 0.9910102692791797,
-      "moe_output_cosine": 0.7262906253800726,
+      "attn_delta_over_stream": 0.9076228306321326,
       "block_output_cosine": 0.7908109967745105,
       "block_output_cosine_per_token": 0.7897410389864343,
-      "residual_drift_relative_norm": 0.5648335159743757,
       "block_output_drift_relative_norm": 0.631454652585991,
-      "attn_delta_over_stream": 0.9076228306321326,
-      "moe_delta_over_stream": 0.5432591995079622,
-      "router_top1_agreement": 0.505859375,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.27783203125,
-      "router_top2_set_agreement": 0.27783203125,
-      "expert_load_reference": [
-        0.131591796875,
-        0.102294921875,
-        0.166259765625,
-        0.125732421875,
-        0.114013671875,
-        0.127197265625,
-        0.12841796875,
-        0.1044921875
-      ],
+      "expert_load_js_bits": 0.11321887431573927,
+      "expert_load_max_abs_delta": 0.147705078125,
       "expert_load_observed": [
         0.21923828125,
         0.14013671875,
@@ -97,93 +66,6 @@
         0.276123046875,
         0.138671875
       ],
-      "expert_load_js_bits": 0.11321887431573927,
-      "expert_load_max_abs_delta": 0.147705078125,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.04731407405325782,
-      "router_margin_mean_delta": 0.01710930683605292,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.011466065376517898,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 758,
-          "top1_flip_rate": 0.6462063086104007
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 169,
-          "top1_flip_rate": 0.38148984198645597
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 81,
-          "top1_flip_rate": 0.23410404624277456
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 4,
-          "top1_flip_rate": 0.046511627906976744
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 0.2,
-      "pack": "attn-tau-0.2.goz1",
-      "pack_sha256": "80c28edd4c5a9e6724e056e26cc513ecae0f42eedb6ac003f9a7d79fef74dc81",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.17252874374389648,
-        "slot_04.attn_proj_i8.model_width": 0.17079745398627388,
-        "slot_05.attn_proj_i8.model_width": 0.16496353679233122,
-        "slot_06.attn_proj_i8.narrow": 0.1668229103088379
-      },
-      "sparsity_expected_gaussian": 0.15851941887820603,
-      "label": "attn_tau_0.2",
-      "seconds": 15.616098403930664,
-      "attention_output_cosine": 0.6683543560900498,
-      "attention_output_cosine_per_token": 0.6908134593227351,
-      "residual_stream_cosine": 0.8351077117589413,
-      "moe_input_normalized_cosine": 0.880618004650171,
-      "router_logit_cosine": 0.9913387435490705,
-      "moe_output_cosine": 0.7242597551903422,
-      "block_output_cosine": 0.7889423647470201,
-      "block_output_cosine_per_token": 0.7884315786191515,
-      "residual_drift_relative_norm": 0.5564888150464791,
-      "block_output_drift_relative_norm": 0.6355329066025824,
-      "attn_delta_over_stream": 0.9114832391851089,
-      "moe_delta_over_stream": 0.5391463905028457,
-      "router_top1_agreement": 0.5068359375,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.26953125,
-      "router_top2_set_agreement": 0.26953125,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -194,6 +76,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6462063086104007,
+          "top1_flips": 758
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.38148984198645597,
+          "top1_flips": 169
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.23410404624277456,
+          "top1_flips": 81
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.046511627906976744,
+          "top1_flips": 4
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_0.1",
+      "moe_delta_over_stream": 0.5432591995079622,
+      "moe_input_normalized_cosine": 0.8701497686564467,
+      "moe_output_cosine": 0.7262906253800726,
+      "pack": "attn-tau-0.1.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "a71e4be1b697d846cf9391b5238e9a93c9efb114103e8c2d6002c14d54b32e12",
+      "residual_drift_relative_norm": 0.5648335159743757,
+      "residual_stream_cosine": 0.8296113150997796,
+      "router_logit_cosine": 0.9910102692791797,
+      "router_margin_mean_delta": 0.01710930683605292,
+      "router_margin_mean_observed": 0.04731407405325782,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.011466065376517898,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.505859375,
+      "router_top2_set_agreement": 0.27783203125,
+      "router_topk_set_agreement": 0.27783203125,
+      "seconds": 13.65711784362793,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.08666308720906579,
+        "slot_04.attn_proj_i8.model_width": 0.0859593550364176,
+        "slot_05.attn_proj_i8.model_width": 0.08295186360677087,
+        "slot_06.attn_proj_i8.narrow": 0.08370224634806311
+      },
+      "sparsity_expected_gaussian": 0.07965567455405796,
+      "tau": 0.1
+    },
+    {
+      "attention_output_cosine": 0.6683543560900498,
+      "attention_output_cosine_per_token": 0.6908134593227351,
+      "attn_delta_over_stream": 0.9114832391851089,
+      "block_output_cosine": 0.7889423647470201,
+      "block_output_cosine_per_token": 0.7884315786191515,
+      "block_output_drift_relative_norm": 0.6355329066025824,
+      "expert_load_js_bits": 0.12229048968125684,
+      "expert_load_max_abs_delta": 0.148681640625,
       "expert_load_observed": [
         0.20556640625,
         0.178955078125,
@@ -204,93 +173,6 @@
         0.277099609375,
         0.146728515625
       ],
-      "expert_load_js_bits": 0.12229048968125684,
-      "expert_load_max_abs_delta": 0.148681640625,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.04259501709005715,
-      "router_margin_mean_delta": 0.012390249872852258,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.008820215377112667,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 732,
-          "top1_flip_rate": 0.6240409207161125
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 180,
-          "top1_flip_rate": 0.40632054176072235
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 93,
-          "top1_flip_rate": 0.26878612716763006
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 5,
-          "top1_flip_rate": 0.05813953488372093
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 0.4,
-      "pack": "attn-tau-0.4.goz1",
-      "pack_sha256": "7d8ebe81fa30413518de08d41e69eb9cb797bc37d626bf559b73efef30be6418",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.33654117584228516,
-        "slot_04.attn_proj_i8.model_width": 0.3336911201477051,
-        "slot_05.attn_proj_i8.model_width": 0.3221785757276747,
-        "slot_06.attn_proj_i8.narrow": 0.32536681493123376
-      },
-      "sparsity_expected_gaussian": 0.3108434832206483,
-      "label": "attn_tau_0.4",
-      "seconds": 14.726291418075562,
-      "attention_output_cosine": 0.6940020873463366,
-      "attention_output_cosine_per_token": 0.7152333533468802,
-      "residual_stream_cosine": 0.8520638509820196,
-      "moe_input_normalized_cosine": 0.9015516802670659,
-      "router_logit_cosine": 0.9919571994722097,
-      "moe_output_cosine": 0.7447908827677504,
-      "block_output_cosine": 0.8064531098603722,
-      "block_output_cosine_per_token": 0.8063090968761824,
-      "residual_drift_relative_norm": 0.5289903859151668,
-      "block_output_drift_relative_norm": 0.6088791597007991,
-      "attn_delta_over_stream": 0.9222133116118338,
-      "moe_delta_over_stream": 0.5459685107507056,
-      "router_top1_agreement": 0.55126953125,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.30419921875,
-      "router_top2_set_agreement": 0.30419921875,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -301,6 +183,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6240409207161125,
+          "top1_flips": 732
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.40632054176072235,
+          "top1_flips": 180
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.26878612716763006,
+          "top1_flips": 93
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.05813953488372093,
+          "top1_flips": 5
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_0.2",
+      "moe_delta_over_stream": 0.5391463905028457,
+      "moe_input_normalized_cosine": 0.880618004650171,
+      "moe_output_cosine": 0.7242597551903422,
+      "pack": "attn-tau-0.2.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "80c28edd4c5a9e6724e056e26cc513ecae0f42eedb6ac003f9a7d79fef74dc81",
+      "residual_drift_relative_norm": 0.5564888150464791,
+      "residual_stream_cosine": 0.8351077117589413,
+      "router_logit_cosine": 0.9913387435490705,
+      "router_margin_mean_delta": 0.012390249872852258,
+      "router_margin_mean_observed": 0.04259501709005715,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.008820215377112667,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.5068359375,
+      "router_top2_set_agreement": 0.26953125,
+      "router_topk_set_agreement": 0.26953125,
+      "seconds": 15.616098403930664,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.17252874374389648,
+        "slot_04.attn_proj_i8.model_width": 0.17079745398627388,
+        "slot_05.attn_proj_i8.model_width": 0.16496353679233122,
+        "slot_06.attn_proj_i8.narrow": 0.1668229103088379
+      },
+      "sparsity_expected_gaussian": 0.15851941887820603,
+      "tau": 0.2
+    },
+    {
+      "attention_output_cosine": 0.6940020873463366,
+      "attention_output_cosine_per_token": 0.7152333533468802,
+      "attn_delta_over_stream": 0.9222133116118338,
+      "block_output_cosine": 0.8064531098603722,
+      "block_output_cosine_per_token": 0.8063090968761824,
+      "block_output_drift_relative_norm": 0.6088791597007991,
+      "expert_load_js_bits": 0.10895478710434198,
+      "expert_load_max_abs_delta": 0.11181640625,
       "expert_load_observed": [
         0.21728515625,
         0.213134765625,
@@ -311,93 +280,6 @@
         0.21044921875,
         0.143310546875
       ],
-      "expert_load_js_bits": 0.10895478710434198,
-      "expert_load_max_abs_delta": 0.11181640625,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.047350876892678,
-      "router_margin_mean_delta": 0.017146109675473108,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.010032188356574379,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 707,
-          "top1_flip_rate": 0.6027280477408354
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 152,
-          "top1_flip_rate": 0.3431151241534989
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 57,
-          "top1_flip_rate": 0.16473988439306358
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 3,
-          "top1_flip_rate": 0.03488372093023256
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 0.6,
-      "pack": "attn-tau-0.6.goz1",
-      "pack_sha256": "becb4978c97fff46fa8237d89ba2d2dfb2f8c577d0cd8dfb25663f14018713fa",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.4836085637410482,
-        "slot_04.attn_proj_i8.model_width": 0.4808473851945665,
-        "slot_05.attn_proj_i8.model_width": 0.46593125661214196,
-        "slot_06.attn_proj_i8.narrow": 0.4701056480407715
-      },
-      "sparsity_expected_gaussian": 0.4514937644998528,
-      "label": "attn_tau_0.6",
-      "seconds": 12.545000791549683,
-      "attention_output_cosine": 0.7303809213878721,
-      "attention_output_cosine_per_token": 0.7494975691968067,
-      "residual_stream_cosine": 0.8707542046193044,
-      "moe_input_normalized_cosine": 0.9167546655076892,
-      "router_logit_cosine": 0.9926388576484938,
-      "moe_output_cosine": 0.7487476544614992,
-      "block_output_cosine": 0.8171827340785156,
-      "block_output_cosine_per_token": 0.8171785578101253,
-      "residual_drift_relative_norm": 0.49810852983866494,
-      "block_output_drift_relative_norm": 0.592825054938303,
-      "attn_delta_over_stream": 0.9410632195333158,
-      "moe_delta_over_stream": 0.5344879859982987,
-      "router_top1_agreement": 0.56640625,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.30810546875,
-      "router_top2_set_agreement": 0.30810546875,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -408,6 +290,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6027280477408354,
+          "top1_flips": 707
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.3431151241534989,
+          "top1_flips": 152
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.16473988439306358,
+          "top1_flips": 57
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.03488372093023256,
+          "top1_flips": 3
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_0.4",
+      "moe_delta_over_stream": 0.5459685107507056,
+      "moe_input_normalized_cosine": 0.9015516802670659,
+      "moe_output_cosine": 0.7447908827677504,
+      "pack": "attn-tau-0.4.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "7d8ebe81fa30413518de08d41e69eb9cb797bc37d626bf559b73efef30be6418",
+      "residual_drift_relative_norm": 0.5289903859151668,
+      "residual_stream_cosine": 0.8520638509820196,
+      "router_logit_cosine": 0.9919571994722097,
+      "router_margin_mean_delta": 0.017146109675473108,
+      "router_margin_mean_observed": 0.047350876892678,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.010032188356574379,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.55126953125,
+      "router_top2_set_agreement": 0.30419921875,
+      "router_topk_set_agreement": 0.30419921875,
+      "seconds": 14.726291418075562,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.33654117584228516,
+        "slot_04.attn_proj_i8.model_width": 0.3336911201477051,
+        "slot_05.attn_proj_i8.model_width": 0.3221785757276747,
+        "slot_06.attn_proj_i8.narrow": 0.32536681493123376
+      },
+      "sparsity_expected_gaussian": 0.3108434832206483,
+      "tau": 0.4
+    },
+    {
+      "attention_output_cosine": 0.7303809213878721,
+      "attention_output_cosine_per_token": 0.7494975691968067,
+      "attn_delta_over_stream": 0.9410632195333158,
+      "block_output_cosine": 0.8171827340785156,
+      "block_output_cosine_per_token": 0.8171785578101253,
+      "block_output_drift_relative_norm": 0.592825054938303,
+      "expert_load_js_bits": 0.10253433729001477,
+      "expert_load_max_abs_delta": 0.165283203125,
       "expert_load_observed": [
         0.173095703125,
         0.176513671875,
@@ -418,93 +387,6 @@
         0.293701171875,
         0.087158203125
       ],
-      "expert_load_js_bits": 0.10253433729001477,
-      "expert_load_max_abs_delta": 0.165283203125,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.03771292055867246,
-      "router_margin_mean_delta": 0.007508153341467563,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.008023267221204694,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 681,
-          "top1_flip_rate": 0.5805626598465473
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 157,
-          "top1_flip_rate": 0.3544018058690745
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 49,
-          "top1_flip_rate": 0.1416184971098266
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 1,
-          "top1_flip_rate": 0.011627906976744186
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 0.8,
-      "pack": "attn-tau-0.8.goz1",
-      "pack_sha256": "8096043b1a0b083362c8f169a8348e4b0c468dce0ab36af7880f9d7c2defc162",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.6090842882792156,
-        "slot_04.attn_proj_i8.model_width": 0.6084998713599311,
-        "slot_05.attn_proj_i8.model_width": 0.5908790164523654,
-        "slot_06.attn_proj_i8.narrow": 0.5950547854105632
-      },
-      "sparsity_expected_gaussian": 0.5762892028332066,
-      "label": "attn_tau_0.8",
-      "seconds": 12.197422504425049,
-      "attention_output_cosine": 0.7857555095684784,
-      "attention_output_cosine_per_token": 0.8040123052723027,
-      "residual_stream_cosine": 0.8949252265228429,
-      "moe_input_normalized_cosine": 0.9039678392586037,
-      "router_logit_cosine": 0.9910881370589534,
-      "moe_output_cosine": 0.7132623794556953,
-      "block_output_cosine": 0.8496555243608246,
-      "block_output_cosine_per_token": 0.8495965609774461,
-      "residual_drift_relative_norm": 0.4551003151745244,
-      "block_output_drift_relative_norm": 0.5432037163497931,
-      "attn_delta_over_stream": 0.9696342512747983,
-      "moe_delta_over_stream": 0.5183251049312805,
-      "router_top1_agreement": 0.5244140625,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.27099609375,
-      "router_top2_set_agreement": 0.27099609375,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -515,6 +397,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.5805626598465473,
+          "top1_flips": 681
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.3544018058690745,
+          "top1_flips": 157
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.1416184971098266,
+          "top1_flips": 49
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.011627906976744186,
+          "top1_flips": 1
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_0.6",
+      "moe_delta_over_stream": 0.5344879859982987,
+      "moe_input_normalized_cosine": 0.9167546655076892,
+      "moe_output_cosine": 0.7487476544614992,
+      "pack": "attn-tau-0.6.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "becb4978c97fff46fa8237d89ba2d2dfb2f8c577d0cd8dfb25663f14018713fa",
+      "residual_drift_relative_norm": 0.49810852983866494,
+      "residual_stream_cosine": 0.8707542046193044,
+      "router_logit_cosine": 0.9926388576484938,
+      "router_margin_mean_delta": 0.007508153341467563,
+      "router_margin_mean_observed": 0.03771292055867246,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.008023267221204694,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.56640625,
+      "router_top2_set_agreement": 0.30810546875,
+      "router_topk_set_agreement": 0.30810546875,
+      "seconds": 12.545000791549683,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.4836085637410482,
+        "slot_04.attn_proj_i8.model_width": 0.4808473851945665,
+        "slot_05.attn_proj_i8.model_width": 0.46593125661214196,
+        "slot_06.attn_proj_i8.narrow": 0.4701056480407715
+      },
+      "sparsity_expected_gaussian": 0.4514937644998528,
+      "tau": 0.6
+    },
+    {
+      "attention_output_cosine": 0.7857555095684784,
+      "attention_output_cosine_per_token": 0.8040123052723027,
+      "attn_delta_over_stream": 0.9696342512747983,
+      "block_output_cosine": 0.8496555243608246,
+      "block_output_cosine_per_token": 0.8495965609774461,
+      "block_output_drift_relative_norm": 0.5432037163497931,
+      "expert_load_js_bits": 0.1292639683457248,
+      "expert_load_max_abs_delta": 0.140625,
       "expert_load_observed": [
         0.219970703125,
         0.115478515625,
@@ -525,93 +494,6 @@
         0.222900390625,
         0.025634765625
       ],
-      "expert_load_js_bits": 0.1292639683457248,
-      "expert_load_max_abs_delta": 0.140625,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.050668086719685666,
-      "router_margin_mean_delta": 0.020463319502480766,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.011216644730204256,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 745,
-          "top1_flip_rate": 0.6351236146632566
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 163,
-          "top1_flip_rate": 0.36794582392776526
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 64,
-          "top1_flip_rate": 0.18497109826589594
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 2,
-          "top1_flip_rate": 0.023255813953488372
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 1.0,
-      "pack": "attn-tau-1.0.goz1",
-      "pack_sha256": "a7e6bfa986e2014ac939ff7ce52753ef6e241f7b099558808850c6b47e71b1d4",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.7115236918131511,
-        "slot_04.attn_proj_i8.model_width": 0.7129982047610812,
-        "slot_05.attn_proj_i8.model_width": 0.6959578196207683,
-        "slot_06.attn_proj_i8.narrow": 0.6992530822753906
-      },
-      "sparsity_expected_gaussian": 0.6826894921370859,
-      "label": "attn_tau_1.0",
-      "seconds": 13.070545196533203,
-      "attention_output_cosine": 0.8404000501766765,
-      "attention_output_cosine_per_token": 0.8557574350816874,
-      "residual_stream_cosine": 0.9215224333234749,
-      "moe_input_normalized_cosine": 0.8903112045145384,
-      "router_logit_cosine": 0.9911810370642574,
-      "moe_output_cosine": 0.7104573219135238,
-      "block_output_cosine": 0.8817757312824375,
-      "block_output_cosine_per_token": 0.8818429270015898,
-      "residual_drift_relative_norm": 0.4048631714970256,
-      "block_output_drift_relative_norm": 0.49260581488330935,
-      "attn_delta_over_stream": 1.0123142884177008,
-      "moe_delta_over_stream": 0.486945388995087,
-      "router_top1_agreement": 0.4931640625,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.248046875,
-      "router_top2_set_agreement": 0.248046875,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -622,6 +504,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6351236146632566,
+          "top1_flips": 745
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.36794582392776526,
+          "top1_flips": 163
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.18497109826589594,
+          "top1_flips": 64
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.023255813953488372,
+          "top1_flips": 2
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_0.8",
+      "moe_delta_over_stream": 0.5183251049312805,
+      "moe_input_normalized_cosine": 0.9039678392586037,
+      "moe_output_cosine": 0.7132623794556953,
+      "pack": "attn-tau-0.8.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "8096043b1a0b083362c8f169a8348e4b0c468dce0ab36af7880f9d7c2defc162",
+      "residual_drift_relative_norm": 0.4551003151745244,
+      "residual_stream_cosine": 0.8949252265228429,
+      "router_logit_cosine": 0.9910881370589534,
+      "router_margin_mean_delta": 0.020463319502480766,
+      "router_margin_mean_observed": 0.050668086719685666,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.011216644730204256,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.5244140625,
+      "router_top2_set_agreement": 0.27099609375,
+      "router_topk_set_agreement": 0.27099609375,
+      "seconds": 12.197422504425049,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.6090842882792156,
+        "slot_04.attn_proj_i8.model_width": 0.6084998713599311,
+        "slot_05.attn_proj_i8.model_width": 0.5908790164523654,
+        "slot_06.attn_proj_i8.narrow": 0.5950547854105632
+      },
+      "sparsity_expected_gaussian": 0.5762892028332066,
+      "tau": 0.8
+    },
+    {
+      "attention_output_cosine": 0.8404000501766765,
+      "attention_output_cosine_per_token": 0.8557574350816874,
+      "attn_delta_over_stream": 1.0123142884177008,
+      "block_output_cosine": 0.8817757312824375,
+      "block_output_cosine_per_token": 0.8818429270015898,
+      "block_output_drift_relative_norm": 0.49260581488330935,
+      "expert_load_js_bits": 0.14312771850709652,
+      "expert_load_max_abs_delta": 0.231689453125,
       "expert_load_observed": [
         0.199462890625,
         0.048828125,
@@ -632,93 +601,6 @@
         0.17578125,
         0.0048828125
       ],
-      "expert_load_js_bits": 0.14312771850709652,
-      "expert_load_max_abs_delta": 0.231689453125,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.04500786576335755,
-      "router_margin_mean_delta": 0.014803098546152646,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.0110036996935136,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 779,
-          "top1_flip_rate": 0.6641091219096334
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 178,
-          "top1_flip_rate": 0.4018058690744921
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 79,
-          "top1_flip_rate": 0.22832369942196531
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 2,
-          "top1_flip_rate": 0.023255813953488372
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 1.2,
-      "pack": "attn-tau-1.2.goz1",
-      "pack_sha256": "395ccb62422c78beb2a9eb028f2d386660ba5e6e93fa206b3fa6faf625dffeb4",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.7905298868815104,
-        "slot_04.attn_proj_i8.model_width": 0.7951975928412544,
-        "slot_05.attn_proj_i8.model_width": 0.7794376744164361,
-        "slot_06.attn_proj_i8.narrow": 0.7817619641621908
-      },
-      "sparsity_expected_gaussian": 0.7698606595565834,
-      "label": "attn_tau_1.2",
-      "seconds": 13.220785140991211,
-      "attention_output_cosine": 0.8899305670638377,
-      "attention_output_cosine_per_token": 0.9025396321283661,
-      "residual_stream_cosine": 0.939853972300652,
-      "moe_input_normalized_cosine": 0.8934750449678699,
-      "router_logit_cosine": 0.9911421846047301,
-      "moe_output_cosine": 0.7261434171257182,
-      "block_output_cosine": 0.8981005859278001,
-      "block_output_cosine_per_token": 0.8980830903951857,
-      "residual_drift_relative_norm": 0.369056578692353,
-      "block_output_drift_relative_norm": 0.4652164923285961,
-      "attn_delta_over_stream": 1.0354657202495288,
-      "moe_delta_over_stream": 0.4663679433657316,
-      "router_top1_agreement": 0.46630859375,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.17919921875,
-      "router_top2_set_agreement": 0.17919921875,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -729,6 +611,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.6641091219096334,
+          "top1_flips": 779
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.4018058690744921,
+          "top1_flips": 178
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.22832369942196531,
+          "top1_flips": 79
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.023255813953488372,
+          "top1_flips": 2
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_1.0",
+      "moe_delta_over_stream": 0.486945388995087,
+      "moe_input_normalized_cosine": 0.8903112045145384,
+      "moe_output_cosine": 0.7104573219135238,
+      "pack": "attn-tau-1.0.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "a7e6bfa986e2014ac939ff7ce52753ef6e241f7b099558808850c6b47e71b1d4",
+      "residual_drift_relative_norm": 0.4048631714970256,
+      "residual_stream_cosine": 0.9215224333234749,
+      "router_logit_cosine": 0.9911810370642574,
+      "router_margin_mean_delta": 0.014803098546152646,
+      "router_margin_mean_observed": 0.04500786576335755,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.0110036996935136,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.4931640625,
+      "router_top2_set_agreement": 0.248046875,
+      "router_topk_set_agreement": 0.248046875,
+      "seconds": 13.070545196533203,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.7115236918131511,
+        "slot_04.attn_proj_i8.model_width": 0.7129982047610812,
+        "slot_05.attn_proj_i8.model_width": 0.6959578196207683,
+        "slot_06.attn_proj_i8.narrow": 0.6992530822753906
+      },
+      "sparsity_expected_gaussian": 0.6826894921370859,
+      "tau": 1.0
+    },
+    {
+      "attention_output_cosine": 0.8899305670638377,
+      "attention_output_cosine_per_token": 0.9025396321283661,
+      "attn_delta_over_stream": 1.0354657202495288,
+      "block_output_cosine": 0.8981005859278001,
+      "block_output_cosine_per_token": 0.8980830903951857,
+      "block_output_drift_relative_norm": 0.4652164923285961,
+      "expert_load_js_bits": 0.2155843225892316,
+      "expert_load_max_abs_delta": 0.254638671875,
       "expert_load_observed": [
         0.17919921875,
         0.02783203125,
@@ -739,93 +708,6 @@
         0.034912109375,
         0.000732421875
       ],
-      "expert_load_js_bits": 0.2155843225892316,
-      "expert_load_max_abs_delta": 0.254638671875,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 0,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.037113714734143,
-      "router_margin_mean_delta": 0.006908947516938103,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.010491938250514393,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 810,
-          "top1_flip_rate": 0.690537084398977
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 203,
-          "top1_flip_rate": 0.4582392776523702
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 76,
-          "top1_flip_rate": 0.21965317919075145
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 4,
-          "top1_flip_rate": 0.046511627906976744
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
-      ],
-      "experts_touched": [
-        0,
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7
-      ]
-    },
-    {
-      "tau": 1.6,
-      "pack": "attn-tau-1.6.goz1",
-      "pack_sha256": "00c5fef1c23692c1b7f8d43a14473aa47f31bb23f15ead7d81c48a25b0d9a8d6",
-      "pack_bytes": 22168640,
-      "sparsity": {
-        "slot_03.attn_proj_i8.narrow": 0.8953730265299479,
-        "slot_04.attn_proj_i8.model_width": 0.9026632308959961,
-        "slot_05.attn_proj_i8.model_width": 0.8928340276082357,
-        "slot_06.attn_proj_i8.narrow": 0.8933672904968262
-      },
-      "sparsity_expected_gaussian": 0.890401416600884,
-      "label": "attn_tau_1.6",
-      "seconds": 12.80456829071045,
-      "attention_output_cosine": 0.8994259975978504,
-      "attention_output_cosine_per_token": 0.9121963470678534,
-      "residual_stream_cosine": 0.9441519705581737,
-      "moe_input_normalized_cosine": 0.8245691527710912,
-      "router_logit_cosine": 0.9902756417001566,
-      "moe_output_cosine": 0.7233418882079503,
-      "block_output_cosine": 0.9172670492125661,
-      "block_output_cosine_per_token": 0.9151671493797464,
-      "residual_drift_relative_norm": 0.414590671701332,
-      "block_output_drift_relative_norm": 0.46994708966231213,
-      "attn_delta_over_stream": 1.0827295984481613,
-      "moe_delta_over_stream": 0.3935953600801783,
-      "router_top1_agreement": 0.4892578125,
-      "selected_experts": 2,
-      "router_topk_set_agreement": 0.1484375,
-      "router_top2_set_agreement": 0.1484375,
       "expert_load_reference": [
         0.131591796875,
         0.102294921875,
@@ -836,6 +718,93 @@
         0.12841796875,
         0.1044921875
       ],
+      "experts_touched": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7
+      ],
+      "experts_unused_observed": 0,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.690537084398977,
+          "top1_flips": 810
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.4582392776523702,
+          "top1_flips": 203
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.21965317919075145,
+          "top1_flips": 76
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.046511627906976744,
+          "top1_flips": 4
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_1.2",
+      "moe_delta_over_stream": 0.4663679433657316,
+      "moe_input_normalized_cosine": 0.8934750449678699,
+      "moe_output_cosine": 0.7261434171257182,
+      "pack": "attn-tau-1.2.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "395ccb62422c78beb2a9eb028f2d386660ba5e6e93fa206b3fa6faf625dffeb4",
+      "residual_drift_relative_norm": 0.369056578692353,
+      "residual_stream_cosine": 0.939853972300652,
+      "router_logit_cosine": 0.9911421846047301,
+      "router_margin_mean_delta": 0.006908947516938103,
+      "router_margin_mean_observed": 0.037113714734143,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.010491938250514393,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.46630859375,
+      "router_top2_set_agreement": 0.17919921875,
+      "router_topk_set_agreement": 0.17919921875,
+      "seconds": 13.220785140991211,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.7905298868815104,
+        "slot_04.attn_proj_i8.model_width": 0.7951975928412544,
+        "slot_05.attn_proj_i8.model_width": 0.7794376744164361,
+        "slot_06.attn_proj_i8.narrow": 0.7817619641621908
+      },
+      "sparsity_expected_gaussian": 0.7698606595565834,
+      "tau": 1.2
+    },
+    {
+      "attention_output_cosine": 0.8994259975978504,
+      "attention_output_cosine_per_token": 0.9121963470678534,
+      "attn_delta_over_stream": 1.0827295984481613,
+      "block_output_cosine": 0.9172670492125661,
+      "block_output_cosine_per_token": 0.9151671493797464,
+      "block_output_drift_relative_norm": 0.46994708966231213,
+      "expert_load_js_bits": 0.26635526685454985,
+      "expert_load_max_abs_delta": 0.249755859375,
       "expert_load_observed": [
         0.21435546875,
         0.00048828125,
@@ -846,51 +815,15 @@
         0.0078125,
         0.0
       ],
-      "expert_load_js_bits": 0.26635526685454985,
-      "expert_load_max_abs_delta": 0.249755859375,
-      "experts_unused_reference": 0,
-      "experts_unused_observed": 1,
-      "router_margin_mean_reference": 0.030204767217204893,
-      "router_margin_mean_observed": 0.04490342261482776,
-      "router_margin_mean_delta": 0.014698655397622861,
-      "router_margin_median_reference": 0.006170911132304002,
-      "router_margin_median_observed": 0.016901693357858183,
-      "flip_stratification_by_reference_margin": [
-        {
-          "margin_low": 0.0,
-          "margin_high": 0.01,
-          "tokens": 1173,
-          "top1_flips": 890,
-          "top1_flip_rate": 0.7587382779198636
-        },
-        {
-          "margin_low": 0.01,
-          "margin_high": 0.05,
-          "tokens": 443,
-          "top1_flips": 127,
-          "top1_flip_rate": 0.2866817155756208
-        },
-        {
-          "margin_low": 0.05,
-          "margin_high": 0.15,
-          "tokens": 346,
-          "top1_flips": 28,
-          "top1_flip_rate": 0.08092485549132948
-        },
-        {
-          "margin_low": 0.15,
-          "margin_high": 0.5,
-          "tokens": 86,
-          "top1_flips": 1,
-          "top1_flip_rate": 0.011627906976744186
-        },
-        {
-          "margin_low": 0.5,
-          "margin_high": 1.01,
-          "tokens": 0,
-          "top1_flips": 0,
-          "top1_flip_rate": null
-        }
+      "expert_load_reference": [
+        0.131591796875,
+        0.102294921875,
+        0.166259765625,
+        0.125732421875,
+        0.114013671875,
+        0.127197265625,
+        0.12841796875,
+        0.1044921875
       ],
       "experts_touched": [
         0,
@@ -900,7 +833,74 @@
         4,
         5,
         6
-      ]
+      ],
+      "experts_unused_observed": 1,
+      "experts_unused_reference": 0,
+      "flip_stratification_by_reference_margin": [
+        {
+          "margin_high": 0.01,
+          "margin_low": 0.0,
+          "tokens": 1173,
+          "top1_flip_rate": 0.7587382779198636,
+          "top1_flips": 890
+        },
+        {
+          "margin_high": 0.05,
+          "margin_low": 0.01,
+          "tokens": 443,
+          "top1_flip_rate": 0.2866817155756208,
+          "top1_flips": 127
+        },
+        {
+          "margin_high": 0.15,
+          "margin_low": 0.05,
+          "tokens": 346,
+          "top1_flip_rate": 0.08092485549132948,
+          "top1_flips": 28
+        },
+        {
+          "margin_high": 0.5,
+          "margin_low": 0.15,
+          "tokens": 86,
+          "top1_flip_rate": 0.011627906976744186,
+          "top1_flips": 1
+        },
+        {
+          "margin_high": 1.01,
+          "margin_low": 0.5,
+          "tokens": 0,
+          "top1_flip_rate": null,
+          "top1_flips": 0
+        }
+      ],
+      "label": "attn_tau_1.6",
+      "moe_delta_over_stream": 0.3935953600801783,
+      "moe_input_normalized_cosine": 0.8245691527710912,
+      "moe_output_cosine": 0.7233418882079503,
+      "pack": "attn-tau-1.6.goz1",
+      "pack_bytes": 22168640,
+      "pack_sha256": "00c5fef1c23692c1b7f8d43a14473aa47f31bb23f15ead7d81c48a25b0d9a8d6",
+      "residual_drift_relative_norm": 0.414590671701332,
+      "residual_stream_cosine": 0.9441519705581737,
+      "router_logit_cosine": 0.9902756417001566,
+      "router_margin_mean_delta": 0.014698655397622861,
+      "router_margin_mean_observed": 0.04490342261482776,
+      "router_margin_mean_reference": 0.030204767217204893,
+      "router_margin_median_observed": 0.016901693357858183,
+      "router_margin_median_reference": 0.006170911132304002,
+      "router_top1_agreement": 0.4892578125,
+      "router_top2_set_agreement": 0.1484375,
+      "router_topk_set_agreement": 0.1484375,
+      "seconds": 12.80456829071045,
+      "selected_experts": 2,
+      "sparsity": {
+        "slot_03.attn_proj_i8.narrow": 0.8953730265299479,
+        "slot_04.attn_proj_i8.model_width": 0.9026632308959961,
+        "slot_05.attn_proj_i8.model_width": 0.8928340276082357,
+        "slot_06.attn_proj_i8.narrow": 0.8933672904968262
+      },
+      "sparsity_expected_gaussian": 0.890401416600884,
+      "tau": 1.6
     }
   ]
 }

--- a/scripts/goz1_trit_histogram.py
+++ b/scripts/goz1_trit_histogram.py
@@ -409,8 +409,11 @@ def _emit_result(result: dict, *, as_json: bool, json_out: Path | None) -> None:
             canonical_json(result), encoding="utf-8"
         )
     if as_json:
+        # canonical_json already ends with exactly one newline, so no print()
+        # here. Adding one emitted a trailing blank line, which made stdout
+        # disagree byte-for-byte with the --json-out file written just above --
+        # the opposite of what canonicalising the writers was for.
         sys.stdout.write(canonical_json(result))
-        print()
     else:
         _print_human(result)
 

--- a/scripts/grok1_block_weights.py
+++ b/scripts/grok1_block_weights.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -131,8 +132,23 @@ def implementation_commit(repo_root: Path | None = None) -> dict[str, str | bool
 
     Never raises: provenance is best-effort, and a run outside a git checkout
     must still write its metrics rather than abort.
+
+    Runs with ``GIT_DIR``/``GIT_WORK_TREE`` stripped from the child environment.
+    ``git -C <root>`` does **not** override an inherited ``GIT_DIR``, and git
+    exports one (absolute) to every hook — so under the pre-push gate restored in
+    GH #97 this reported the *gate's* repository regardless of which
+    ``repo_root`` it was handed. That is wrong twice over: the "outside a
+    checkout" contract above silently stopped holding, and a hook-run experiment
+    would stamp provenance with a commit from a tree it never read.
     """
     root = repo_root or Path(__file__).resolve().parent.parent
+    # Inherit the environment except git's own location overrides, so that the
+    # `-C <root>` argument is authoritative.
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")
+    }
     git = shutil.which("git")
     if git is None:
         return {"commit": None, "dirty": None}
@@ -145,7 +161,7 @@ def implementation_commit(repo_root: Path | None = None) -> dict[str, str | bool
         # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
         sha = subprocess.run(  # nosec B603  # noqa: S603
             [git, "-C", str(root), "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=30, check=True,
+            capture_output=True, text=True, timeout=30, check=True, env=env,
         ).stdout.strip()
         # nosemgrep: python.lang.security.audit.dangerous-subprocess-use-audit.dangerous-subprocess-use-audit
         status = subprocess.run(  # nosec B603  # noqa: S603
@@ -153,7 +169,7 @@ def implementation_commit(repo_root: Path | None = None) -> dict[str, str | bool
                 git, "-C", str(root), "status", "--porcelain",
                 "--untracked-files=no", "--", "scripts", "src",
             ],
-            capture_output=True, text=True, timeout=30, check=True,
+            capture_output=True, text=True, timeout=30, check=True, env=env,
         ).stdout.strip()
     except (OSError, subprocess.SubprocessError):
         return {"commit": None, "dirty": None}

--- a/scripts/grok1_block_weights.py
+++ b/scripts/grok1_block_weights.py
@@ -38,6 +38,7 @@ from collections.abc import Callable
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from json_canonical import canonical_json  # noqa: E402
 
 from grok1_block_forward import ForwardError, resolve_roles  # noqa: E402
 from route_preservation_io import (  # noqa: E402
@@ -432,7 +433,7 @@ class PackWeights(WeightSource):
             "fingerprint": self._fingerprint(),
             "scales": {n: {"alpha": s.alpha, "fired": s.fired, "total": s.total, "sign_mismatches": s.sign_mismatches} for n, s in sorted(self._scales.items())},
         }
-        self._cache_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        self._cache_path.write_text(canonical_json(payload))
 
     def scale(self, name: str) -> TernaryScale:
         """Reconstruction scale for a ternary tensor.

--- a/scripts/grok1_multiblock_experiment.py
+++ b/scripts/grok1_multiblock_experiment.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from json_canonical import canonical_json  # noqa: E402
 
 from grok1_block0_experiment import (  # noqa: E402
     EXIT_UNRESOLVED,
@@ -158,8 +159,7 @@ def _atomic_write_json(path: Path, payload: dict) -> None:
     tmp_path = Path(tmp_name)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            json.dump(payload, stream, indent=2)
-            stream.write("\n")
+            stream.write(canonical_json(payload))
             stream.flush()
             os.fsync(stream.fileno())
         os.replace(tmp_path, path)

--- a/scripts/grok1_multiblock_lib.py
+++ b/scripts/grok1_multiblock_lib.py
@@ -33,6 +33,7 @@ from grok1_block_weights import (
     NpyWeights,
     PackWeights,
 )
+from json_canonical import canonical_json  # noqa: E402
 from route_preservation_io import TENSOR_TERNARY, read_trits
 
 
@@ -783,7 +784,7 @@ def _atomic_write_json(path: Path, payload: dict[str, object]) -> None:
     temp_path = _temp_sibling(path)
     try:
         with temp_path.open("w", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, indent=2) + "\n")
+            handle.write(canonical_json(payload))
             handle.flush()
             os.fsync(handle.fileno())
         _durable_replace(temp_path, path)

--- a/scripts/grok1_multiblock_v4_supervisor.py
+++ b/scripts/grok1_multiblock_v4_supervisor.py
@@ -37,6 +37,10 @@ from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
+# Sibling module; this script's own directory is sys.path[0] when run
+# directly, and the test modules insert scripts/ explicitly.
+from json_canonical import canonical_json
+
 try:
     import fcntl as _fcntl
 except ImportError:  # pragma: no cover - this supervisor requires POSIX.
@@ -284,7 +288,7 @@ def _atomic_write_text(path: Path, body: str) -> None:
 
 
 def _atomic_write_json(path: Path, payload: object) -> None:
-    _atomic_write_text(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    _atomic_write_text(path, canonical_json(payload))
 
 
 def _fsync_directory_strict(path: Path) -> None:

--- a/scripts/json_canonical.py
+++ b/scripts/json_canonical.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""One canonical JSON serialization for every artifact this repo writes (GH #108).
+
+Three `_atomic_write_json` implementations existed --
+`grok1_multiblock_lib.py`, `grok1_multiblock_experiment.py` and
+`grok1_multiblock_v4_supervisor.py` -- with identical `indent`, `separators`
+and `ensure_ascii`, differing in exactly one flag: the supervisor passed
+`sort_keys=True` and the other two did not.
+
+So the same logical payload serialized to *different bytes* depending on which
+module happened to write it, in a pipeline whose provenance and certification
+compare and hash JSON artifacts. The `progress-*.json` files were the clearest
+symptom: written by both the supervisor (sorted) and the experiment (unsorted),
+last writer wins, so the committed copies were unsorted even though the
+supervisor had set `sort_keys=True` since its first commit.
+
+Only the *serialization* is shared here. Each caller keeps its own durability
+mechanics -- they differ in strictness but all are correct, and two of them are
+monkeypatched by name in the side-table tests, so consolidating them is a
+separate change with a different risk profile.
+"""
+
+from __future__ import annotations
+
+import json
+
+__all__ = ["canonical_json"]
+
+
+def canonical_json(payload: object) -> str:
+    """Serialize `payload` the one way this repo writes JSON.
+
+    `sort_keys=True` is the load-bearing part: it makes output depend only on
+    content, not on dict insertion order, so a hash or a diff of an artifact
+    means something regardless of which writer produced it.
+
+    The trailing newline is included so callers can `write()` the result
+    directly and every artifact ends POSIX-clean.
+    """
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/scripts/test_json_canonical.py
+++ b/scripts/test_json_canonical.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Canonical JSON serialization and the committed-artifact guard (GH #108)."""
+
+from __future__ import annotations
+
+import json
+import subprocess  # nosec B404 - fixed argv, shell disabled
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from json_canonical import canonical_json  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class CanonicalFormTests(unittest.TestCase):
+    def test_keys_are_sorted_regardless_of_insertion_order(self) -> None:
+        a = canonical_json({"b": 1, "a": 2})
+        b = canonical_json({"a": 2, "b": 1})
+        self.assertEqual(a, b, "output must depend on content, not insertion order")
+        self.assertLess(a.index('"a"'), a.index('"b"'))
+
+    def test_is_idempotent(self) -> None:
+        payload = {"z": [3, 1, 2], "a": {"y": 1, "x": 2}}
+        once = canonical_json(payload)
+        twice = canonical_json(json.loads(once))
+        self.assertEqual(once, twice)
+
+    def test_ends_with_exactly_one_newline(self) -> None:
+        out = canonical_json({"a": 1})
+        self.assertTrue(out.endswith("}\n"))
+        self.assertFalse(out.endswith("\n\n"))
+
+    def test_nested_keys_are_sorted_too(self) -> None:
+        out = canonical_json({"outer": {"b": 1, "a": 2}})
+        self.assertLess(out.index('"a"'), out.index('"b"'))
+
+
+class CommittedArtifactsAreCanonicalTests(unittest.TestCase):
+    """Every tracked JSON under reports/ must already be canonical.
+
+    Before GH #108 three writers disagreed on `sort_keys`, so the same logical
+    payload serialized to different bytes depending on which one produced it —
+    and 20 of 24 committed artifacts were in the unsorted form. This test is the
+    guard that stops that returning: a writer that bypasses `canonical_json`
+    fails here the moment its output is committed.
+    """
+
+    @staticmethod
+    def _tracked_report_json() -> list[Path]:
+        out = subprocess.run(  # nosec B603 - fixed argv, no shell
+            ["git", "ls-files", "reports/*.json", "reports/**/*.json"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return [REPO_ROOT / line for line in out.stdout.split() if line]
+
+    def test_every_tracked_report_json_is_canonical(self) -> None:
+        files = self._tracked_report_json()
+        if not files:
+            self.skipTest("no tracked reports/*.json (not a git checkout?)")
+
+        offenders = []
+        for path in files:
+            raw = path.read_text(encoding="utf-8")
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}: unparseable ({exc})")
+                continue
+            if canonical_json(parsed) != raw:
+                offenders.append(str(path.relative_to(REPO_ROOT)))
+
+        self.assertEqual(
+            offenders,
+            [],
+            "these committed artifacts are not in canonical form; regenerate them "
+            "with canonical_json (GH #108):\n  " + "\n  ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## **User description**
**Agent:** Claude Code: Opus 5 (Anthropic) · **Issue:** #108

Closes #108.

## Why

Three `_atomic_write_json` implementations with identical `indent`, `separators` and `ensure_ascii`, differing in exactly one flag: the supervisor passed `sort_keys=True`, the other two did not. So **the same logical payload serialized to different bytes depending on which module wrote it** — in a pipeline whose provenance and certification compare and hash JSON.

The `progress-*.json` files were the clearest symptom: written by both the supervisor (sorted) and the experiment (unsorted), last writer wins, so the committed copies were unsorted even though the supervisor had set `sort_keys` since its first commit.

## Scope, deliberately narrower than the issue

New `scripts/json_canonical.py` holds the one serialization; all three writers use it. **Only the serialization is shared.**

The issue proposed extracting a shared *durable-write* helper. I did not: the three durability paths differ in strictness but all are correct, and `lib._atomic_write_json` / `lib._fsync_directory_strict` are **monkeypatched by module attribute** in the side-table tests. Sharing the bytes fixes the reported defect; consolidating the fsync paths is a separate change with a different risk profile.

## Regeneration, verified rather than assumed

```
tracked reports/*.json      24
rewritten                   20
already canonical            4   (all supervisor-written, as expected)

content-identical after reparse: 20/20
line diff: +16685 -16685 across 20 files
```

The **symmetric line count** and the reparse check together are the evidence this is key *order* only — no value added, removed or altered.

## The guard

`test_json_canonical.py` pins the form and adds what matters: every tracked `reports/*.json` must already be canonical, so a writer bypassing `canonical_json` fails the moment its output is committed.

Verified by seeding a reversed-key file — the guard fails and names it. Worth stating: **my first attempt to test that was a false negative**, because the file I picked already had alphabetical top-level keys. That is exactly the kind of check that silently proves nothing.

## Note for whoever merges second

Wired into the justfile, `python-scripts.yml`, `CLAUDE.md` and `REVIEW.md` — fourteen modules on this base. **#122 (GH #107) adds a fifteenth on its own branch**; whichever merges second resolves a one-line list conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MQY2Roz94s2zwtAWAodEQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes JSON serialization canonical across all three writers so the same payload no longer serializes to different bytes depending on which module wrote it; the supervisor sorted keys while the other two did not. Regenerates the 20 divergent `reports/*.json` (key order only) and adds a guard that fails any committed non-canonical report.

- All writers and the alpha-cache writer now use `scripts/json_canonical.py`; each keeps its own durability mechanics.
- Fixed `implementation_commit` to drop inherited git environment variables (`GIT_DIR`, `GIT_WORK_TREE`, etc.) so hook-driven runs don't stamp wrong provenance.
- Fixed `--json` stdout to end in exactly one newline, matching the `--json-out` file byte-for-byte.
- Made the codex hook test hermetic by unsetting the git environment variables before creating its throwaway repo; previously a hook run could commit into the real repository.
- Wired `test_json_canonical` into the justfile, CI, `CLAUDE.md`, and `REVIEW.md`; the test list is now fifteen modules after merging with GH #107.

<sup>Written for commit e776d0692a2058edfbcedc1bef1248054d3d0a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Make all generated JSON artifacts use one canonical format

### What Changed
- JSON written by the library, experiment, and supervisor now uses the same sorted-key format with one trailing newline
- Regenerated 20 tracked report files so their content is unchanged while their key order is consistent
- Added tests that verify stable ordering, nested-key ordering, idempotence, and exactly one trailing newline
- CI now rejects tracked report files that are invalid or not in canonical form

### Impact
`✅ Consistent JSON hashes and diffs`
`✅ Fewer artifact format mismatches`
`✅ Early detection of non-canonical reports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
