### PR TITLE
fix(types): serialize TensorPrecision as snake_case wire form (#91 / RM-795)

### DIFF
--- a/src/core/dry_run.rs
+++ b/src/core/dry_run.rs
@@ -127,7 +127,7 @@ fn plan_ternary_rules<I: ModelInventory>(
             matcher: entry.name.clone(),
             kernel_method: method,
             class,
-            precision: TensorPrecision::TernarySnN,
+            precision: TensorPrecision::TernarySnn,
             gif_threshold,
             estimated_tensor_count: estimated,
         });
@@ -316,7 +316,7 @@ impl DryRunPlanner {
                 plan.matcher.clone(),
                 serde_json::json!({
                     "kernel_method": plan.kernel_method,
-                    "precision": format!("{:?}", plan.precision),
+                    "precision": plan.precision,
                     "gif_threshold": plan.gif_threshold,
                     "estimated_tensor_count": plan.estimated_tensor_count,
                     "class": format!("{:?}", plan.class),
@@ -552,6 +552,21 @@ mod tests {
         assert!(
             json.contains_key("__coverage__"),
             "JSON output should contain __coverage__ key"
+        );
+    }
+
+    #[test]
+    fn planned_backend_calls_json_uses_serde_precision_wire_form() {
+        let report = plan_structural_manifest();
+        let json = DryRunPlanner::planned_backend_calls_json(&report);
+        let embedding = json
+            .iter()
+            .find(|(matcher, _)| matcher.contains("token_embedding"))
+            .map(|(_, value)| value)
+            .expect("embedding rule should exist");
+        assert_eq!(
+            embedding["precision"], "ternary_snn",
+            "dry-run JSON must emit the serde wire form, not Debug/PascalCase"
         );
     }
 }

--- a/src/core/precision.rs
+++ b/src/core/precision.rs
@@ -12,10 +12,10 @@
 //!   (FP16-at-rest in GOZ1 v1; semantically distinct from `Fp16`,
 //!   identical on disk — see the `TensorPrecision::Preserve` docs).
 //! - `TensorClass::Fp16`              → [`TensorPrecision::Fp16`]
-//! - `TensorClass::TernaryCandidate`  → [`TensorPrecision::TernarySnN`]
+//! - `TensorClass::TernaryCandidate`  → [`TensorPrecision::TernarySnn`]
 //! - `TensorClass::Default`           → parsed from
 //!   `manifest.defaults.precision` (if present), else
-//!   [`TensorPrecision::TernarySnN`].
+//!   [`TensorPrecision::TernarySnn`].
 //!
 //! Unknown `defaults.precision` strings are a **hard failure**
 //! ([`GrokOzempicError::ManifestInvalidPrecision`]) to match the rest of
@@ -36,7 +36,7 @@ pub fn decide(
     let precision = match class {
         TensorClass::Preserve { .. } => TensorPrecision::Preserve,
         TensorClass::Fp16 { .. } => TensorPrecision::Fp16,
-        TensorClass::TernaryCandidate { .. } => TensorPrecision::TernarySnN,
+        TensorClass::TernaryCandidate { .. } => TensorPrecision::TernarySnn,
         TensorClass::Default => resolve_default_precision(manifest)?,
     };
     let threshold = resolve_threshold(class, manifest, config)?;
@@ -45,10 +45,10 @@ pub fn decide(
 
 fn resolve_default_precision(manifest: Option<&DissectManifest>) -> Result<TensorPrecision> {
     let Some(m) = manifest else {
-        return Ok(TensorPrecision::TernarySnN);
+        return Ok(TensorPrecision::TernarySnn);
     };
     match m.defaults.precision.as_deref() {
-        None => Ok(TensorPrecision::TernarySnN),
+        None => Ok(TensorPrecision::TernarySnn),
         Some(s) => parse_precision_str(s),
     }
 }
@@ -83,7 +83,7 @@ fn resolve_threshold(
 /// Accepted values: `ternary_snn`, `fp16`, `preserve`.
 pub fn parse_precision_str(s: &str) -> Result<TensorPrecision> {
     match s {
-        "ternary_snn" => Ok(TensorPrecision::TernarySnN),
+        "ternary_snn" => Ok(TensorPrecision::TernarySnn),
         "fp16" => Ok(TensorPrecision::Fp16),
         "preserve" => Ok(TensorPrecision::Preserve),
         other => Err(GrokOzempicError::ManifestInvalidPrecision {
@@ -132,7 +132,7 @@ mod tests {
     fn parse_precision_accepts_known_tiers() {
         assert_eq!(
             parse_precision_str("ternary_snn").unwrap(),
-            TensorPrecision::TernarySnN
+            TensorPrecision::TernarySnn
         );
         assert_eq!(parse_precision_str("fp16").unwrap(), TensorPrecision::Fp16);
         assert_eq!(
@@ -175,7 +175,7 @@ mod tests {
             gif_threshold: None,
         };
         let (p, _) = decide(&cls, None, &config).unwrap();
-        assert_eq!(p, TensorPrecision::TernarySnN);
+        assert_eq!(p, TensorPrecision::TernarySnn);
     }
 
     #[test]
@@ -219,7 +219,7 @@ mod tests {
     fn default_precision_falls_back_to_ternary_snn_without_manifest() {
         let config = config_with_threshold(0.05);
         let (p, _) = decide(&TensorClass::Default, None, &config).unwrap();
-        assert_eq!(p, TensorPrecision::TernarySnN);
+        assert_eq!(p, TensorPrecision::TernarySnn);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,10 +7,16 @@ use serde::{Deserialize, Serialize};
 // ---------------------------------------------------------------------------
 
 /// Controls which precision is applied to a given tensor.
+///
+/// Serde and [`Self::as_str`] share the manifest/CLI vocabulary
+/// (`ternary_snn`, `fp16`, `preserve`). The variant is spelled
+/// [`Self::TernarySnn`] so `rename_all = "snake_case"` yields
+/// `ternary_snn` rather than `ternary_sn_n`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum TensorPrecision {
     /// Two-bit ternary {-1, 0, +1} with saliency-gated GIF threshold.
-    TernarySnN,
+    TernarySnn,
     /// Keep original FP16 — used for MoE routing gates.
     Fp16,
     /// Routing-critical / no-touch tier. Populated when the
@@ -34,6 +40,23 @@ pub enum TensorPrecision {
     ///    promote `Preserve` to true source-dtype passthrough
     ///    (F32/BF16 kept as-is) without an API rename or migration.
     Preserve,
+}
+
+impl TensorPrecision {
+    /// Manifest / CLI / serde wire spelling (`ternary_snn`, `fp16`, `preserve`).
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::TernarySnn => "ternary_snn",
+            Self::Fp16 => "fp16",
+            Self::Preserve => "preserve",
+        }
+    }
+}
+
+impl std::fmt::Display for TensorPrecision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// Weight container layout for [`QuantizationConfig::input_dir`].
@@ -208,6 +231,34 @@ mod quantize_goz1_config_tests {
         assert!(validate_gif_threshold(f32::NAN).is_err());
         assert!(validate_gif_threshold(f32::INFINITY).is_err());
         assert!(validate_gif_threshold(-0.1).is_err());
+    }
+
+    #[test]
+    fn tensor_precision_serde_wire_form_is_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&TensorPrecision::TernarySnn).unwrap(),
+            "\"ternary_snn\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TensorPrecision::Fp16).unwrap(),
+            "\"fp16\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TensorPrecision::Preserve).unwrap(),
+            "\"preserve\""
+        );
+        for tier in [
+            TensorPrecision::TernarySnn,
+            TensorPrecision::Fp16,
+            TensorPrecision::Preserve,
+        ] {
+            let json = serde_json::to_string(&tier).unwrap();
+            assert_eq!(json, format!("\"{}\"", tier.as_str()));
+            assert_eq!(
+                serde_json::from_str::<TensorPrecision>(&json).unwrap(),
+                tier
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Agent:** Cursor Grok 4.6 (xAI) · **Issue:** #91 / Linear RM-795

Closes #91.

## Why

`TensorPrecision` derived serde without `rename_all`, so the wire form was PascalCase (`TernarySnN`) while every manifest, CLI string, and `parse_precision_str` uses `ternary_snn` / `fp16` / `preserve`. `QuantizationInputFormat` already had the attribute; this was an omission, not a design choice.

`rename_all = "snake_case"` on `TernarySnN` would have produced `ternary_sn_n`, so the variant is respelled `TernarySnn`. Dry-run JSON now serializes the serde wire form instead of `{:?}`.

## Verification

- Pin: `serde_json::to_string(&TensorPrecision::TernarySnn) == "\"ternary_snn\""`
- Dry-run JSON for the embedding rule emits `"precision": "ternary_snn"`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked`

## Relationships

Sibling defects from the same review (do not mill/merge):

- #91 / RM-795 — this PR (serde vocabulary)
- #92 / RM-796 — destructive default in `resolve_default_precision`
- #93 / RM-797 — unchecked `kernel_method` strings in `DryRunPlanner`

Related: `rmems/hybrid-fusion#24` (extracts these tiers as `PrecisionTier` and already uses snake_case).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fae09b9-37d9-4ca0-a952-84d918677ff3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fae09b9-37d9-4ca0-a952-84d918677ff3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
Use consistent snake_case precision values in manifests, CLI output, and dry-run JSON

### What Changed
- Tensor precision values now serialize and deserialize as `ternary_snn`, `fp16`, and `preserve`
- Dry-run JSON reports `ternary_snn` instead of the internal `TernarySnN`-style name
- Precision display and parsing now use the same vocabulary across manifests, CLI output, and planning results
- Added coverage for serialization, round trips, and dry-run output

### Impact
`✅ Compatible precision values for manifest and CLI workflows`
`✅ Correct machine-readable dry-run JSON`
`✅ Fewer precision parsing and integration errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`TensorPrecision` was serialized as PascalCase (`TernarySnN`) while manifests, CLI strings, and `parse_precision_str` all use `ternary_snn`, `fp16`, and `preserve`. This aligns serde with that vocabulary and makes dry-run JSON emit the serde wire form instead of `{:?}` Debug output. Closes #91 / RM-795.

**Migration**
- Rust code referencing the `TernarySnN` variant must use `TernarySnn`; JSON consumers expecting PascalCase values must switch to snake_case.

<sup>Written for commit 88681cfce7d05dc8db6ac146a4950db0795eebad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

