### PR TITLE
fix(precision): fail closed when no explicit default precision (#92 / RM-796)

### DIFF
--- a/src/core/dry_run.rs
+++ b/src/core/dry_run.rs
@@ -159,33 +159,27 @@ fn plan_default_rule<I: ModelInventory>(
     by_method: &mut BTreeMap<String, usize>,
     covered_by_rules: &mut usize,
 ) -> Result<()> {
-    let default_precision = manifest
-        .defaults
-        .precision
-        .as_deref()
-        .unwrap_or("ternary_snn");
-    let default_class = TensorClass::Default;
-    let (_precision, gif_threshold) = resolve_precision(&default_class, manifest, config)?;
-    let default_method = match default_precision {
-        "ternary_snn" => "quantize_f32",
-        "fp16" => "convert_f32_to_f16_bytes",
-        "preserve" => "convert_f32_to_f16_bytes",
-        _ => "quantize_f32",
-    };
     let inventory_total = inventory.total_tensors();
     let default_estimated = inventory_total.saturating_sub(*covered_by_rules);
-    if default_estimated > 0 {
-        rule_plans.push(PlannedKernelCall {
-            matcher: "<defaults>".to_string(),
-            kernel_method: default_method,
-            class: default_class,
-            precision: _precision,
-            gif_threshold,
-            estimated_tensor_count: default_estimated,
-        });
-        *by_method.entry(default_method.to_string()).or_insert(0) += default_estimated;
-        *covered_by_rules += default_estimated;
+    if default_estimated == 0 {
+        return Ok(());
     }
+    let default_class = TensorClass::Default;
+    let (precision, gif_threshold) = resolve_precision(&default_class, manifest, config)?;
+    let default_method = match precision {
+        TensorPrecision::TernarySnn => "quantize_f32",
+        TensorPrecision::Fp16 | TensorPrecision::Preserve => "convert_f32_to_f16_bytes",
+    };
+    rule_plans.push(PlannedKernelCall {
+        matcher: "<defaults>".to_string(),
+        kernel_method: default_method,
+        class: default_class,
+        precision,
+        gif_threshold,
+        estimated_tensor_count: default_estimated,
+    });
+    *by_method.entry(default_method.to_string()).or_insert(0) += default_estimated;
+    *covered_by_rules += default_estimated;
     Ok(())
 }
 

--- a/src/core/precision.rs
+++ b/src/core/precision.rs
@@ -14,8 +14,9 @@
 //! - `TensorClass::Fp16`              → [`TensorPrecision::Fp16`]
 //! - `TensorClass::TernaryCandidate`  → [`TensorPrecision::TernarySnn`]
 //! - `TensorClass::Default`           → parsed from
-//!   `manifest.defaults.precision` (if present), else
-//!   [`TensorPrecision::TernarySnn`].
+//!   `manifest.defaults.precision`. Absence of a manifest, or of that
+//!   field, is [`GrokOzempicError::MissingDefaultPrecision`] — not a
+//!   silent ternary fallback.
 //!
 //! Unknown `defaults.precision` strings are a **hard failure**
 //! ([`GrokOzempicError::ManifestInvalidPrecision`]) to match the rest of
@@ -45,10 +46,10 @@ pub fn decide(
 
 fn resolve_default_precision(manifest: Option<&DissectManifest>) -> Result<TensorPrecision> {
     let Some(m) = manifest else {
-        return Ok(TensorPrecision::TernarySnn);
+        return Err(GrokOzempicError::MissingDefaultPrecision);
     };
     match m.defaults.precision.as_deref() {
-        None => Ok(TensorPrecision::TernarySnn),
+        None => Err(GrokOzempicError::MissingDefaultPrecision),
         Some(s) => parse_precision_str(s),
     }
 }
@@ -193,7 +194,7 @@ mod tests {
     #[test]
     fn manifest_default_threshold_overrides_config_default() {
         let config = config_with_threshold(0.05);
-        let m = manifest_with_defaults(None, Some(0.08));
+        let m = manifest_with_defaults(Some("ternary_snn"), Some(0.08));
         let cls = TensorClass::Default;
         let (_, t) = decide(&cls, Some(&m), &config).unwrap();
         assert_eq!(t, 0.08);
@@ -202,7 +203,10 @@ mod tests {
     #[test]
     fn config_default_wins_when_no_overrides() {
         let config = config_with_threshold(0.05);
-        let cls = TensorClass::Default;
+        let cls = TensorClass::TernaryCandidate {
+            rank: None,
+            gif_threshold: None,
+        };
         let (_, t) = decide(&cls, None, &config).unwrap();
         assert_eq!(t, 0.05);
     }
@@ -216,10 +220,24 @@ mod tests {
     }
 
     #[test]
-    fn default_precision_falls_back_to_ternary_snn_without_manifest() {
+    fn default_class_without_manifest_is_missing_default_precision() {
         let config = config_with_threshold(0.05);
-        let (p, _) = decide(&TensorClass::Default, None, &config).unwrap();
-        assert_eq!(p, TensorPrecision::TernarySnn);
+        let err = decide(&TensorClass::Default, None, &config).unwrap_err();
+        assert!(
+            matches!(err, GrokOzempicError::MissingDefaultPrecision),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn default_class_without_defaults_precision_is_missing_default_precision() {
+        let config = config_with_threshold(0.05);
+        let m = manifest_with_defaults(None, None);
+        let err = decide(&TensorClass::Default, Some(&m), &config).unwrap_err();
+        assert!(
+            matches!(err, GrokOzempicError::MissingDefaultPrecision),
+            "got {err:?}"
+        );
     }
 
     #[test]
@@ -236,7 +254,7 @@ mod tests {
     #[test]
     fn negative_manifest_gif_threshold_rejected() {
         let config = config_with_threshold(0.05);
-        let m = manifest_with_defaults(None, Some(-0.5));
+        let m = manifest_with_defaults(Some("preserve"), Some(-0.5));
         let err = decide(&TensorClass::Default, Some(&m), &config).unwrap_err();
         assert!(
             matches!(err, GrokOzempicError::InvalidConfig(_)),

--- a/src/core/selection.rs
+++ b/src/core/selection.rs
@@ -36,13 +36,16 @@ pub enum TensorClass {
     /// legacy router heuristic when no manifest is present.
     Fp16 { reason: Option<String> },
     /// Tensor appeared in the manifest's `ternary_candidates` list with
-    /// optional rank and per-tensor threshold override.
+    /// optional rank and per-tensor threshold override, **or** did not
+    /// match the legacy router heuristic when no manifest is present
+    /// (explicit ternary, not a `Default` fallthrough).
     TernaryCandidate {
         rank: Option<f32>,
         gif_threshold: Option<f32>,
     },
-    /// No explicit manifest entry; falls through to manifest
-    /// `defaults.precision` or the pipeline's global default.
+    /// No explicit manifest entry. Precision is taken from
+    /// `manifest.defaults.precision`; absence of that field is a hard
+    /// error ([`crate::error::GrokOzempicError::MissingDefaultPrecision`]).
     Default,
 }
 
@@ -98,7 +101,13 @@ fn classify_legacy(name: &str, legacy_patterns: &[String]) -> TensorClass {
     if hit {
         TensorClass::Fp16 { reason: None }
     } else {
-        TensorClass::Default
+        // The no-manifest heuristic's policy is "ternary everything that is
+        // not a router". Encode that as an explicit class so `Default` stays
+        // reserved for unmatched *manifest* names, which fail closed.
+        TensorClass::TernaryCandidate {
+            rank: None,
+            gif_threshold: None,
+        }
     }
 }
 
@@ -334,17 +343,20 @@ mod tests {
     }
 
     #[test]
-    fn legacy_default_leaves_ffn_weights_as_default() {
+    fn legacy_heuristic_classifies_non_routers_as_ternary() {
+        // The no-manifest heuristic's policy is explicit ternary for
+        // everything that is not a router — not TensorClass::Default,
+        // which now fail-closes in precision::decide (GH #92 / RM-796).
         // Note: with the legacy heuristic, 'ffn_gate' false-matches
         // 'gate'. That's a known weakness — see the manifest path for
         // the fix. This test documents current legacy behavior.
         assert!(matches!(
             classify("blk.0.ffn_down.weight", None, &[]),
-            TensorClass::Default
+            TensorClass::TernaryCandidate { .. }
         ));
         assert!(matches!(
             classify("blk.0.ffn_up.weight", None, &[]),
-            TensorClass::Default
+            TensorClass::TernaryCandidate { .. }
         ));
     }
 
@@ -358,7 +370,7 @@ mod tests {
         // Default 'gate' is not consulted when a custom list is given.
         assert!(matches!(
             classify("blk.0.gate.weight", None, &patterns),
-            TensorClass::Default
+            TensorClass::TernaryCandidate { .. }
         ));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,13 @@ pub enum GrokOzempicError {
     )]
     ManifestV2UnmatchedTensor { name: String },
 
+    #[error(
+        "no explicit default precision is configured; refusing to silently ternary-quantize \
+         unclassified tensors. Set manifest defaults.precision to ternary_snn, fp16, or \
+         preserve, or list the tensor under preserve / fp16 / ternary_candidates"
+    )]
+    MissingDefaultPrecision,
+
     #[error("artifact validation error: {0}")]
     ArtifactValidation(String),
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// (`ternary_snn`, `fp16`, `preserve`). The variant is spelled
 /// [`Self::TernarySnn`] so `rename_all = "snake_case"` yields
 /// `ternary_snn` rather than `ternary_sn_n`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TensorPrecision {
     /// Two-bit ternary {-1, 0, +1} with saliency-gated GIF threshold.
@@ -39,6 +39,7 @@ pub enum TensorPrecision {
     /// 3. **Forward compatibility** — a future GOZ1 format version may
     ///    promote `Preserve` to true source-dtype passthrough
     ///    (F32/BF16 kept as-is) without an API rename or migration.
+    #[default]
     Preserve,
 }
 
@@ -259,6 +260,11 @@ mod quantize_goz1_config_tests {
                 tier
             );
         }
+    }
+
+    #[test]
+    fn tensor_precision_type_default_is_preserve() {
+        assert_eq!(TensorPrecision::default(), TensorPrecision::Preserve);
     }
 }
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Agent:** Cursor Grok 4.6 (xAI) · **Issue:** #92 / Linear RM-796

Closes #92.

## Why

`resolve_default_precision` returned `TernarySnn` on both miss paths (no manifest, or a manifest with no `defaults.precision`). That is the lossiest transform on the tensors the pipeline knows the least about. The V2 unmatched path already fails closed (`ManifestV2UnmatchedTensor`); this brings the Default-class path in line.

## Chosen fix (option 1, fail-closed)

`decide(&TensorClass::Default, None, &config)` and `decide(&Default, Some(manifest_without_defaults.precision), …)` now return `GrokOzempicError::MissingDefaultPrecision`.

The no-manifest **legacy heuristic** still ternary-quantizes non-routers — that path is an explicit product contract (parity vs baseline). It now classifies those tensors as `TernaryCandidate` instead of `Default`, so `Default` stays reserved for unmatched *manifest* names, which fail closed.

Also derives `Default` on `TensorPrecision` as `Preserve`, so the type-level default is the non-destructive tier.

Stacked on #130 (`cursor/tensor-precision-serde-7ff3`) for the `TernarySnn` rename.

## Verification

- Pin: `decide(&TensorClass::Default, None, &config)` → `Err(MissingDefaultPrecision)`
- Pin: manifest with no `defaults.precision` → same error
- `TensorPrecision::default() == Preserve`
- Legacy no-manifest stream tests (parity / divergence) still pass
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked`

## Relationships

Sibling defects from the same review (do not mill/merge):

- #91 / RM-795 — TensorPrecision serde vocabulary (#130; this PR stacks on it)
- #92 / RM-796 — this PR (destructive default)
- #93 / RM-797 — unchecked `kernel_method` strings in `DryRunPlanner`

Related: `rmems/hybrid-fusion#24` (`PrecisionTier::default()` is `Preserve` there because that crate plans but never quantizes).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fae09b9-37d9-4ca0-a952-84d918677ff3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fae09b9-37d9-4ca0-a952-84d918677ff3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #92 / RM-796: unclassified tensors now fail closed instead of being silently ternary-quantized when no manifest or `defaults.precision` is present. `TensorClass::Default` now returns `GrokOzempicError::MissingDefaultPrecision`, matching the V2 unmatched-tensor behavior.

The legacy no-manifest heuristic still ternary-quantizes non-routers, but classifies them as `TernaryCandidate` instead of `Default`. `TensorPrecision::default()` is now `Preserve`, and dry-run planning uses the same resolved precision for the `<defaults>` rule.

**Migration**
- Manifests relying on the implicit `ternary_snn` default must set `defaults.precision` to `ternary_snn`, `fp16`, or `preserve`.

<sup>Written for commit bd3ab0a3f6a77c1f8d8811d9e910684aae1f34a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Fail closed when tensor precision is not explicitly configured

### What Changed
- Unclassified tensors now stop with a clear missing-default-precision error instead of being silently ternary-quantized when no manifest precision is available.
- Legacy no-manifest processing keeps its existing behavior by explicitly treating non-router tensors as ternary candidates.
- Dry runs now use the same validated precision rules as processing and report no default plan when all tensors are already covered.
- The default tensor precision is now Preserve, avoiding destructive conversion when a type-level default is used.

### Impact
`✅ Fewer silent destructive quantizations`
`✅ Clearer configuration errors for unmatched tensors`
`✅ Consistent dry-run and processing outcomes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
