### PR TITLE
fix(dry-run): replace kernel_method strings with OperationKind (#93 / RM-797)

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -1,3 +1,4 @@
+use crate::core::dry_run::OperationKind;
 use crate::core::manifest::{DissectManifest, parse_manifest_bytes};
 use crate::core::stream::{GROK1_BLOCK_COUNT, GROK1_EXPERT_COUNT};
 use crate::error::{GrokOzempicError, Result};
@@ -499,11 +500,9 @@ fn push_block_entries(
     // and `.up`.
     for bs in GROK1_BLOCK_SLOTS.iter().filter(|s| s.is_int8) {
         let (slot, kind, shape, bytes) = (bs.slot, bs.kind, bs.shape.to_vec(), bs.bytes);
-        let policy = if kind.starts_with("moe_expert") {
-            "wrap_existing_int8_expert"
-        } else {
-            "wrap_existing_int8_unknown"
-        };
+        let policy = OperationKind::for_ternary_source_dtype("int8")
+            .expect("int8 expert/attn slots are already quantized")
+            .as_str();
         push_entry(
             entries,
             offset,

--- a/src/core/dry_run.rs
+++ b/src/core/dry_run.rs
@@ -1,18 +1,80 @@
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::core::inventory::ModelInventory;
 use crate::core::manifest::{DissectManifest, MANIFEST_NAME_CONVENTION_V2};
 use crate::core::selection::TensorClass;
-use crate::error::Result;
+use crate::error::{GrokOzempicError, Result};
 use crate::types::{QuantizationConfig, TensorPrecision};
+
+/// Orchestration-level verb for a planned tensor transform.
+///
+/// This is not a 1:1 map of [`crate::core::backend::BackendKernel`] methods:
+/// wrapping an already-quantized source is an artifact-path operation, not a
+/// kernel. Convert and quantize map onto real `BackendKernel` methods.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperationKind {
+    /// Ternary-quantize floating-point source weights
+    /// ([`crate::core::backend::BackendKernel::quantize_f32`]).
+    QuantizeTernary,
+    /// Convert floating-point source to FP16 bytes
+    /// ([`crate::core::backend::BackendKernel::convert_f32_to_f16_bytes`]).
+    ConvertFp16,
+    /// Wrap an already-quantized (typically int8) payload without re-quantizing.
+    WrapExistingQuantized,
+}
+
+impl OperationKind {
+    /// Manifest / JSON / artifact-policy spelling of this verb.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::QuantizeTernary => "quantize_ternary",
+            Self::ConvertFp16 => "convert_fp16",
+            Self::WrapExistingQuantized => "wrap_existing_quantized",
+        }
+    }
+
+    /// Wrap vs re-quantize from a single source dtype.
+    ///
+    /// Unknown dtypes fail closed rather than guessing from a glob substring.
+    pub fn for_ternary_source_dtype(dtype: &str) -> Result<Self> {
+        if is_already_quantized_dtype(dtype) {
+            Ok(Self::WrapExistingQuantized)
+        } else if is_float_source_dtype(dtype) {
+            Ok(Self::QuantizeTernary)
+        } else {
+            Err(GrokOzempicError::MixedInventoryDtype {
+                pattern: format!("dtype={dtype}"),
+            })
+        }
+    }
+}
+
+impl std::fmt::Display for OperationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// True when the source is already a quantized integer payload (wrap, don't
+/// re-quantize). Inventory uses `i8`; the artifact planner uses `int8`.
+pub fn is_already_quantized_dtype(dtype: &str) -> bool {
+    matches!(dtype, "i8" | "int8" | "u8")
+}
+
+fn is_float_source_dtype(dtype: &str) -> bool {
+    matches!(dtype, "f32" | "f16" | "bf16" | "fp16")
+}
 
 /// A single planned backend kernel invocation derived from a manifest rule.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PlannedKernelCall {
     /// Glob pattern or concrete tensor name from the manifest.
     pub matcher: String,
-    /// The `BackendKernel` trait method that would execute this work.
-    pub kernel_method: &'static str,
+    /// Orchestration verb this rule would execute.
+    pub operation: OperationKind,
     /// Classification outcome.
     pub class: TensorClass,
     /// Resolved precision.
@@ -26,8 +88,8 @@ pub struct PlannedKernelCall {
 /// Coverage analysis against the known Grok-1 tensor inventory.
 #[derive(Debug, Clone)]
 pub struct CoverageSummary {
-    /// How many tensors each backend method is planned to handle.
-    pub by_method: BTreeMap<String, usize>,
+    /// How many tensors each operation is planned to handle.
+    pub by_operation: BTreeMap<OperationKind, usize>,
     /// Total tensors covered by manifest rules.
     pub covered_by_rules: usize,
     /// Total tensors in the Grok-1 baseline inventory.
@@ -48,7 +110,7 @@ fn plan_preserve_rules<I: ModelInventory>(
     manifest: &DissectManifest,
     config: &QuantizationConfig,
     rule_plans: &mut Vec<PlannedKernelCall>,
-    by_method: &mut BTreeMap<String, usize>,
+    by_operation: &mut BTreeMap<OperationKind, usize>,
     covered_by_rules: &mut usize,
 ) -> Result<()> {
     for entry in &manifest.preserve {
@@ -56,17 +118,17 @@ fn plan_preserve_rules<I: ModelInventory>(
             reason: entry.reason.clone(),
         };
         let (_precision, gif_threshold) = resolve_precision(&class, manifest, config)?;
-        let method = "convert_f32_to_f16_bytes";
+        let operation = OperationKind::ConvertFp16;
         let estimated = estimate_tensor_count_for_manifest(inventory, manifest, &entry.name);
         rule_plans.push(PlannedKernelCall {
             matcher: entry.name.clone(),
-            kernel_method: method,
+            operation,
             class,
             precision: TensorPrecision::Preserve,
             gif_threshold,
             estimated_tensor_count: estimated,
         });
-        *by_method.entry(method.to_string()).or_insert(0) += estimated;
+        *by_operation.entry(operation).or_insert(0) += estimated;
         *covered_by_rules += estimated;
     }
     Ok(())
@@ -77,7 +139,7 @@ fn plan_fp16_rules<I: ModelInventory>(
     manifest: &DissectManifest,
     config: &QuantizationConfig,
     rule_plans: &mut Vec<PlannedKernelCall>,
-    by_method: &mut BTreeMap<String, usize>,
+    by_operation: &mut BTreeMap<OperationKind, usize>,
     covered_by_rules: &mut usize,
 ) -> Result<()> {
     for entry in &manifest.fp16 {
@@ -85,17 +147,17 @@ fn plan_fp16_rules<I: ModelInventory>(
             reason: entry.reason.clone(),
         };
         let (_precision, gif_threshold) = resolve_precision(&class, manifest, config)?;
-        let method = "convert_f32_to_f16_bytes";
+        let operation = OperationKind::ConvertFp16;
         let estimated = estimate_tensor_count_for_manifest(inventory, manifest, &entry.name);
         rule_plans.push(PlannedKernelCall {
             matcher: entry.name.clone(),
-            kernel_method: method,
+            operation,
             class,
             precision: TensorPrecision::Fp16,
             gif_threshold,
             estimated_tensor_count: estimated,
         });
-        *by_method.entry(method.to_string()).or_insert(0) += estimated;
+        *by_operation.entry(operation).or_insert(0) += estimated;
         *covered_by_rules += estimated;
     }
     Ok(())
@@ -106,7 +168,7 @@ fn plan_ternary_rules<I: ModelInventory>(
     manifest: &DissectManifest,
     config: &QuantizationConfig,
     rule_plans: &mut Vec<PlannedKernelCall>,
-    by_method: &mut BTreeMap<String, usize>,
+    by_operation: &mut BTreeMap<OperationKind, usize>,
     covered_by_rules: &mut usize,
 ) -> Result<()> {
     for entry in &manifest.ternary_candidates {
@@ -115,26 +177,51 @@ fn plan_ternary_rules<I: ModelInventory>(
             gif_threshold: entry.gif_threshold,
         };
         let (_precision, gif_threshold) = resolve_precision(&class, manifest, config)?;
-        let method = if entry.name.contains("moe_expert") {
-            "wrap_existing_int8_expert"
-        } else if entry.name.contains("attn_proj_i8") {
-            "wrap_existing_int8_unknown"
-        } else {
-            "quantize_f32"
-        };
+        let operation = ternary_operation_from_inventory(inventory, &entry.name)?;
         let estimated = estimate_tensor_count_for_manifest(inventory, manifest, &entry.name);
         rule_plans.push(PlannedKernelCall {
             matcher: entry.name.clone(),
-            kernel_method: method,
+            operation,
             class,
             precision: TensorPrecision::TernarySnn,
             gif_threshold,
             estimated_tensor_count: estimated,
         });
-        *by_method.entry(method.to_string()).or_insert(0) += estimated;
+        *by_operation.entry(operation).or_insert(0) += estimated;
         *covered_by_rules += estimated;
     }
     Ok(())
+}
+
+/// Wrap vs re-quantize from matching inventory dtypes, never from a glob
+/// substring. No matches (legacy V1 names against a structural inventory)
+/// default to quantize, which is the float-stream path.
+fn ternary_operation_from_inventory<I: ModelInventory>(
+    inventory: &I,
+    pattern: &str,
+) -> Result<OperationKind> {
+    let mut saw_quantized = false;
+    let mut saw_float = false;
+    let mut saw_other = false;
+    for tensor in inventory.tensors() {
+        if !crate::core::selection::glob_match(pattern, &tensor.structural_name) {
+            continue;
+        }
+        if is_already_quantized_dtype(tensor.dtype) {
+            saw_quantized = true;
+        } else if is_float_source_dtype(tensor.dtype) {
+            saw_float = true;
+        } else {
+            saw_other = true;
+        }
+    }
+    match (saw_quantized, saw_float, saw_other) {
+        (true, false, false) => Ok(OperationKind::WrapExistingQuantized),
+        (false, true, false) | (false, false, false) => Ok(OperationKind::QuantizeTernary),
+        _ => Err(GrokOzempicError::MixedInventoryDtype {
+            pattern: pattern.to_string(),
+        }),
+    }
 }
 
 fn calculate_coverage(covered: usize, total: usize) -> CoverageStatus {
@@ -156,7 +243,7 @@ fn plan_default_rule<I: ModelInventory>(
     manifest: &DissectManifest,
     config: &QuantizationConfig,
     rule_plans: &mut Vec<PlannedKernelCall>,
-    by_method: &mut BTreeMap<String, usize>,
+    by_operation: &mut BTreeMap<OperationKind, usize>,
     covered_by_rules: &mut usize,
 ) -> Result<()> {
     let inventory_total = inventory.total_tensors();
@@ -166,19 +253,19 @@ fn plan_default_rule<I: ModelInventory>(
     }
     let default_class = TensorClass::Default;
     let (precision, gif_threshold) = resolve_precision(&default_class, manifest, config)?;
-    let default_method = match precision {
-        TensorPrecision::TernarySnn => "quantize_f32",
-        TensorPrecision::Fp16 | TensorPrecision::Preserve => "convert_f32_to_f16_bytes",
+    let operation = match precision {
+        TensorPrecision::TernarySnn => OperationKind::QuantizeTernary,
+        TensorPrecision::Fp16 | TensorPrecision::Preserve => OperationKind::ConvertFp16,
     };
     rule_plans.push(PlannedKernelCall {
         matcher: "<defaults>".to_string(),
-        kernel_method: default_method,
+        operation,
         class: default_class,
         precision,
         gif_threshold,
         estimated_tensor_count: default_estimated,
     });
-    *by_method.entry(default_method.to_string()).or_insert(0) += default_estimated;
+    *by_operation.entry(operation).or_insert(0) += default_estimated;
     *covered_by_rules += default_estimated;
     Ok(())
 }
@@ -207,18 +294,19 @@ impl DryRunReport {
     }
 }
 
-/// Plans which backend kernel calls each manifest rule would produce.
+/// Plans which orchestration verbs each manifest rule would produce.
 ///
 /// The planner reads the xai-dissect manifest, classifies every rule
 /// (preserve / fp16 / ternary_candidates / defaults) through the existing
-/// selection pipeline, and maps each to a `BackendKernel` method. The
-/// result can be validated against the xai-dissect tensor inventory to
-/// ensure full coverage.
+/// selection pipeline, and maps each to an [`OperationKind`]. Wrap vs
+/// re-quantize is decided from inventory dtype, not glob substrings.
+/// The result can be validated against the xai-dissect tensor inventory
+/// to ensure full coverage.
 pub struct DryRunPlanner;
 
 impl DryRunPlanner {
     /// Walk every classification rule in the manifest and produce a
-    /// `DryRunReport` mapping each rule to its planned backend kernel call.
+    /// `DryRunReport` mapping each rule to its planned operation.
     ///
     /// The `inventory` parameter provides model-specific tensor counts for
     /// accurate per-rule estimates. For V2 structural manifests, counts are
@@ -230,7 +318,7 @@ impl DryRunPlanner {
         config: &QuantizationConfig,
     ) -> Result<DryRunReport> {
         let mut rule_plans = Vec::new();
-        let mut by_method: BTreeMap<String, usize> = BTreeMap::new();
+        let mut by_operation: BTreeMap<OperationKind, usize> = BTreeMap::new();
         let mut covered_by_rules = 0usize;
 
         Self::plan_all_rules(
@@ -238,17 +326,17 @@ impl DryRunPlanner {
             manifest,
             config,
             &mut rule_plans,
-            &mut by_method,
+            &mut by_operation,
             &mut covered_by_rules,
         )?;
 
         let inventory_coverage = calculate_coverage(covered_by_rules, inventory.total_tensors());
-        let backend_handled_total = by_method.values().sum();
+        let backend_handled_total = by_operation.values().sum();
 
         Ok(DryRunReport {
             rule_plans,
             coverage: CoverageSummary {
-                by_method,
+                by_operation,
                 covered_by_rules,
                 inventory_total: inventory.total_tensors(),
                 inventory_coverage,
@@ -262,7 +350,7 @@ impl DryRunPlanner {
         manifest: &DissectManifest,
         config: &QuantizationConfig,
         rule_plans: &mut Vec<PlannedKernelCall>,
-        by_method: &mut BTreeMap<String, usize>,
+        by_operation: &mut BTreeMap<OperationKind, usize>,
         covered_by_rules: &mut usize,
     ) -> Result<()> {
         plan_preserve_rules(
@@ -270,7 +358,7 @@ impl DryRunPlanner {
             manifest,
             config,
             rule_plans,
-            by_method,
+            by_operation,
             covered_by_rules,
         )?;
         plan_fp16_rules(
@@ -278,7 +366,7 @@ impl DryRunPlanner {
             manifest,
             config,
             rule_plans,
-            by_method,
+            by_operation,
             covered_by_rules,
         )?;
         plan_ternary_rules(
@@ -286,7 +374,7 @@ impl DryRunPlanner {
             manifest,
             config,
             rule_plans,
-            by_method,
+            by_operation,
             covered_by_rules,
         )?;
         plan_default_rule(
@@ -294,13 +382,13 @@ impl DryRunPlanner {
             manifest,
             config,
             rule_plans,
-            by_method,
+            by_operation,
             covered_by_rules,
         )
     }
 
     /// Produce a machine-readable JSON mapping from rule matcher to planned
-    /// backend method, suitable for comparison with xai-dissect artifacts.
+    /// operation, suitable for comparison with xai-dissect artifacts.
     pub fn planned_backend_calls_json(
         report: &DryRunReport,
     ) -> BTreeMap<String, serde_json::Value> {
@@ -309,7 +397,7 @@ impl DryRunPlanner {
             map.insert(
                 plan.matcher.clone(),
                 serde_json::json!({
-                    "kernel_method": plan.kernel_method,
+                    "operation": plan.operation,
                     "precision": plan.precision,
                     "gif_threshold": plan.gif_threshold,
                     "estimated_tensor_count": plan.estimated_tensor_count,
@@ -320,7 +408,7 @@ impl DryRunPlanner {
         map.insert(
             "__coverage__".to_string(),
             serde_json::json!({
-                "by_method": report.coverage.by_method,
+                "by_operation": report.coverage.by_operation,
                 "covered_by_rules": report.coverage.covered_by_rules,
                 "inventory_total": report.coverage.inventory_total,
                 "coverage": format!("{:?}", report.coverage.inventory_coverage),
@@ -398,8 +486,9 @@ mod tests {
     use crate::core::alignment::embedded_grok1_structural_manifest;
     use crate::core::alignment::plan_structural_manifest;
     use crate::core::grok1_inventory::Grok1Inventory;
+    use crate::core::inventory::{InventoryTensor, ModelInventory};
     use crate::core::manifest::MANIFEST_NAME_CONVENTION_V2;
-    use crate::types::GROK1_TENSOR_TOTAL;
+    use crate::types::{GROK1_TENSOR_TOTAL, QuantizationConfig};
 
     #[test]
     fn structural_manifest_router_rule_counts_exactly_64() {
@@ -435,52 +524,41 @@ mod tests {
     }
 
     #[test]
-    fn preserve_rules_map_to_convert_f32_to_f16_bytes() {
+    fn preserve_rules_map_to_convert_fp16() {
         let report = plan_structural_manifest();
 
         for plan in &report.rule_plans {
             if matches!(plan.class, TensorClass::Preserve { .. }) {
                 assert_eq!(
-                    plan.kernel_method, "convert_f32_to_f16_bytes",
-                    "preserve rule '{}' should use convert_f32_to_f16_bytes, got {}",
-                    plan.matcher, plan.kernel_method
+                    plan.operation,
+                    OperationKind::ConvertFp16,
+                    "preserve rule '{}' should use ConvertFp16, got {}",
+                    plan.matcher,
+                    plan.operation
                 );
             }
         }
     }
 
     #[test]
-    fn ternary_moe_expert_rules_map_to_wrap_int8() {
+    fn ternary_i8_inventory_rules_map_to_wrap() {
         let report = plan_structural_manifest();
 
         for plan in &report.rule_plans {
-            if plan.matcher.contains("moe_expert") {
+            if plan.matcher.contains("moe_expert") || plan.matcher.contains("attn_proj_i8") {
                 assert_eq!(
-                    plan.kernel_method, "wrap_existing_int8_expert",
-                    "moe_expert rule '{}' should use wrap_existing_int8_expert, got {}",
-                    plan.matcher, plan.kernel_method
+                    plan.operation,
+                    OperationKind::WrapExistingQuantized,
+                    "i8 ternary rule '{}' should wrap, got {}",
+                    plan.matcher,
+                    plan.operation
                 );
             }
         }
     }
 
     #[test]
-    fn ternary_attn_proj_i8_rules_map_to_wrap_int8() {
-        let report = plan_structural_manifest();
-
-        for plan in &report.rule_plans {
-            if plan.matcher.contains("attn_proj_i8") {
-                assert_eq!(
-                    plan.kernel_method, "wrap_existing_int8_unknown",
-                    "attn_proj_i8 rule '{}' should use wrap_existing_int8_unknown, got {}",
-                    plan.matcher, plan.kernel_method
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn ternary_embedding_maps_to_quantize_f32() {
+    fn ternary_embedding_maps_to_quantize_ternary() {
         let report = plan_structural_manifest();
 
         let embedding_plan = report
@@ -489,9 +567,10 @@ mod tests {
             .find(|p| p.matcher.contains("token_embedding"))
             .expect("embedding rule should exist");
         assert_eq!(
-            embedding_plan.kernel_method, "quantize_f32",
-            "embedding should use quantize_f32, got {}",
-            embedding_plan.kernel_method
+            embedding_plan.operation,
+            OperationKind::QuantizeTernary,
+            "embedding should use QuantizeTernary, got {}",
+            embedding_plan.operation
         );
     }
 
@@ -501,12 +580,12 @@ mod tests {
 
         let default_plan = report.rule_plans.iter().find(|p| p.matcher == "<defaults>");
         if let Some(plan) = default_plan {
-            assert!(
-                plan.kernel_method == "quantize_f32"
-                    || plan.kernel_method == "convert_f32_to_f16_bytes",
-                "default rule should use quantize_f32 or convert_f32_to_f16_bytes, got {}",
-                plan.kernel_method
-            );
+            match plan.operation {
+                OperationKind::QuantizeTernary | OperationKind::ConvertFp16 => {}
+                other => {
+                    panic!("default rule should use QuantizeTernary or ConvertFp16, got {other}")
+                }
+            }
         } else {
             assert_eq!(
                 report.coverage.inventory_coverage,
@@ -528,13 +607,13 @@ mod tests {
     }
 
     #[test]
-    fn by_method_sums_to_backend_handled_total() {
+    fn by_operation_sums_to_backend_handled_total() {
         let report = plan_structural_manifest();
 
-        let sum: usize = report.coverage.by_method.values().sum();
+        let sum: usize = report.coverage.by_operation.values().sum();
         assert_eq!(
             sum, report.backend_handled_total,
-            "by_method values should sum to backend_handled_total"
+            "by_operation values should sum to backend_handled_total"
         );
     }
 
@@ -561,6 +640,125 @@ mod tests {
         assert_eq!(
             embedding["precision"], "ternary_snn",
             "dry-run JSON must emit the serde wire form, not Debug/PascalCase"
+        );
+        assert_eq!(embedding["operation"], "quantize_ternary");
+    }
+
+    #[test]
+    fn every_planned_operation_is_exhaustively_known() {
+        let report = plan_structural_manifest();
+        for plan in &report.rule_plans {
+            match plan.operation {
+                OperationKind::QuantizeTernary
+                | OperationKind::ConvertFp16
+                | OperationKind::WrapExistingQuantized => {}
+            }
+        }
+    }
+
+    struct TinyInv(Vec<InventoryTensor>);
+
+    impl ModelInventory for TinyInv {
+        fn total_tensors(&self) -> usize {
+            self.0.len()
+        }
+        fn tensors(&self) -> &[InventoryTensor] {
+            &self.0
+        }
+    }
+
+    fn tiny_tensor(name: &str, dtype: &'static str) -> InventoryTensor {
+        InventoryTensor {
+            structural_name: name.into(),
+            expected_class: TensorClass::TernaryCandidate {
+                rank: None,
+                gif_threshold: None,
+            },
+            dtype,
+            block: None,
+            slot: None,
+            kind: "test",
+        }
+    }
+
+    fn v2_manifest_with_ternary(pattern: &str) -> DissectManifest {
+        use crate::core::manifest::{
+            MANIFEST_SCHEMA_VERSION, ManifestDefaults, ManifestModel, TernaryCandidate,
+        };
+        DissectManifest {
+            schema: "xai-dissect.manifest".into(),
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            model: ManifestModel {
+                family: "grok-1".into(),
+                source: "xai-org/grok-1".into(),
+                tensor_name_convention: MANIFEST_NAME_CONVENTION_V2.into(),
+            },
+            produced_by: None,
+            defaults: ManifestDefaults {
+                precision: Some("ternary_snn".into()),
+                gif_threshold: None,
+            },
+            preserve: vec![],
+            fp16: vec![],
+            ternary_candidates: vec![TernaryCandidate {
+                name: pattern.into(),
+                rank: None,
+                gif_threshold: None,
+            }],
+            blocks: vec![],
+        }
+    }
+
+    #[test]
+    fn ternary_i8_source_plans_wrap_even_without_moe_expert_in_glob() {
+        let inv = TinyInv(vec![tiny_tensor("block_000.slot_00.already_int8", "i8")]);
+        let m = v2_manifest_with_ternary("block_*.slot_00.already_int8");
+        let report = DryRunPlanner::plan(&inv, &m, &QuantizationConfig::default())
+            .expect("plan should succeed");
+        let plan = report
+            .rule_plans
+            .iter()
+            .find(|p| p.matcher.contains("already_int8"))
+            .expect("ternary rule");
+        assert_eq!(plan.operation, OperationKind::WrapExistingQuantized);
+    }
+
+    #[test]
+    fn glob_containing_moe_expert_does_not_force_wrap_on_f32() {
+        let inv = TinyInv(vec![tiny_tensor(
+            "block_000.slot_00.moe_expert.floaty",
+            "f32",
+        )]);
+        let m = v2_manifest_with_ternary("block_*.slot_00.moe_expert.floaty");
+        let report = DryRunPlanner::plan(&inv, &m, &QuantizationConfig::default())
+            .expect("plan should succeed");
+        let plan = report
+            .rule_plans
+            .iter()
+            .find(|p| p.matcher.contains("moe_expert"))
+            .expect("ternary rule");
+        assert_eq!(
+            plan.operation,
+            OperationKind::QuantizeTernary,
+            "f32 source must quantize even if the glob contains moe_expert"
+        );
+    }
+
+    #[test]
+    fn mixed_inventory_dtypes_fail_closed() {
+        let inv = TinyInv(vec![
+            tiny_tensor("block_000.slot_00.mixed", "i8"),
+            tiny_tensor("block_001.slot_00.mixed", "f32"),
+        ]);
+        let m = v2_manifest_with_ternary("block_*.slot_00.mixed");
+        let err = DryRunPlanner::plan(&inv, &m, &QuantizationConfig::default())
+            .expect_err("mixed dtypes must fail closed");
+        assert!(
+            matches!(
+                err,
+                crate::error::GrokOzempicError::MixedInventoryDtype { .. }
+            ),
+            "got {err:?}"
         );
     }
 }

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -464,7 +464,7 @@ fn quantize_safetensors_entry(
     if dtype == SourceDtype::Other {
         // i8/Other tensors from xai-dissect inventory are covered by structural manifest for alignment
         // (see grok1_inventory.rs:NOTE and structural-manifest.json _i8_streaming_note); they arrive
-        // via artifact wrapping (wrap_existing_int8_*), not this float-only stream path.
+        // via artifact wrapping (OperationKind::WrapExistingQuantized), not this float-only stream path.
         // Kilo agent xAI/Grok Build 0.1 addressing Codex P1 on PR #26.
         return Err(GrokOzempicError::InvalidConfig(format!(
             "tensor {} has unsupported dtype",

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,12 @@ pub enum GrokOzempicError {
     )]
     MissingDefaultPrecision,
 
+    #[error(
+        "ternary rule {pattern:?} matches mixed or unknown inventory dtypes; \
+         wrap-vs-quantize cannot be decided from dtype"
+    )]
+    MixedInventoryDtype { pattern: String },
+
     #[error("artifact validation error: {0}")]
     ArtifactValidation(String),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod types;
 pub use core::HybridModel;
 pub use core::backend::{BackendKernel, LocalBackend, MyelinBackend};
 pub use core::dry_run::{
-    CoverageStatus, CoverageSummary, DryRunPlanner, DryRunReport, PlannedKernelCall,
+    CoverageStatus, CoverageSummary, DryRunPlanner, DryRunReport, OperationKind, PlannedKernelCall,
 };
 pub use core::inventory::{InventoryTensor, ModelInventory};
 pub use types::{


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Agent:** Cursor Grok 4.6 (xAI) · **Issue:** #93 / Linear RM-797

Closes #93.

## Why

`PlannedKernelCall::kernel_method` was a bare `&'static str` documented as "the BackendKernel trait method", but two of the four emitted labels (`wrap_existing_int8_expert`, `wrap_existing_int8_unknown`) are not methods on `BackendKernel`. Wrap vs quantize was also sniffed from glob substrings (`moe_expert` / `attn_proj_i8`), the same class of bug `glob_match` was introduced to fix.

## Chosen fix (backend-neutral `OperationKind`)

Replaced the string with `OperationKind::{QuantizeTernary, ConvertFp16, WrapExistingQuantized}`. Convert/quantize map onto real `BackendKernel` methods; wrap is an artifact-path verb, not a fake kernel. Wrap vs re-quantize is decided from `InventoryTensor::dtype` (`i8`/`int8` → wrap, float → quantize). Mixed dtypes fail closed (`MixedInventoryDtype`).

`src/artifact.rs` now uses the same enum for int8 slots instead of duplicating `wrap_existing_int8_*` via `kind.starts_with("moe_expert")`.

Stacked on #131 (`cursor/fail-closed-default-precision-7ff3`).

## Verification

- i8 ternary source with no `moe_expert` in the glob → `WrapExistingQuantized`
- Glob containing `moe_expert` over an f32 source → `QuantizeTernary` (not wrap)
- Mixed dtypes → `Err(MixedInventoryDtype)`
- Exhaustive match over every planned operation on the structural manifest
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-features --locked`

## Relationships

Sibling defects from the same review (do not mill/merge):

- #91 / RM-795 — TensorPrecision serde vocabulary (#130)
- #92 / RM-796 — destructive default precision (#131; this PR stacks on it)
- #93 / RM-797 — this PR (typed dry-run operation)

Related: `rmems/hybrid-fusion#24` (extracted planner uses `OperationKind::{Convert, Passthrough}` at the crate boundary).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fae09b9-37d9-4ca0-a952-84d918677ff3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fae09b9-37d9-4ca0-a952-84d918677ff3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #93. Replaces the bare `kernel_method` string labels in dry-run planning with a typed `OperationKind` enum, and decides wrap-vs-quantize from inventory dtype instead of glob substrings. Mixed or unknown dtypes now fail closed with a new `MixedInventoryDtype` error, and `src/artifact.rs` shares the same enum.

**Behavior changes**
- Dry-run JSON now reports `operation`/`by_operation` keys instead of `kernel_method`/`by_method`.
- A glob matching an `f32` source now quantizes even if the name contains `moe_expert`.
- A glob matching mixed dtypes (for example `i8` and `f32`) now errors with `MixedInventoryDtype` instead of guessing.

<sup>Written for commit d224f55142e6f5529225bfb76ac188fdbb687359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Use tensor data to choose safe dry-run operations

### What Changed
- Dry-run plans now report typed operations for ternary quantization, FP16 conversion, and wrapping existing quantized data
- Ternary rules decide between wrapping and re-quantizing from the source tensor dtype instead of matching name fragments
- Mixed or unknown dtypes now stop planning with a clear error rather than guessing
- Artifact entries use the same operation naming as dry-run output, and JSON reports expose operations instead of backend method names

### Impact
`✅ Prevents accidental re-quantization of existing int8 tensors`
`✅ Correctly quantizes floating-point tensors with misleading names`
`✅ Clear errors for mixed or unsupported source dtypes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
