### PR TITLE
ci(qodana): run Community Python, drop expired rust Ultimate (#133)

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -13,6 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Community Python only. qodana-python-community does not need Qodana Cloud,
+  # so this job runs without QODANA_TOKEN / QODANA_ENDPOINT (including
+  # Dependabot and fork pull requests). The rust Ultimate/EAP scanner is gone.
   qodana:
     runs-on: ubuntu-latest
     permissions:
@@ -32,10 +35,8 @@ jobs:
         # Pin third-party action to full commit SHA (Codacy / Opengrep GHA rule).
         uses: JetBrains/qodana-action@4861e015da555e86a72b862892aba6c2b93e6891 # v2026.1.3
         with:
-          args: --linter qodana-rust
+          args: --linter qodana-python-community
           # Full-project baseline (not PR-diff-only): intentional for this repo until
           # Qodana coverage is stable; re-enable pr-mode once that is useful.
           pr-mode: false
-        env:
-          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
-          QODANA_ENDPOINT: "https://qodana.cloud"
+        # No QODANA_TOKEN / QODANA_ENDPOINT: Community does not talk to Cloud.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -115,8 +115,8 @@ Do not disable hooks permanently; use `--no-verify` only for documented emergenc
 
 ## 3. Local Qodana CLI
 
-Config: root [`qodana.yaml`](qodana.yaml) (`linter: qodana-rust`). CI workflow:
-[`.github/workflows/qodana.yml`](.github/workflows/qodana.yml).
+Config: root [`qodana.yaml`](qodana.yaml) (`linter: qodana-python-community`).
+CI workflow: [`.github/workflows/qodana.yml`](.github/workflows/qodana.yml).
 
 ### Install
 
@@ -129,7 +129,7 @@ command -v qodana && qodana --version
 Docker is used when the CLI runs the linter in a container (`--within-docker=true`
 or default depending on environment). Native mode: `--within-docker=false`.
 
-Optional Cloud upload needs `QODANA_TOKEN` (same secret as GHA). Local reports
+Community Python does not need `QODANA_TOKEN` (no Cloud upload). Local reports
 do not require a token.
 
 ### Recipes
@@ -144,7 +144,7 @@ Equivalent manual CLI (kept for environments without the new recipes):
 ```bash
 # Full project (matches CI pr-mode: false intent — whole tree, not PR-diff-only)
 qodana scan \
-  --linter qodana-rust \
+  --linter qodana-python-community \
   --project-dir . \
   --results-dir .qodana/results \
   --report-dir .qodana/report \
@@ -156,7 +156,7 @@ qodana show --report-dir .qodana/report
 # or: qodana view --sarif .qodana/results/qodana.sarif.json
 
 # Diff-only against main (optional, faster feedback while iterating)
-qodana scan --linter qodana-rust --diff-start origin/main --print-problems
+qodana scan --linter qodana-python-community --diff-start origin/main --print-problems
 ```
 
 `.qodana/` is gitignored (local cache/results). Do not commit SARIF or HTML
@@ -279,7 +279,7 @@ python3 -m unittest scripts.test_grok1_block_forward -v
 python3 -m unittest scripts.test_grok1_block_weights -v
 
 # --- optional full ---
-qodana scan --linter qodana-rust --project-dir . \
+qodana scan --linter qodana-python-community --project-dir . \
   --results-dir .qodana/results --report-dir .qodana/report \
   --print-problems --save-report
 ```

--- a/justfile
+++ b/justfile
@@ -209,7 +209,7 @@ review:
     @just _cargo-audit
     @just _py-compile
 
-# Local JetBrains Qodana (qodana-rust). Needs `qodana` on PATH; results under .qodana/
+# Local JetBrains Qodana (qodana-python-community). Needs `qodana` on PATH; results under .qodana/
 qodana:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -220,9 +220,9 @@ qodana:
       exit 1
     fi
     mkdir -p .qodana/results .qodana/report
-    echo "+ qodana scan --linter qodana-rust --print-problems (results → .qodana/)"
+    echo "+ qodana scan --linter qodana-python-community --print-problems (results → .qodana/)"
     qodana scan \
-      --linter qodana-rust \
+      --linter qodana-python-community \
       --project-dir . \
       --results-dir .qodana/results \
       --report-dir .qodana/report \

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,7 @@
-# Qodana for Rust (EAP) — see https://www.jetbrains.com/help/qodana/rust.html
+# Free Community Python — no Qodana Cloud token.
+# See https://www.jetbrains.com/help/qodana/qodana-python-community.html
 version: "1.0"
-linter: qodana-rust
+linter: qodana-python-community
 
 # Skip build artifacts and local tool caches.
 exclude:


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Paid Qodana membership has expired, so the rust Ultimate/EAP scan cannot start. This repo is Python-primary, so CI now runs the free Community Python linter with no Cloud token.

- `qodana.yaml`: `linter: qodana-python-community`
- Single Community job in `.github/workflows/qodana.yml` with no `QODANA_TOKEN` / `QODANA_ENDPOINT`
- `just qodana` / REVIEW.md pointed at Community Python

## Relationships

- Closes #133
- Parent N/A on PRs

Cited by: GitHub Janitor (Grok Bot)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0631bc38-b21e-4133-990a-8aeea6150780?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0631bc38-b21e-4133-990a-8aeea6150780&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Qodana from the expired Rust Ultimate/EAP scanner to the free Community Python linter, so CI no longer needs a Qodana Cloud token or endpoint. This repo is Python-primary.

- Updates `qodana.yaml`, the CI workflow, `REVIEW.md`, and `justfile` to use `qodana-python-community`.

<sup>Written for commit 046624417907d4f007fbef21f3e51785a01b7202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmems/grok-ozempic/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Switch Qodana checks to the free Community Python scanner

### What Changed
- CI now scans the repository with Qodana Community Python instead of the expired Rust Ultimate/EAP scanner
- Pull requests, forks, and Dependabot runs no longer require Qodana Cloud credentials
- Local Qodana commands and review documentation now use the Community Python scanner

### Impact
`✅ Qodana checks run without paid or expired credentials`
`✅ Python-focused linting in pull requests`
`✅ Consistent local and CI scan instructions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
